### PR TITLE
Fix dex_species macro for rgbds v0.4.0

### DIFF
--- a/macros/pokedex.asm
+++ b/macros/pokedex.asm
@@ -69,16 +69,20 @@ x = \1 * 10
 	db $00, $FC
 	ENDM
 
+; \1 = species string
 dex_species: MACRO
-	REPT _NARG
-	dex_species_char \1
-	SHIFT
-	ENDR
-	REPT 11 - _NARG
-	dex_species_char " "
-	ENDR
-	db $00
-	ENDM
+; Add right padding to format to 11 characters, define 2 bytes
+; for each character (using dex_species_char below)
+I = 0
+    REPT STRLEN(\1)
+I = I + 1
+        dex_species_char STRSUB(\1\, I\, 1)
+    ENDR
+    REPT 11 - STRLEN(\1)
+        dex_species_char " "
+    ENDR
+    db "@"
+ENDM
 
 dex_species_char: MACRO
 	IF \1 == " "

--- a/macros/pokedex.asm
+++ b/macros/pokedex.asm
@@ -1,8 +1,8 @@
 dex_number: MACRO
-	db ((\1 / 100) % 10) + $30
-	db ((\1 / 10) % 10) + $30
-	db ((\1 / 1) % 10) + $30
-	db $00
+	db ((\1 / 100) % 10) + "0"
+	db ((\1 / 10) % 10) + "0"
+	db ((\1 / 1) % 10) + "0"
+	db "@"
 	ENDM
 
 ; \1 = feet
@@ -10,12 +10,12 @@ dex_number: MACRO
 dex_height: MACRO
 feet_tens_digit = (\1 / 10) % 10
 	IF feet_tens_digit == 0
-	db $20
+	db " "
 	ELSE
-	db feet_tens_digit + $30
+	db feet_tens_digit + "0"
 	ENDC
 feet_ones_digit = \1 % 10
-	db feet_ones_digit + $30
+	db feet_ones_digit + "0"
 inches_tens_digit = (\2 / 10) % 10
 	IF inches_tens_digit > 0
 	db $70
@@ -23,49 +23,49 @@ inches_tens_digit = (\2 / 10) % 10
 	db $72
 	ENDC
 inches_ones_digit = \2 % 10
-	db inches_ones_digit + $30
-	db $00
+	db inches_ones_digit + "0"
+	db "@"
 	ENDM
 
 dex_weight: MACRO
 	IF \1 >= 1000
-	db ((\1 / 1000) % 10) + $30
+	db ((\1 / 1000) % 10) + "0"
 	ELSE
-	db $20
+	db " "
 	ENDC
 
 	IF \1 >= 100
-	db ((\1 / 100) % 10) + $30
+	db ((\1 / 100) % 10) + "0"
 	ELSE
-	db $20
+	db " "
 	ENDC
 
 	IF \1 >= 10
-	db ((\1 / 10) % 10) + $30
+	db ((\1 / 10) % 10) + "0"
 	ELSE
-	db $20
+	db " "
 	ENDC
 
-	db (\1 % 10) + $30
+	db (\1 % 10) + "0"
 	db $00, $83
 	ENDM
 
 dex_weight_decimal: MACRO
 x = \1 * 10
 	IF x >= 100
-	db ((x / 100) % 10) + $30
+	db ((x / 100) % 10) + "0"
 	ELSE
-	db $20
+	db " "
 	ENDC
 
 	IF x >= 10
-	db ((x / 100) % 10) + $30
+	db ((x / 100) % 10) + "0"
 	ELSE
-	db $20
+	db " "
 	ENDC
 
-	db (x % 10) + $30
-	db (\2 % 10) + $30
+	db (x % 10) + "0"
+	db (\2 % 10) + "0"
 	db $00, $FC
 	ENDM
 

--- a/text/pokedex_species.asm
+++ b/text/pokedex_species.asm
@@ -1,98 +1,98 @@
 MonSpeciesNames: ; 0x29fa6
-	dex_species "S","E","E","D"                         ; SPECIES_SEED
-	dex_species "L","I","Z","A","R","D"                 ; SPECIES_LIZARD
-	dex_species "F","L","A","M","E"                     ; SPECIES_FLAME
-	dex_species "T","I","N","Y","T","U","R","T","L","E" ; SPECIES_TINYTURTLE
-	dex_species "T","U","R","T","L","E"                 ; SPECIES_TURTLE
-	dex_species "S","H","E","L","L","F","I","S","H"     ; SPECIES_SHELLFISH
-	dex_species "W","O","R","M"                         ; SPECIES_WORM
-	dex_species "C","O","C","O","O","N"                 ; SPECIES_COCOON
-	dex_species "B","U","T","T","E","R","F","L","Y"     ; SPECIES_BUTTERFLY
-	dex_species "H","A","I","R","Y"," ","B","U","G"     ; SPECIES_HAIRY_BUG
-	dex_species "P","O","I","S","O","N"," ","B","E","E" ; SPECIES_POISON_BEE
-	dex_species "T","I","N","Y"," ","B","I","R","D"     ; SPECIES_TINY_BIRD
-	dex_species "B","I","R","D"                         ; SPECIES_BIRD
-	dex_species "M","O","U","S","E"                     ; SPECIES_MOUSE
-	dex_species "B","E","A","K"                         ; SPECIES_BEAK
-	dex_species "S","N","A","K","E"                     ; SPECIES_SNAKE
-	dex_species "C","O","B","R","A"                     ; SPECIES_COBRA
-	dex_species "P","O","I","S","O","N"," ","P","I","N" ; SPECIES_POISON_PIN
-	dex_species "D","R","I","L","L"                     ; SPECIES_DRILL
-	dex_species "F","A","I","R","Y"                     ; SPECIES_FAIRY
-	dex_species "F","O","X"                             ; SPECIES_FOX
-	dex_species "B","A","L","L","O","O","N"             ; SPECIES_BALLOON
-	dex_species "B","A","T"                             ; SPECIES_BAT
-	dex_species "W","E","E","D"                         ; SPECIES_WEED
-	dex_species "F","L","O","W","E","R"                 ; SPECIES_FLOWER
-	dex_species "M","U","S","H","R","O","O","M"         ; SPECIES_MUSHROOM
-	dex_species "I","N","S","E","C","T"                 ; SPECIES_INSECT
-	dex_species "P","O","I","S","O","N","M","O","T","H" ; SPECIES_POISONMOTH
-	dex_species "M","O","L","E"                         ; SPECIES_MOLE
-	dex_species "S","C","R","A","T","C","H","C","A","T" ; SPECIES_SCRATCHCAT
-	dex_species "C","L","A","S","S","Y"," ","C","A","T" ; SPECIES_CLASSY_CAT
-	dex_species "D","U","C","K"                         ; SPECIES_DUCK
-	dex_species "P","I","G"," ","M","O","N","K","E","Y" ; SPECIES_PIG_MONKEY
-	dex_species "P","U","P","P","Y"                     ; SPECIES_PUPPY
-	dex_species "L","E","G","E","N","D","A","R","Y"     ; SPECIES_LEGENDARY
-	dex_species "T","A","D","P","O","L","E"             ; SPECIES_TADPOLE
-	dex_species "P","S","I"                             ; SPECIES_PSI
-	dex_species "S","U","P","E","R","P","O","W","E","R" ; SPECIES_SUPERPOWER
-	dex_species "F","L","Y","C","A","T","C","H","E","R" ; SPECIES_FLYCATCHER
-	dex_species "J","E","L","L","Y","F","I","S","H"     ; SPECIES_JELLYFISH
-	dex_species "R","O","C","K"                         ; SPECIES_ROCK
-	dex_species "M","E","G","A","T","O","N"             ; SPECIES_MEGATON
-	dex_species "F","I","R","E"," ","H","O","R","S","E" ; SPECIES_FIRE_HORSE
-	dex_species "D","O","P","E","Y"                     ; SPECIES_DOPEY
-	dex_species "H","E","R","M","I","T","C","R","A","B" ; SPECIES_HERMITCRAB
-	dex_species "M","A","G","N","E","T"                 ; SPECIES_MAGNET
-	dex_species "W","I","L","D"," ","D","U","C","K"     ; SPECIES_WILD_DUCK
-	dex_species "T","W","I","N"," ","B","I","R","D"     ; SPECIES_TWIN_BIRD
-	dex_species "T","R","I","P","L","E","B","I","R","D" ; SPECIES_TRIPLEBIRD
-	dex_species "S","E","A"," ","L","I","O","N"         ; SPECIES_SEA_LION
-	dex_species "S","L","U","D","G","E"                 ; SPECIES_SLUDGE
-	dex_species "B","I","V","A","L","V","E"             ; SPECIES_BIVALVE
-	dex_species "G","A","S"                             ; SPECIES_GAS
-	dex_species "S","H","A","D","O","W"                 ; SPECIES_SHADOW
-	dex_species "R","O","C","K"," ","S","N","A","K","E" ; SPECIES_ROCK_SNAKE
-	dex_species "H","Y","P","N","O","S","I","S"         ; SPECIES_HYPNOSIS
-	dex_species "R","I","V","E","R"," ","C","R","A","B" ; SPECIES_RIVER_CRAB
-	dex_species "P","I","N","C","E","R"                 ; SPECIES_PINCER
-	dex_species "B","A","L","L"                         ; SPECIES_BALL
-	dex_species "E","G","G"                             ; SPECIES_EGG
-	dex_species "C","O","C","O","N","U","T"             ; SPECIES_COCONUT
-	dex_species "L","O","N","E","L","Y"                 ; SPECIES_LONELY
-	dex_species "B","O","N","E","K","E","E","P","E","R" ; SPECIES_BONEKEEPER
-	dex_species "K","I","C","K","I","N","G"             ; SPECIES_KICKING
-	dex_species "P","U","N","C","H","I","N","G"         ; SPECIES_PUNCHING
-	dex_species "L","I","C","K","I","N","G"             ; SPECIES_LICKING
-	dex_species "P","O","I","S","O","N"," ","G","A","S" ; SPECIES_POISON_GAS
-	dex_species "S","P","I","K","E","S"                 ; SPECIES_SPIKES
-	dex_species "V","I","N","E"                         ; SPECIES_VINE
-	dex_species "P","A","R","E","N","T"                 ; SPECIES_PARENT
-	dex_species "D","R","A","G","O","N"                 ; SPECIES_DRAGON
-	dex_species "G","O","L","D","F","I","S","H"         ; SPECIES_GOLDFISH
-	dex_species "S","T","A","R","S","H","A","P","E"     ; SPECIES_STARSHAPE
-	dex_species "M","Y","S","T","E","R","I","O","U","S" ; SPECIES_MYSTERIOUS
-	dex_species "B","A","R","R","I","E","R"             ; SPECIES_BARRIER
-	dex_species "M","A","N","T","I","S"                 ; SPECIES_MANTIS
-	dex_species "H","U","M","A","N","S","H","A","P","E" ; SPECIES_HUMANSHAPE
-	dex_species "E","L","E","C","T","R","I","C"         ; SPECIES_ELECTRIC
-	dex_species "S","P","I","T","F","I","R","E"         ; SPECIES_SPITFIRE
-	dex_species "S","T","A","G","B","E","E","T","L","E" ; SPECIES_STAGBEETLE
-	dex_species "W","I","L","D"," ","B","U","L","L"     ; SPECIES_WILD_BULL
-	dex_species "F","I","S","H"                         ; SPECIES_FISH
-	dex_species "A","T","R","O","C","I","O","U","S"     ; SPECIES_ATROCIOUS
-	dex_species "T","R","A","N","S","P","O","R","T"     ; SPECIES_TRANSPORT
-	dex_species "T","R","A","N","S","F","O","R","M"     ; SPECIES_TRANSFORM
-	dex_species "E","V","O","L","U","T","I","O","N"     ; SPECIES_EVOLUTION
-	dex_species "B","U","B","B","L","E"," ","J","E","T" ; SPECIES_BUBBLE_JET
-	dex_species "L","I","G","H","T","N","I","N","G"     ; SPECIES_LIGHTNING
-	dex_species "F","L","A","M","E"                     ; SPECIES_FLAME_2
-	dex_species "V","I","R","T","U","A","L"             ; SPECIES_VIRTUAL
-	dex_species "S","P","I","R","A","L"                 ; SPECIES_SPIRAL
-	dex_species "F","O","S","S","I","L"                 ; SPECIES_FOSSIL
-	dex_species "S","L","E","E","P","I","N","G"         ; SPECIES_SLEEPING
-	dex_species "F","R","E","E","Z","E"                 ; SPECIES_FREEZE
-	dex_species "G","E","N","E","T","I","C"             ; SPECIES_GENETIC
-	dex_species "N","E","W"," ","S","P","E","C","I","E" ; SPECIES_NEW_SPECIE
-	dex_species "R","A","T"                             ; SPECIES_RAT
+	dex_species "SEED"       ; SPECIES_SEED
+	dex_species "LIZARD"     ; SPECIES_LIZARD
+	dex_species "FLAME"      ; SPECIES_FLAME
+	dex_species "TINYTURTLE" ; SPECIES_TINYTURTLE
+	dex_species "TURTLE"     ; SPECIES_TURTLE
+	dex_species "SHELLFISH"  ; SPECIES_SHELLFISH
+	dex_species "WORM"       ; SPECIES_WORM
+	dex_species "COCOON"     ; SPECIES_COCOON
+	dex_species "BUTTERFLY"  ; SPECIES_BUTTERFLY
+	dex_species "HAIRY BUG"  ; SPECIES_HAIRY_BUG
+	dex_species "POISON BEE" ; SPECIES_POISON_BEE
+	dex_species "TINY BIRD"  ; SPECIES_TINY_BIRD
+	dex_species "BIRD"       ; SPECIES_BIRD
+	dex_species "MOUSE"      ; SPECIES_MOUSE
+	dex_species "BEAK"       ; SPECIES_BEAK
+	dex_species "SNAKE"      ; SPECIES_SNAKE
+	dex_species "COBRA"      ; SPECIES_COBRA
+	dex_species "POISON PIN" ; SPECIES_POISON_PIN
+	dex_species "DRILL"      ; SPECIES_DRILL
+	dex_species "FAIRY"      ; SPECIES_FAIRY
+	dex_species "FOX"        ; SPECIES_FOX
+	dex_species "BALLOON"    ; SPECIES_BALLOON
+	dex_species "BAT"        ; SPECIES_BAT
+	dex_species "WEED"       ; SPECIES_WEED
+	dex_species "FLOWER"     ; SPECIES_FLOWER
+	dex_species "MUSHROOM"   ; SPECIES_MUSHROOM
+	dex_species "INSECT"     ; SPECIES_INSECT
+	dex_species "POISONMOTH" ; SPECIES_POISONMOTH
+	dex_species "MOLE"       ; SPECIES_MOLE
+	dex_species "SCRATCHCAT" ; SPECIES_SCRATCHCAT
+	dex_species "CLASSY CAT" ; SPECIES_CLASSY_CAT
+	dex_species "DUCK"       ; SPECIES_DUCK
+	dex_species "PIG MONKEY" ; SPECIES_PIG_MONKEY
+	dex_species "PUPPY"      ; SPECIES_PUPPY
+	dex_species "LEGENDARY"  ; SPECIES_LEGENDARY
+	dex_species "TADPOLE"    ; SPECIES_TADPOLE
+	dex_species "PSI"        ; SPECIES_PSI
+	dex_species "SUPERPOWER" ; SPECIES_SUPERPOWER
+	dex_species "FLYCATCHER" ; SPECIES_FLYCATCHER
+	dex_species "JELLYFISH"  ; SPECIES_JELLYFISH
+	dex_species "ROCK"       ; SPECIES_ROCK
+	dex_species "MEGATON"    ; SPECIES_MEGATON
+	dex_species "FIRE HORSE" ; SPECIES_FIRE_HORSE
+	dex_species "DOPEY"      ; SPECIES_DOPEY
+	dex_species "HERMITCRAB" ; SPECIES_HERMITCRAB
+	dex_species "MAGNET"     ; SPECIES_MAGNET
+	dex_species "WILD DUCK"  ; SPECIES_WILD_DUCK
+	dex_species "TWIN BIRD"  ; SPECIES_TWIN_BIRD
+	dex_species "TRIPLEBIRD" ; SPECIES_TRIPLEBIRD
+	dex_species "SEA LION"   ; SPECIES_SEA_LION
+	dex_species "SLUDGE"     ; SPECIES_SLUDGE
+	dex_species "BIVALVE"    ; SPECIES_BIVALVE
+	dex_species "GAS"        ; SPECIES_GAS
+	dex_species "SHADOW"     ; SPECIES_SHADOW
+	dex_species "ROCK SNAKE" ; SPECIES_ROCK_SNAKE
+	dex_species "HYPNOSIS"   ; SPECIES_HYPNOSIS
+	dex_species "RIVER CRAB" ; SPECIES_RIVER_CRAB
+	dex_species "PINCER"     ; SPECIES_PINCER
+	dex_species "BALL"       ; SPECIES_BALL
+	dex_species "EGG"        ; SPECIES_EGG
+	dex_species "COCONUT"    ; SPECIES_COCONUT
+	dex_species "LONELY"     ; SPECIES_LONELY
+	dex_species "BONEKEEPER" ; SPECIES_BONEKEEPER
+	dex_species "KICKING"    ; SPECIES_KICKING
+	dex_species "PUNCHING"   ; SPECIES_PUNCHING
+	dex_species "LICKING"    ; SPECIES_LICKING
+	dex_species "POISON GAS" ; SPECIES_POISON_GAS
+	dex_species "SPIKES"     ; SPECIES_SPIKES
+	dex_species "VINE"       ; SPECIES_VINE
+	dex_species "PARENT"     ; SPECIES_PARENT
+	dex_species "DRAGON"     ; SPECIES_DRAGON
+	dex_species "GOLDFISH"   ; SPECIES_GOLDFISH
+	dex_species "STARSHAPE"  ; SPECIES_STARSHAPE
+	dex_species "MYSTERIOUS" ; SPECIES_MYSTERIOUS
+	dex_species "BARRIER"    ; SPECIES_BARRIER
+	dex_species "MANTIS"     ; SPECIES_MANTIS
+	dex_species "HUMANSHAPE" ; SPECIES_HUMANSHAPE
+	dex_species "ELECTRIC"   ; SPECIES_ELECTRIC
+	dex_species "SPITFIRE"   ; SPECIES_SPITFIRE
+	dex_species "STAGBEETLE" ; SPECIES_STAGBEETLE
+	dex_species "WILD BULL"  ; SPECIES_WILD_BULL
+	dex_species "FISH"       ; SPECIES_FISH
+	dex_species "ATROCIOUS"  ; SPECIES_ATROCIOUS
+	dex_species "TRANSPORT"  ; SPECIES_TRANSPORT
+	dex_species "TRANSFORM"  ; SPECIES_TRANSFORM
+	dex_species "EVOLUTION"  ; SPECIES_EVOLUTION
+	dex_species "BUBBLE JET" ; SPECIES_BUBBLE_JET
+	dex_species "LIGHTNING"  ; SPECIES_LIGHTNING
+	dex_species "FLAME"      ; SPECIES_FLAME_2
+	dex_species "VIRTUAL"    ; SPECIES_VIRTUAL
+	dex_species "SPIRAL"     ; SPECIES_SPIRAL
+	dex_species "FOSSIL"     ; SPECIES_FOSSIL
+	dex_species "SLEEPING"   ; SPECIES_SLEEPING
+	dex_species "FREEZE"     ; SPECIES_FREEZE
+	dex_species "GENETIC"    ; SPECIES_GENETIC
+	dex_species "NEW SPECIE" ; SPECIES_NEW_SPECIE
+	dex_species "RAT"        ; SPECIES_RAT

--- a/tools/.gitignore
+++ b/tools/.gitignore
@@ -1,0 +1,3 @@
+gfx
+pcm
+scan_includes


### PR DESCRIPTION
I was rebuilding various pret repos to get updated .sym files for local use, and noticed an incorrect ROM was built when using rgbds v0.4.0. I traced it to the `dex_species` macro, which ISSOtm noted relied on [this buggy behavior](https://github.com/rednex/rgbds/issues/321) that was present in v0.3.x.

PR contains ISSO's proposed solution, which is backwards-compatible and improves readability of `text/pokedex_species.asm`. I added a second commit to use ASCII characters in place of some magic numbers in `macros/pokedex.asm`, and added `tools/.gitignore` to ignore build output in the `tools/` directory.