### PR TITLE
Turn two $ffa0 that are not related to hSCY back into literals

### DIFF
--- a/engine/high_scores_screen.asm
+++ b/engine/high_scores_screen.asm
@@ -1164,7 +1164,7 @@ Func_d2cb: ; 0xd2cb
 	xor a
 	call Func_d317
 	pop hl
-	ld bc, hSCY
+	ld bc, -3 * $20
 	add hl, bc
 	pop bc
 	dec b
@@ -1286,7 +1286,7 @@ Func_d361: ; 0xd361
 	xor a
 	call Func_d3ad
 	pop hl
-	ld bc, hSCY
+	ld bc, -3 * $20
 	add hl, bc
 	pop bc
 	dec b


### PR DESCRIPTION
These two additions are instead moving a cursor from the vram coordinates of one high-score row to the previous row; since each row is three tiles tall, that is subtracting $60, or equivalently adding $ffa0.
Without this change and if hSCY is moved, the high score table will have names and scores drawn to the wrong location.