### PR TITLE
Rename wd7ad to wStageCollisionStateBitsToSet

### DIFF
--- a/engine/pinball_game/ball_init/ball_init_red_field.asm
+++ b/engine/pinball_game/ball_init/ball_init_red_field.asm
@@ -13,12 +13,12 @@ InitBallRedField: ; 0x3007d
 	xor a
 	ld [wEnableBallGravityAndTilt], a
 	ld [wd580], a
-	ld a, [wStageCollisionStateBitsToSet]
+	ld a, [wRedStageStructureBackup]
 	bit 7, a
 	jr z, .asm_300ae
 	ld a, [wStageCollisionState]
 	res 0, a
-	ld [wStageCollisionStateBitsToSet], a
+	ld [wRedStageStructureBackup], a
 .asm_300ae
 	ld a, [wStageCollisionState]
 	and $1

--- a/engine/pinball_game/ball_init/ball_init_red_field.asm
+++ b/engine/pinball_game/ball_init/ball_init_red_field.asm
@@ -13,12 +13,12 @@ InitBallRedField: ; 0x3007d
 	xor a
 	ld [wEnableBallGravityAndTilt], a
 	ld [wd580], a
-	ld a, [wd7ad]
+	ld a, [wStageCollisionStateBitsToSet]
 	bit 7, a
 	jr z, .asm_300ae
 	ld a, [wStageCollisionState]
 	res 0, a
-	ld [wd7ad], a
+	ld [wStageCollisionStateBitsToSet], a
 .asm_300ae
 	ld a, [wStageCollisionState]
 	and $1

--- a/engine/pinball_game/ball_loss/ball_loss_red_field.asm
+++ b/engine/pinball_game/ball_loss/ball_loss_red_field.asm
@@ -91,7 +91,7 @@ ConcludeSpecialMode_RedField: ; 0xddfd
 	ld [wFramesUntilSlotCaveOpens], a
 	callba ConcludeMapMoveMode
 .setCollisionState
-	ld a, [wStageCollisionStateBitsToSet]
+	ld a, [wRedStageStructureBackup]
 	ld c, a
 	ld a, [wStageCollisionState]
 	and $1

--- a/engine/pinball_game/ball_loss/ball_loss_red_field.asm
+++ b/engine/pinball_game/ball_loss/ball_loss_red_field.asm
@@ -91,7 +91,7 @@ ConcludeSpecialMode_RedField: ; 0xddfd
 	ld [wFramesUntilSlotCaveOpens], a
 	callba ConcludeMapMoveMode
 .setCollisionState
-	ld a, [wd7ad]
+	ld a, [wStageCollisionStateBitsToSet]
 	ld c, a
 	ld a, [wStageCollisionState]
 	and $1

--- a/engine/pinball_game/evolution_mode.asm
+++ b/engine/pinball_game/evolution_mode.asm
@@ -633,7 +633,7 @@ StartEvolutionMode_RedField: ; 0x10ebb
 	ld [wLeftAlleyCount], a
 	call CloseSlotCave_
 	ld a, $2
-	ld [wd7ad], a
+	ld [wStageCollisionStateBitsToSet], a
 	ld de, MUSIC_CATCH_EM_BLUE ; Either MUSIC_CATCH_EM_BLUE or MUSIC_CATCH_EM_RED. They have the same id in their respective audio Banks.
 	call PlaySong
 	call SetPokemonSeenFlag
@@ -769,7 +769,7 @@ StartEvolutionMode_BlueField: ; 0x11061
 	ld [wLeftAlleyCount], a
 	callba CloseSlotCave
 	ld a, $2
-	ld [wd7ad], a
+	ld [wStageCollisionStateBitsToSet], a
 	ld de, MUSIC_CATCH_EM_BLUE ; Either MUSIC_CATCH_EM_BLUE or MUSIC_CATCH_EM_RED. They have the same id in their respective audio Banks.
 	call PlaySong
 	call SetPokemonSeenFlag

--- a/engine/pinball_game/evolution_mode.asm
+++ b/engine/pinball_game/evolution_mode.asm
@@ -633,7 +633,7 @@ StartEvolutionMode_RedField: ; 0x10ebb
 	ld [wLeftAlleyCount], a
 	call CloseSlotCave_
 	ld a, $2
-	ld [wStageCollisionStateBitsToSet], a
+	ld [wRedStageStructureBackup], a
 	ld de, MUSIC_CATCH_EM_BLUE ; Either MUSIC_CATCH_EM_BLUE or MUSIC_CATCH_EM_RED. They have the same id in their respective audio Banks.
 	call PlaySong
 	call SetPokemonSeenFlag
@@ -769,7 +769,7 @@ StartEvolutionMode_BlueField: ; 0x11061
 	ld [wLeftAlleyCount], a
 	callba CloseSlotCave
 	ld a, $2
-	ld [wStageCollisionStateBitsToSet], a
+	ld [wRedStageStructureBackup], a
 	ld de, MUSIC_CATCH_EM_BLUE ; Either MUSIC_CATCH_EM_BLUE or MUSIC_CATCH_EM_RED. They have the same id in their respective audio Banks.
 	call PlaySong
 	call SetPokemonSeenFlag

--- a/engine/pinball_game/map_move.asm
+++ b/engine/pinball_game/map_move.asm
@@ -119,7 +119,7 @@ Func_311b4: ; 0x311b4
 	ld [wStageCollisionMap + $103], a
 	callba CloseSlotCave_
 	ld a, $4
-	ld [wd7ad], a
+	ld [wStageCollisionStateBitsToSet], a
 	ld de, MUSIC_HURRY_UP_BLUE ; Either MUSIC_HURRY_UP_BLUE or MUSIC_HURRY_UP_RED. They have the same id in their respective audio Banks.
 	call PlaySong
 	ld a, [wCurrentStage]

--- a/engine/pinball_game/map_move.asm
+++ b/engine/pinball_game/map_move.asm
@@ -119,7 +119,7 @@ Func_311b4: ; 0x311b4
 	ld [wStageCollisionMap + $103], a
 	callba CloseSlotCave_
 	ld a, $4
-	ld [wStageCollisionStateBitsToSet], a
+	ld [wRedStageStructureBackup], a
 	ld de, MUSIC_HURRY_UP_BLUE ; Either MUSIC_HURRY_UP_BLUE or MUSIC_HURRY_UP_RED. They have the same id in their respective audio Banks.
 	call PlaySong
 	ld a, [wCurrentStage]

--- a/engine/pinball_game/object_collision/red_stage_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/red_stage_resolve_collision.asm
@@ -1455,7 +1455,7 @@ HandleThirdRightAlleyTrigger_RedField: ; 0x15990
 
 UpdateFieldStructures_RedField: ; 0x159c9
 ; The Red field's top half has some dynamic strucutres, such as Ditto, the lightning bolt guard rail, and the roof over the 3 Voltorbs.
-	ld a, [wd7ad]
+	ld a, [wStageCollisionStateBitsToSet]
 	bit 7, a
 	ret nz
 	ld c, a
@@ -1464,7 +1464,8 @@ UpdateFieldStructures_RedField: ; 0x159c9
 	or c
 	ld [wStageCollisionState], a
 	ld a, $ff
-	ld [wd7ad], a
+	; setting 7th bit of [wStageCollisionStateBitsToSet] to 1 will cause this method to be skipped, or in this case 0xff, but only the 7th bit matters
+	ld [wStageCollisionStateBitsToSet], a
 	callba LoadStageCollisionAttributes
 	call LoadFieldStructureGraphics_RedField
 	ld a, $1
@@ -2097,7 +2098,7 @@ DoSlotLogic_RedField: ; 0x16352
 	cp EVOLUTION_MODE_SLOT_REWARD
 	ret nz
 	callba StartEvolutionMode
-	ld a, [wd7ad]
+	ld a, [wStageCollisionStateBitsToSet]
 	ld c, a
 	ld a, [wStageCollisionState]
 	and $1

--- a/engine/pinball_game/object_collision/red_stage_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/red_stage_resolve_collision.asm
@@ -1455,7 +1455,7 @@ HandleThirdRightAlleyTrigger_RedField: ; 0x15990
 
 UpdateFieldStructures_RedField: ; 0x159c9
 ; The Red field's top half has some dynamic strucutres, such as Ditto, the lightning bolt guard rail, and the roof over the 3 Voltorbs.
-	ld a, [wStageCollisionStateBitsToSet]
+	ld a, [wRedStageStructureBackup]
 	bit 7, a
 	ret nz
 	ld c, a
@@ -1465,7 +1465,7 @@ UpdateFieldStructures_RedField: ; 0x159c9
 	ld [wStageCollisionState], a
 	ld a, $ff
 	; setting 7th bit of [wStageCollisionStateBitsToSet] to 1 will cause this method to be skipped, or in this case 0xff, but only the 7th bit matters
-	ld [wStageCollisionStateBitsToSet], a
+	ld [wRedStageStructureBackup], a
 	callba LoadStageCollisionAttributes
 	call LoadFieldStructureGraphics_RedField
 	ld a, $1
@@ -2098,7 +2098,7 @@ DoSlotLogic_RedField: ; 0x16352
 	cp EVOLUTION_MODE_SLOT_REWARD
 	ret nz
 	callba StartEvolutionMode
-	ld a, [wStageCollisionStateBitsToSet]
+	ld a, [wRedStageStructureBackup]
 	ld c, a
 	ld a, [wStageCollisionState]
 	and $1

--- a/engine/pinball_game/stage_init/init_red_field.asm
+++ b/engine/pinball_game/stage_init/init_red_field.asm
@@ -34,7 +34,7 @@ InitRedField: ; 0x30000
 	ld [wInitialNextBonusStage], a ; BONUS_STAGE_ORDER_DIGLETT
 	ld a, $4
 	ld [wStageCollisionState], a
-	ld [wd7ad], a
+	ld [wStageCollisionStateBitsToSet], a
 	ld a, $80
 	ld [wIndicatorStates], a
 	ld [wIndicatorStates + 3], a

--- a/engine/pinball_game/stage_init/init_red_field.asm
+++ b/engine/pinball_game/stage_init/init_red_field.asm
@@ -34,7 +34,7 @@ InitRedField: ; 0x30000
 	ld [wInitialNextBonusStage], a ; BONUS_STAGE_ORDER_DIGLETT
 	ld a, $4
 	ld [wStageCollisionState], a
-	ld [wStageCollisionStateBitsToSet], a
+	ld [wRedStageStructureBackup], a
 	ld a, $80
 	ld [wIndicatorStates], a
 	ld [wIndicatorStates + 3], a

--- a/wram.asm
+++ b/wram.asm
@@ -1733,7 +1733,10 @@ wDisableHorizontalScrollForBallStart:: ; 0xd7ac
 ; 0 = Enable the scrolling
 	ds $1
 
-wd7ad:: ; 0xd7ad
+wStageCollisionStateBitsToSet:: ; 0xd7ad
+; The ditto state on red stage is heavily reliant on this value being initialized to 0b100,
+; The var appears to be a bitfield and I dont think bit 3 gets cleared after being initialized.
+; A value of 0xff will cause this var to be ignored and treated as no changes.
 	ds $1
 
 wLeftFlipperState:: ; 0xd7ae

--- a/wram.asm
+++ b/wram.asm
@@ -1735,7 +1735,6 @@ wDisableHorizontalScrollForBallStart:: ; 0xd7ac
 
 wRedStageStructureBackup:: ; 0xd7ad
 ; The ditto state on red stage is heavily reliant on this value being initialized to 0b100,
-; The var appears to be a bitfield and I dont think bit 3 gets cleared after being initialized.
 ; A value of 0xff will cause this var to be ignored and treated as no changes.
 	ds $1
 

--- a/wram.asm
+++ b/wram.asm
@@ -1733,7 +1733,7 @@ wDisableHorizontalScrollForBallStart:: ; 0xd7ac
 ; 0 = Enable the scrolling
 	ds $1
 
-wStageCollisionStateBitsToSet:: ; 0xd7ad
+wRedStageStructureBackup:: ; 0xd7ad
 ; The ditto state on red stage is heavily reliant on this value being initialized to 0b100,
 ; The var appears to be a bitfield and I dont think bit 3 gets cleared after being initialized.
 ; A value of 0xff will cause this var to be ignored and treated as no changes.


### PR DESCRIPTION
This var seems to be a temporary value that holds bits to be set in wStageCollisionState, it is intertwined in the ditto logic on the red field and is required to be initialized for ditto to work properly. 

I discovered that if this field is not initialized to 0b100, the dittos will not move to cover the ball starting area on the red stage. Setting this value to 0b110 will move ditto out of the way for the player to reach the top left slot, but then also sets the wStageCollisionState second bit, causing the collision state of the map to match the pattern of the blue stage, I suspect that the second bit flips depending on where the ball is on the field when playing red stage when the slot should be open.