### PR TITLE
MD5 to SHA1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,11 @@
 ROM := pokepinball.gbc
 OBJS := main.o wram.o sram.o
 
-MD5 := md5sum -c
+ifeq (,$(shell which sha1sum))
+SHA1 := shasum
+else
+SHA1 := sha1sum
+endif
 
 all: $(ROM) compare
 
@@ -26,7 +30,7 @@ $(ROM): $(OBJS) contents/contents.link
 
 # For contributors to make sure a change didn't affect the contents of the rom.
 compare: $(ROM)
-	@$(MD5) rom.md5
+	@$(SHA1) -c rom.sha1
 
 tools:
 	$(MAKE) -C tools

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is a disassembly of Pokémon Pinball (Game Boy Color).
 
 It builds the following rom:
 
-* Pokemon Pinball (U) [C][!].gb  `md5: fbe20570c2e52c937a9395024069ba3c`
+* Pokemon Pinball (U) [C][!].gb  `sha1: 9402014d14969432142abfde728c6f1a10ee4dac`
 
 To set up the repository, see [**INSTALL.md**](INSTALL.md).
 

--- a/rom.md5
+++ b/rom.md5
@@ -1,1 +1,0 @@
-fbe20570c2e52c937a9395024069ba3c  pokepinball.gbc

--- a/rom.sha1
+++ b/rom.sha1
@@ -1,0 +1,1 @@
+9402014d14969432142abfde728c6f1a10ee4dac *pokepinball.gbc


### PR DESCRIPTION
This converts the compare MD5 hashing to SHA1 that is used in the other pret repo's.

Please reference: https://github.com/pret/pokepinball/issues/36