### PR TITLE
Convert `hram.asm` to a HRAM Section

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@
 .SECONDARY:
 
 ROM := pokepinball.gbc
-OBJS := main.o wram.o sram.o
+OBJS := main.o wram.o sram.o hram.o
 
 ifeq (,$(shell which sha1sum))
 SHA1 := shasum

--- a/constants.asm
+++ b/constants.asm
@@ -1,4 +1,3 @@
-INCLUDE "hram.asm"
 INCLUDE "vram.asm"
 INCLUDE "gbhw.asm"
 

--- a/contents/contents.link
+++ b/contents/contents.link
@@ -5,3 +5,9 @@ INCLUDE "contents/wram.link"
 SRAM 0
 	org $a000
 	"SRAM 0"
+
+HRAM
+	org $FF80
+	"HRAM"
+	org $FFF8
+	"HRAM.2"

--- a/engine/copyright_screen.asm
+++ b/engine/copyright_screen.asm
@@ -8,15 +8,15 @@ CopyrightScreenFunctions: ; 0x8222
 
 FadeInCopyrightScreen: ; 0x8228
 	ld a, $41
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e4
 	ld [wBGP], a
 	xor a
 	ld [wOBP0], a
 	ld [wOBP1], a
-	ld [hSCX], a
-	ld [hSCY], a
-	ld a, [hGameBoyColorFlag]
+	ldh [hSCX], a
+	ldh [hSCY], a
+	ldh a, [hGameBoyColorFlag]
 	ld hl, CopyrightTextGfxPointers
 	call LoadVideoData
 	call ClearSpriteBuffer
@@ -55,7 +55,7 @@ DisplayCopyrightScreen: ; 0x8290
 	ld a, b
 	cp $2d  ; player can press A button to skip copyright screen once counter is below $2d
 	jr nc, .decrementCounter
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr nz, .done
 .decrementCounter

--- a/engine/erase_all_data_menu.asm
+++ b/engine/erase_all_data_menu.asm
@@ -7,7 +7,7 @@ EraseAllDataMenuFunctions: ; 0x8161
 	dw ExitEraseAllDataMenu
 
 CheckForResetButtonCombo: ; 0x8167
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	cp (D_UP | D_RIGHT | START | SELECT)
 	jr z, .heldCorrectButtons
 	ld hl, wCurrentScreen
@@ -16,15 +16,15 @@ CheckForResetButtonCombo: ; 0x8167
 
 .heldCorrectButtons
 	ld a, $41
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e4
 	ld [wBGP], a
 	xor a
 	ld [wOBP0], a
 	ld [wOBP1], a
-	ld [hSCX], a
-	ld [hSCY], a
-	ld a, [hGameBoyColorFlag]
+	ldh [hSCX], a
+	ldh [hSCY], a
+	ldh a, [hGameBoyColorFlag]
 	ld hl, EraseAllDataGfxPointers
 	call LoadVideoData
 	call ClearSpriteBuffer
@@ -53,7 +53,7 @@ EraseAllDataGfx_GameBoyColor: ; 0x81b6
 	db $FF, $FF ; terminators
 
 HandleEraseAllDataInput: ; 0x81d4
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .checkForBButton
 	ld hl, $a000

--- a/engine/field_select_screen.asm
+++ b/engine/field_select_screen.asm
@@ -8,17 +8,17 @@ FieldSelectScreenFunctions: ; 0xd6d7
 
 LoadFieldSelectScreen: ; 0xd6dd
 	ld a, $43
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e4
 	ld [wBGP], a
 	ld a, $d2
 	ld [wOBP0], a
 	ld [wOBP1], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld hl, FieldSelectGfxPointers
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	call LoadVideoData
 	call ClearSpriteBuffer
 	ld a, $8
@@ -54,7 +54,7 @@ ChooseFieldToPlay: ; 0xd74e
 	call MoveFieldSelectCursor
 	ld hl, FieldSelectBorderAnimationData
 	call AnimateBlinkingFieldSelectBorder
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and (A_BUTTON | B_BUTTON)
 	ret z
 	ld [wFieldSelectPressedButton], a
@@ -79,7 +79,7 @@ ExitFieldSelectScreen: ; 0xd774
 	ld [wFieldSelectBlinkingBorderTimer], a
 	ret nz
 .didntPressA
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	push af
 	call FadeOut
 	call DisableLCD
@@ -125,7 +125,7 @@ MoveFieldSelectCursor: ; 0xd7d3
 ; When the player presses Right or Left, the stage is
 ; illuminated with a blinking border.  This function keeps tracks
 ; of which field is currently selected.
-	ld a, [hPressedButtons]
+	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [wSelectedFieldIndex]
 	bit BIT_D_LEFT, b

--- a/engine/high_scores_screen.asm
+++ b/engine/high_scores_screen.asm
@@ -98,30 +98,30 @@ Func_ca8f: ; 0xca8f
 
 Func_cb14: ; 0xcb14
 	ld a, $43
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e0
 	ld [wBGP], a
 	ld a, $e1
 	ld [wOBP0], a
 	ld [wOBP1], a
 	xor a
-	ld [hSCX], a
-	ld [hNextFrameHBlankSCX], a
-	ld [hSCY], a
-	ld [hNextFrameHBlankSCY], a
+	ldh [hSCX], a
+	ldh [hNextFrameHBlankSCX], a
+	ldh [hSCY], a
+	ldh [hNextFrameHBlankSCY], a
 	ld a, $e
-	ld [hLYC], a
-	ld [hLastLYC], a
+	ldh [hLYC], a
+	ldh [hLastLYC], a
 	ld a, $82
-	ld [hNextLYCSub], a
-	ld [hLYCSub], a
+	ldh [hNextLYCSub], a
+	ldh [hLYCSub], a
 	ld hl, hSTAT
 	set 6, [hl]
 	ld hl, rIE
 	set 1, [hl]
 	ld a, $3
-	ld [hStatIntrRoutine], a
-	ld a, [hGameBoyColorFlag]
+	ldh [hStatIntrRoutine], a
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_cb51
 	ld a, [wHighScoresStage]
@@ -277,7 +277,7 @@ Func_ccac: ; 0xccac
 Func_ccb6: ; 0xccb6
 	call Func_d4cf
 	call AnimateHighScoresArrow
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_ccd1
 	lb de, $00, $01
@@ -303,7 +303,7 @@ Func_ccb6: ; 0xccb6
 	bit 3, a
 	jr z, .asm_ccfb
 	call Func_1a43
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	ld [wd8f0], a
 	lb de, $00, $01
 	call PlaySoundEffect
@@ -312,10 +312,10 @@ Func_ccb6: ; 0xccb6
 	ret
 
 .asm_ccfb
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	cp (SELECT | D_UP)
 	ret nz
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and (SELECT | D_UP)
 	ret z
 	lb de, $00, $01
@@ -326,7 +326,7 @@ Func_ccb6: ; 0xccb6
 	call LoadSpriteData
 .waitForDeleteScoresConfirmation
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	jr z, .asm_cd24
 	lb de, $00, $01
@@ -362,12 +362,12 @@ Func_ccb6: ; 0xccb6
 	ret
 
 Func_cd6c: ; 0xcd6c
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $1f
 	call z, Func_1a43
 	call Func_cf7d
 	call Func_cfa6
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_cdbb
 	lb de, $00, $01
@@ -399,7 +399,7 @@ Func_cd6c: ; 0xcd6c
 	pop af
 	jr nc, .asm_cdc6
 .asm_cdbb
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	ret z
 	lb de, $00, $01
@@ -569,14 +569,14 @@ SendHighScores: ; 0xced1
 .attemptToSendHighScoresLoop
 	push bc
 	xor a
-	ld [hNumFramesSinceLastVBlank], a
+	ldh [hNumFramesSinceLastVBlank], a
 .asm_cefa
 	ld b, $2
 	ld c, $56
 	ld a, [$ff00+c]
 	and b
 	jr z, .asm_cf09
-	ld a, [hNumFramesSinceLastVBlank]
+	ldh a, [hNumFramesSinceLastVBlank]
 	and a
 	jr z, .asm_cefa
 	jr .asm_cf0e
@@ -637,7 +637,7 @@ Func_cf58: ; 0xcf58
 	call LoadSpriteData
 .asm_cf6f
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_cf6f
 	lb de, $00, $01
@@ -791,7 +791,7 @@ Func_d035: ; 0xd035
 	ret
 
 Func_d042: ; 0xd042
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	ld [wda86], a
 	ld b, a
 	ld a, $80
@@ -956,7 +956,7 @@ ExitHighScoresScreen: ; 0xd171
 	ret
 
 Func_d18b: ; 0xd18b
-	ld a, [hPressedButtons]
+	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [wHighScoreNameRow]
 	ld e, a
@@ -1001,7 +1001,7 @@ Func_d18b: ; 0xd18b
 	ret
 
 Func_d1d2: ; 0xd1d2
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wHighScoreNameColumn]
 	bit BIT_A_BUTTON, b
@@ -1040,7 +1040,7 @@ Func_d211: ; 0xd211
 	ld a, [wHighScoreIsEnteringName]
 	and a
 	ret z
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and (D_RIGHT | D_LEFT)
 	jr z, .asm_d221
 	; current name entry character changed; hide asterisk to show new letter
@@ -1463,7 +1463,7 @@ Func_d46f: ; 0xd46f
 	ret
 
 Func_d4cf: ; 0xd4cf
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wHighScoresStage]
 	bit 4, b
@@ -1487,11 +1487,11 @@ Func_d4cf: ; 0xd4cf
 	call ClearSpriteBuffer
 	call Func_d57b
 	ld a, $a5
-	ld [hWX], a
+	ldh [hWX], a
 	xor a
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, $2
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld hl, hLCDC
 	set 5, [hl]
 	ld b, $27
@@ -1516,7 +1516,7 @@ Func_d4cf: ; 0xd4cf
 	dec b
 	jr nz, .asm_d508
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld hl, hLCDC
 	res 5, [hl]
 	set 3, [hl]
@@ -1529,11 +1529,11 @@ Func_d4cf: ; 0xd4cf
 	call ClearSpriteBuffer
 	call Func_d57b
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	xor a
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, $a0
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld hl, hLCDC
 	set 5, [hl]
 	res 3, [hl]
@@ -1558,7 +1558,7 @@ Func_d4cf: ; 0xd4cf
 	dec b
 	jr nz, .asm_d551
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld hl, hLCDC
 	res 5, [hl]
 	xor a
@@ -1568,11 +1568,11 @@ Func_d4cf: ; 0xd4cf
 
 Func_d57b: ; 0xd57b
 	ld a, $f0
-	ld [hSCY], a
+	ldh [hSCY], a
 	xor a
-	ld [hNextFrameHBlankSCX], a
+	ldh [hNextFrameHBlankSCX], a
 	ld a, $10
-	ld [hNextFrameHBlankSCY], a
+	ldh [hNextFrameHBlankSCY], a
 	rst AdvanceFrame
 	ld a, BANK(HighScoresTilemap)
 	ld hl, HighScoresTilemap
@@ -1642,16 +1642,16 @@ Func_d5d0: ; 0xd5d0
 	ld bc, $0009
 	call Func_d68a
 	xor a
-	ld [hSCY], a
-	ld [hNextFrameHBlankSCX], a
-	ld [hNextFrameHBlankSCY], a
+	ldh [hSCY], a
+	ldh [hNextFrameHBlankSCX], a
+	ldh [hNextFrameHBlankSCY], a
 	ret
 
 TransitionHighScoresPalettes: ; 0xd626
 ; When switching between the Red and Blue field high scores, the palettes
 ; of the rows smoothly transition between red and blue.
 	ld c, a
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld a, c

--- a/engine/high_scores_screen.asm
+++ b/engine/high_scores_screen.asm
@@ -691,15 +691,15 @@ Func_cfa6: ; 0xcfa6
 
 Func_cfcb: ; 0xcfcb
 	ld a, e
-	ld [$ff8c], a
+	ldh [hHighscoresFF8C], a
 	ld a, d
-	ld [$ff8d], a
+	ldh [hHighscoresFF8C + 1], a
 	push hl
 	ld b, $5
 .asm_cfd4
-	ld a, [$ff8c]
+	ldh a, [hHighscoresFF8C]
 	ld e, a
-	ld a, [$ff8d]
+	ldh a, [hHighscoresFF8C + 1]
 	ld d, a
 	call Func_d005
 	call Func_d017
@@ -717,9 +717,9 @@ Func_cfcb: ; 0xcfcb
 	ret c
 	push af
 	jr nz, .asm_cff8
-	ld a, [$ff8c]
+	ldh a, [hHighscoresFF8C]
 	ld l, a
-	ld a, [$ff8d]
+	ldh a, [hHighscoresFF8C + 1]
 	ld h, a
 .asm_cff8
 	ld c, $d
@@ -746,7 +746,7 @@ Func_d005: ; 0xd005
 	jr nz, .asm_d007
 .asm_d010
 	ld a, c
-	ld [$ff8e], a
+	ldh [hHighscoresFF8E], a
 	call Func_d035
 	ret
 
@@ -761,7 +761,7 @@ Func_d017: ; 0xd017
 	dec hl
 	dec c
 	jr nz, .asm_d019
-	ld a, [$ff8e]
+	ldh a, [hHighscoresFF8E]
 	and a
 	jr nz, .asm_d02b
 	ld b, $5

--- a/engine/options_screen.asm
+++ b/engine/options_screen.asm
@@ -11,17 +11,17 @@ OptionsScreenFunctions: ; 0xc34e
 
 Func_c35a: ; 0xc35a
 	ld a, $47
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e4
 	ld [wBGP], a
 	ld [wOBP0], a
 	ld a, $d2
 	ld [wOBP1], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld hl, OptionsScreenVideoDataPointers
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	call LoadVideoData
 	call ClearSpriteBuffer
 	ld a, $2
@@ -71,7 +71,7 @@ Func_c400: ; 0xc400
 	call Func_c41a
 	call Func_c43a
 	call Func_c447
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit 1, a
 	ret z
 	lb de, $00, $01
@@ -81,7 +81,7 @@ Func_c400: ; 0xc400
 	ret
 
 Func_c41a: ; 0xc41a
-	ld a, [hPressedButtons]
+	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [wd916]
 	bit 6, b
@@ -111,7 +111,7 @@ Func_c43a: ; 0xc43a
 	ret
 
 Func_c447: ; 0xc447
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	ret z
 	lb de, $00, $01
@@ -119,7 +119,7 @@ Func_c447: ; 0xc447
 	ld a, [wd916]
 	and a
 	jr nz, .asm_c465
-	ld a, [hSGBFlag]
+	ldh a, [hSGBFlag]
 	and a
 	ret nz
 	call Func_c4f4
@@ -157,7 +157,7 @@ Func_c493: ; 0xc493
 	call Func_c4b4
 	call Func_c4e6
 	call Func_c869
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	ret z
 	lb de, $00, $01
@@ -170,7 +170,7 @@ Func_c493: ; 0xc493
 	ret
 
 Func_c4b4: ; 0xc4b4
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wd917]
 	bit BIT_D_LEFT, b
@@ -220,7 +220,7 @@ Func_c506: ; 0xc506
 	call Func_c534
 	call Func_c554
 	call Func_c55a
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	ret z
 	lb de, $00, $01
@@ -237,7 +237,7 @@ Func_c506: ; 0xc506
 	ret
 
 Func_c534: ; 0xc534
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wd918]
 	bit BIT_D_UP, b
@@ -268,7 +268,7 @@ Func_c55a: ; 0xc55a
 	ld a, [wd918]
 	and a
 	jr nz, .asm_c572
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	ret z
 	lb de, $00, $01
@@ -278,7 +278,7 @@ Func_c55a: ; 0xc55a
 	ret
 
 .asm_c572
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	ret z
 	lb de, $00, $01
@@ -312,7 +312,7 @@ Func_c55a: ; 0xc55a
 	rst AdvanceFrame
 	pop hl
 	pop bc
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and a
 	jr z, .asm_c5c2
 	ld c, $0
@@ -357,7 +357,7 @@ Func_c55a: ; 0xc55a
 	pop bc
 	dec d
 	ret z
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and a
 	jr z, .asm_c613
 	ld d, $ff
@@ -386,7 +386,7 @@ Func_c621: ; 0xc621
 	ld c, a
 	ld a, [hl]
 	ld b, a
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	bit 2, a
 	ret z
 	ld a, SPRITE_OPTIONS_SOLID_WHITE
@@ -453,7 +453,7 @@ Func_c691: ; 0xc91
 	call Func_c6bf
 	call Func_c6d9
 	call Func_c6e8
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	ret z
 	ld de, MUSIC_NOTHING
@@ -472,7 +472,7 @@ Func_c691: ; 0xc91
 	ret
 
 Func_c6bf: ; 0xc6bf
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wd919]
 	bit BIT_D_UP, b
@@ -504,7 +504,7 @@ Func_c6e8: ; 0xc6e8
 	ld a, [wd919]
 	and a
 	jr nz, UpdateSoundTestSoundEffectSelection
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, UpdateSoundTestBackgroundMusicSelection
 	ld de, MUSIC_NOTHING
@@ -527,7 +527,7 @@ Func_c6e8: ; 0xc6e8
 	ret
 
 UpdateSoundTestBackgroundMusicSelection: ; 0xc715
-	ld a, [hPressedButtons] ; joypad state
+	ldh a, [hPressedButtons] ; joypad state
 	ld b, a
 	ld a, [wSoundTestCurrentBackgroundMusic]
 	bit BIT_D_LEFT, b  ; was the left dpad button pressed?
@@ -551,7 +551,7 @@ UpdateSoundTestBackgroundMusicSelection: ; 0xc715
 	jp RedrawSoundTestID
 
 UpdateSoundTestSoundEffectSelection: ; 0xc73a
-	ld a, [hNewlyPressedButtons] ; joypad state
+	ldh a, [hNewlyPressedButtons] ; joypad state
 	bit BIT_A_BUTTON, a
 	jr z, .didntPressAButton
 	ld a, [wSoundTextCurrentSoundEffect]
@@ -561,7 +561,7 @@ UpdateSoundTestSoundEffectSelection: ; 0xc73a
 	ret
 
 .didntPressAButton
-	ld a, [hPressedButtons] ; joypad state
+	ldh a, [hPressedButtons] ; joypad state
 	ld b, a
 	ld a, [wSoundTextCurrentSoundEffect]
 	bit BIT_D_LEFT, b  ; was the left dpad button pressed?

--- a/engine/pinball_game.asm
+++ b/engine/pinball_game.asm
@@ -22,7 +22,7 @@ GameScreenFunction_LoadGFX: ; 0xd861
 
 GameScreenFunction_StartBall: ; 0xd87f
 	ld a, $67
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e4
 	ld [wBGP], a
 	ld a, $e1
@@ -30,22 +30,22 @@ GameScreenFunction_StartBall: ; 0xd87f
 	ld a, $e4
 	ld [wOBP1], a
 	ld a, [wSCX]
-	ld [hSCX], a
+	ldh [hSCX], a
 	xor a
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $83
-	ld [hLYC], a
-	ld [hLastLYC], a
+	ldh [hLYC], a
+	ldh [hLastLYC], a
 	ld a, $ff
-	ld [hLCDCMask], a
+	ldh [hLCDCMask], a
 	ld hl, hSTAT
 	set 6, [hl]
 	ld hl, rIE
 	set 1, [hl]
 	ld a, $1
-	ld [hStatIntrRoutine], a
+	ldh [hStatIntrRoutine], a
 	callba InitBallForStage
 	callba LoadStageCollisionAttributes
 	callba LoadStageData
@@ -177,9 +177,9 @@ INCLUDE "engine/pinball_game/save_game.asm"
 
 GameScreenFunction_HandleBallLoss: ; 0xda36
 	xor a
-	ld [hJoypadState], a
-	ld [hNewlyPressedButtons], a
-	ld [hPressedButtons], a
+	ldh [hJoypadState], a
+	ldh [hNewlyPressedButtons], a
+	ldh [hPressedButtons], a
 	ld [wFlipperCollision], a
 	ld [wCollisionForceAmplification], a
 	xor a

--- a/engine/pinball_game/billboard.asm
+++ b/engine/pinball_game/billboard.asm
@@ -51,7 +51,7 @@ LoadBillboardOffPicture: ; 0xf196
 INCLUDE "data/billboard/billboard_pic_pointers.asm"
 
 LoadGreyBillboardPaletteData: ; 0xf269
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .loadPaletteMap
 	ld a, BANK(StageRedFieldBottomBGPalette5) ; also used in blue stage

--- a/engine/pinball_game/billboard_tiledata.asm
+++ b/engine/pinball_game/billboard_tiledata.asm
@@ -14,7 +14,7 @@ LoadBillboardTileData: ; 0x30256
 	ld a, Bank(BillboardTileDataPointers)
 	call QueueGraphicsToLoad
 	pop bc
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld hl, BillboardPaletteDataPointers

--- a/engine/pinball_game/catchem_mode.asm
+++ b/engine/pinball_game/catchem_mode.asm
@@ -222,19 +222,19 @@ Func_10184: ; 0x10184 called by what looks like the "hit voltorb and shellder" h
 	ld hl, MonBillboardPicPointers
 	add hl, bc
 	ld a, [hli]
-	ld [$ff8c], a ;load 3 byte billboard pointer into Hram
+	ldh [hBillboardPicPointer], a ;load 3 byte billboard pointer into Hram
 	ld a, [hli]
-	ld [$ff8d], a
+	ldh [hBillboardPicPointer + 1], a
 	ld a, [hl]
-	ld [$ff8e], a
+	ldh [hBillboardPicBank], a
 	ld hl, MonBillboardPaletteMapPointers ;and the PAL pointers
 	add hl, bc
 	ld a, [hli]
-	ld [$ff8f], a
+	ldh [hBillboardPaletteMapPointer], a
 	ld a, [hli]
-	ld [$ff90], a
+	ldh [hBillboardPaletteMapPointer + 1], a
 	ld a, [hli]
-	ld [$ff91], a
+	ldh [hBillboardPaletteMapBank], a
 	ld de, wc000
 	ld hl, wBillboardTilesIlluminationStates
 	ld c, $0
@@ -290,9 +290,9 @@ Func_101d9: ; 0x101d9
 	ld a, h
 	ld [de], a
 	inc de ;load result in to de
-	ld a, [$ff8c] ;loaded billboard pointer
+	ldh a, [hBillboardPicPointer] ;loaded billboard pointer
 	ld l, a
-	ld a, [$ff8d]
+	ldh a, [hBillboardPicPointer + 1]
 	ld h, a
 	add hl, bc ;add ???*16
 	pop af
@@ -307,7 +307,7 @@ Func_101d9: ; 0x101d9
 	ld a, h
 	ld [de], a
 	inc de
-	ld a, [$ff8e]
+	ldh a, [hBillboardPicBank]
 	ld [de], a
 	inc de ;load adjusted pointer into de, then 0
 	ld a, $0
@@ -347,14 +347,14 @@ Func_10230: ; 0x10230
 	ld [de], a
 	inc de
 	srl c
-	ld a, [$ff8f];load PAL pointer
+	ldh a, [hBillboardPaletteMapPointer];load PAL pointer
 	ld l, a
-	ld a, [$ff90]
+	ldh a, [hBillboardPaletteMapPointer + 1]
 	ld h, a
 	add hl, bc ;add the value from Data_102a4
 	pop af
 	and a
-	ld a, [$ff91]
+	ldh a, [hBillboardPaletteMapBank]
 	call ReadByteFromBank ;fetch pallete data
 	jr nz, .asm_10261 ;
 	ld a, $5
@@ -417,11 +417,11 @@ Func_102bc: ; 0x102bc
 	ld hl, MonBillboardPalettePointers
 	add hl, bc
 	ld a, [hli]
-	ld [$ff8c], a
+	ldh [hBillboardPicPointer], a
 	ld a, [hli]
-	ld [$ff8d], a
+	ldh [hBillboardPicPointer + 1], a
 	ld a, [hl]
-	ld [$ff8e], a
+	ldh [hBillboardPicBank], a
 	ld de, wc1b8
 	ld a, $10
 	ld [de], a
@@ -432,13 +432,13 @@ Func_102bc: ; 0x102bc
 	ld a, $30
 	ld [de], a
 	inc de
-	ld a, [$ff8c]
+	ldh a, [hBillboardPicPointer]
 	ld [de], a
 	inc de
-	ld a, [$ff8d]
+	ldh a, [hBillboardPicPointer + 1]
 	ld [de], a
 	inc de
-	ld a, [$ff8e]
+	ldh a, [hBillboardPicBank]
 	ld [de], a
 	inc de
 	ld a, $0
@@ -463,11 +463,11 @@ Func_10301: ; 0x10301
 	ld hl, MonAnimatedPalettePointers
 	add hl, bc
 	ld a, [hli]
-	ld [$ff8c], a
+	ldh [hBillboardPicPointer], a
 	ld a, [hli]
-	ld [$ff8d], a
+	ldh [hBillboardPicPointer + 1], a
 	ld a, [hl]
-	ld [$ff8e], a
+	ldh [hBillboardPicBank], a
 	ld de, wc1b8
 	ld a, $10
 	ld [de], a
@@ -478,13 +478,13 @@ Func_10301: ; 0x10301
 	ld a, $58
 	ld [de], a
 	inc de
-	ld a, [$ff8c]
+	ldh a, [hBillboardPicPointer]
 	ld [de], a
 	inc de
-	ld a, [$ff8d]
+	ldh a, [hBillboardPicPointer + 1]
 	ld [de], a
 	inc de
-	ld a, [$ff8e]
+	ldh a, [hBillboardPicBank]
 	ld [de], a
 	inc de
 	ld a, $4
@@ -493,9 +493,9 @@ Func_10301: ; 0x10301
 	ld a, $68
 	ld [de], a
 	inc de
-	ld a, [$ff8c]
+	ldh a, [hBillboardPicPointer]
 	ld l, a
-	ld a, [$ff8d]
+	ldh a, [hBillboardPicPointer + 1]
 	ld h, a
 	ld bc, $0008
 	add hl, bc
@@ -505,7 +505,7 @@ Func_10301: ; 0x10301
 	ld a, h
 	ld [de], a
 	inc de
-	ld a, [$ff8e]
+	ldh a, [hBillboardPicBank]
 	ld [de], a
 	inc de
 	ld a, $0
@@ -530,11 +530,11 @@ Func_10362: ; 0x10362
 	ld hl, MonAnimatedPicPointers
 	add hl, bc
 	ld a, [hli]
-	ld [$ff8c], a
+	ldh [hBillboardPicPointer], a
 	ld a, [hli]
-	ld [$ff8d], a
+	ldh [hBillboardPicPointer + 1], a
 	ld a, [hl]
-	ld [$ff8e], a
+	ldh [hBillboardPicBank], a
 	ld de, wc150
 	ld bc, 0
 .loop
@@ -567,16 +567,16 @@ Func_1038e: ; 0x1038e
 	ld a, [hli]
 	ld [de], a
 	inc de
-	ld a, [$ff8c]
+	ldh a, [hBillboardPicPointer]
 	add [hl]
 	ld [de], a
 	inc hl
 	inc de
-	ld a, [$ff8d]
+	ldh a, [hBillboardPicPointer + 1]
 	adc [hl]
 	ld [de], a
 	inc de
-	ld a, [$ff8e]
+	ldh a, [hBillboardPicBank]
 	ld [de], a
 	inc de
 	ld a, $0

--- a/engine/pinball_game/catchem_mode.asm
+++ b/engine/pinball_game/catchem_mode.asm
@@ -245,7 +245,7 @@ Func_10184: ; 0x10184 called by what looks like the "hit voltorb and shellder" h
 	jr z, .NextLoop
 	ld b, a ;else store in b
 	call nz, Func_101d9
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .NextLoop ;skip if DMG
 	ld a, [wCurrentStage]
@@ -1264,7 +1264,7 @@ Func_10871: ; 0x10871
 .asm_108d3
 	callba ClearAllRedIndicators
 	callba Func_10184
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_102bc
 	ret
@@ -1392,7 +1392,7 @@ Func_1098c: ; 0x1098c
 	ret z
 	callba Func_1c2cb
 	callba Func_10184
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_102bc
 	ret

--- a/engine/pinball_game/catchem_mode/catchem_mode_blue_field.asm
+++ b/engine/pinball_game/catchem_mode/catchem_mode_blue_field.asm
@@ -57,7 +57,7 @@ Func_2032c: ; 0x2032c
 	jr nz, .asm_20362
 	callba Func_10414
 	callba Func_10362
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_10301
 .asm_20333

--- a/engine/pinball_game/catchem_mode/catchem_mode_red_field.asm
+++ b/engine/pinball_game/catchem_mode/catchem_mode_red_field.asm
@@ -55,7 +55,7 @@ Func_2006b: ; 0x2006b
 	jr nz, .asm_200a1
 	callba Func_10414
 	callba Func_10362
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_10301
 .asm_20098

--- a/engine/pinball_game/draw_sprites/draw_blue_field_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_blue_field_sprites.asm
@@ -35,12 +35,12 @@ DrawShellderSprites: ; 0x1f395
 	; fall through
 
 DrawShellderSprite: ; 0x1f3ad
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld b, a
 	ld a, [hli]
 	sub b
 	ld b, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld c, a
 	ld a, [hli]
 	sub c
@@ -152,9 +152,9 @@ CloysterSpriteIds:
 	db SPRITE_CLOYSTER_2
 
 DrawPikachuSavers_BlueStage: ; 0x1f448
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld d, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld e, a
 	ld a, [wPikachuSaverSlotRewardActive]
 	and a
@@ -163,7 +163,7 @@ DrawPikachuSavers_BlueStage: ; 0x1f448
 	ld a, [wd51c]
 	and a
 	jr nz, .asm_1f469
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	srl a
 	srl a
 	srl a
@@ -201,7 +201,7 @@ DrawEvolutionIndicatorArrows_BlueFieldTop: ; 0x1f48f
 	ld a, [wEvolutionObjectsDisabled]
 	and a
 	ret nz
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	bit 4, a
 	ret z
 	ld de, wIndicatorStates + 5
@@ -213,7 +213,7 @@ DrawEvolutionIndicatorArrows_BlueFieldBottom: ; 0x1f4a3
 	ld a, [wEvolutionObjectsDisabled]
 	and a
 	ret nz
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	bit 4, a
 	ret z
 	ld de, wIndicatorStates + 11
@@ -221,12 +221,12 @@ DrawEvolutionIndicatorArrows_BlueFieldBottom: ; 0x1f4a3
 	ld b, $8
 DrawEvolutionIndicatorArrows_BlueField:
 	push bc
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld b, a
 	ld a, [hli]
 	sub b
 	ld b, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld c, a
 	ld a, [hli]
 	sub c
@@ -313,17 +313,17 @@ DrawEvolutionTrinket_BlueField: ; 0x1f518
 	add c
 	cp c
 	push af
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld b, a
 	ld a, [hli]
 	sub b
 	ld b, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld c, a
 	ld a, [hli]
 	sub c
 	ld c, a
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $e
 	jr nz, .asm_1f530
 	dec c

--- a/engine/pinball_game/draw_sprites/draw_gengar_bonus_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_gengar_bonus_sprites.asm
@@ -12,7 +12,7 @@ Debug_CycleGengarBonusPhase:
 ; Leftover debugging function for quickly cycling through
 ; the three phases of the Gengar Bonus stage. Pressing UP
 ; will instantly skip to the next phase.
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_D_UP, a
 	ret z
 	ld a, [wGastly1Enabled]

--- a/engine/pinball_game/draw_sprites/draw_pinball.asm
+++ b/engine/pinball_game/draw_sprites/draw_pinball.asm
@@ -26,13 +26,13 @@ DrawPinball: ; 0x17e81
 	and SPRITE_BALL_SPIN_COUNT - 1
 	add SPRITE_BALL_SPIN
 	call LoadSpriteData
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret nz
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret nz
-	ld a, [hSGBFlag]
+	ldh a, [hSGBFlag]
 	and a
 	ret nz
 	ld a, [wd4c5]

--- a/engine/pinball_game/draw_sprites/draw_red_field_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_red_field_sprites.asm
@@ -127,12 +127,12 @@ DrawVoltorbSprite: ; 0x17cdc
 .drawVoltorb
 	pop hl
 	inc de
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld b, a
 	ld a, [hli]
 	sub b
 	ld b, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld c, a
 	ld a, [hli]
 	sub c
@@ -228,7 +228,7 @@ BellsproutHeadAnimationSpriteIds: ; 0x17d76
 	db SPRITE_BELLSPROUT_HEAD_3
 
 DrawBellsproutBody: ; 0x17d7a
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld a, $67
@@ -244,7 +244,7 @@ DrawBellsproutBody: ; 0x17d7a
 	ret
 
 DrawStaryu: ; 0x17d92
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld hl, StaryuAnimation
@@ -327,9 +327,9 @@ SpinnerSpriteIds_RedField: ; 0x17e02
 	db SPRITE_RED_FIELD_SPINNER_5
 
 DrawPikachuSavers_RedStage: ; 0x17e08
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld d, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld e, a
 	ld a, [wPikachuSaverSlotRewardActive]
 	and a
@@ -338,7 +338,7 @@ DrawPikachuSavers_RedStage: ; 0x17e08
 	ld a, [wd51c]
 	and a
 	jr nz, .asm_17e29
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	srl a
 	srl a
 	srl a
@@ -383,9 +383,9 @@ UnusedData_7e55: ; 0x17e55
 
 Func_17e5e: ; 0x17e5e
 ; unused
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	ld e, a
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld d, a
 .asm_17e64
 	ld a, [hli]
@@ -401,7 +401,7 @@ Func_17e5e: ; 0x17e5e
 	ld a, [hli]
 	sub d
 	ld b, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld c, a
 	ld a, [hli]
 	sub c
@@ -417,7 +417,7 @@ DrawEvolutionIndicatorArrows_RedFieldTop: ; 0x17efb
 	ld a, [wEvolutionObjectsDisabled]
 	and a
 	ret nz
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	bit 4, a
 	ret z
 	ld de, wIndicatorStates + 5
@@ -429,7 +429,7 @@ DrawEvolutionIndicatorArrows_RedFieldBottom: ; 0x17f0f
 	ld a, [wEvolutionObjectsDisabled]
 	and a
 	ret nz
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	bit 4, a
 	ret z
 	ld de, wIndicatorStates + 11
@@ -437,12 +437,12 @@ DrawEvolutionIndicatorArrows_RedFieldBottom: ; 0x17f0f
 	ld b, $8
 DrawEvolutionIndicatorArrows_RedField: ; 0x17f21
 	push bc
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld b, a
 	ld a, [hli]
 	sub b
 	ld b, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld c, a
 	ld a, [hli]
 	sub c
@@ -525,17 +525,17 @@ DrawEvolutionTrinket_RedField: ; 0x17f84
 	add c
 	cp c
 	push af
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld b, a
 	ld a, [hli]
 	sub b
 	ld b, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld c, a
 	ld a, [hli]
 	sub c
 	ld c, a
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $e
 	jr nz, .asm_17f9c
 	dec c

--- a/engine/pinball_game/draw_sprites/draw_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_sprites.asm
@@ -22,7 +22,7 @@ CallTable_84bd: ; 0x84bd
 
 UnusedFunc_84fd:
 ; unused
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .not_cgb
 	ld a, $1

--- a/engine/pinball_game/draw_sprites/draw_timer.asm
+++ b/engine/pinball_game/draw_sprites/draw_timer.asm
@@ -2,7 +2,7 @@ DrawTimer: ; 0x175a4
 	ld a, [wTimerActive]
 	and a
 	ret z
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, DrawTimer_GameBoyColor
 	ld a, [wd580]

--- a/engine/pinball_game/end_of_ball_bonus.asm
+++ b/engine/pinball_game/end_of_ball_bonus.asm
@@ -3,24 +3,24 @@ EndOfBallBonus: ; 0xf533
 	call LoadEAcuteCharacterGfx
 	call Func_f57f
 	ld a, $60
-	ld [hWY], a
+	ldh [hWY], a
 	dec a
-	ld [hLYC], a
+	ldh [hLYC], a
 	ld a, $fd
-	ld [hLCDCMask], a
+	ldh [hLCDCMask], a
 	call ShowBallBonusSummary
 	ld a, $90
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, $83
-	ld [hLYC], a
-	ld [hLastLYC], a
+	ldh [hLYC], a
+	ldh [hLastLYC], a
 	ld a, $ff
-	ld [hLCDCMask], a
+	ldh [hLCDCMask], a
 	call FillBottomMessageBufferWithBlackTile
 	ret
 
 LoadEAcuteCharacterGfx: ; 0xf55c
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .gameboyColor
 	ld a, BANK(E_Acute_CharacterGfx)
@@ -96,7 +96,7 @@ ShowBallBonusSummary: ; 0xf5a0
 	call Func_f80d
 .waitForAPress
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .waitForAPress
 	ret
@@ -165,7 +165,7 @@ Func_f676: ; 0xf676
 	and a
 	jr z, .asm_f69f
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_f69f
 	xor a
@@ -201,7 +201,7 @@ Func_f676: ; 0xf676
 	and a
 	jr z, .asm_f6f2
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_f6f2
 	xor a
@@ -238,7 +238,7 @@ Func_f70d: ; 0xf70d
 	and a
 	jr z, .asm_f736
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_f736
 	xor a
@@ -262,7 +262,7 @@ Func_f70d: ; 0xf70d
 	and a
 	jr z, .asm_f76c
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_f76c
 	xor a
@@ -416,7 +416,7 @@ Func_f83a: ; 0xf83a
 	push bc
 	rst AdvanceFrame
 	pop bc
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr nz, .asm_f84e
 	dec b
@@ -448,7 +448,7 @@ Func_f853: ; 0xf853
 	and a
 	jr z, .asm_f886
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_f886
 	xor a

--- a/engine/pinball_game/evolution_mode.asm
+++ b/engine/pinball_game/evolution_mode.asm
@@ -272,7 +272,7 @@ UpdateEvolutionSelectionList: ; 0x10c38
 	ld hl, wPartyMons
 	add hl, bc
 	call LoadMonNamesIntoEvolutionSelectionList
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and a
 	ld a, [wPartySelectionCursorCounter]
 	jr z, .asm_10c62
@@ -330,20 +330,20 @@ SelectPokemonToEvolve: ; 0x10cb7
 	call FillBottomMessageBufferWithBlackTile
 	call InitEvolutionSelectionMenu
 	ld a, $60
-	ld [hWY], a
+	ldh [hWY], a
 	dec a
-	ld [hLYC], a
+	ldh [hLYC], a
 	ld a, $fd
-	ld [hLCDCMask], a
+	ldh [hLCDCMask], a
 	call SelectPokemonToEvolveMenu
 	ld a, $86
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, $83
-	ld [hLYC], a
-	ld [hLastLYC], a
+	ldh [hLYC], a
+	ldh [hLastLYC], a
 	ld a, $ff
-	ld [hLCDCMask], a
-	ld a, [hGameBoyColorFlag]
+	ldh [hLCDCMask], a
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .gameboyColor
 	ld a, BANK(StageRedFieldTopStatusBarSymbolsGfx_GameBoy)
@@ -655,7 +655,7 @@ StartEvolutionMode_RedField: ; 0x10ebb
 	call LoadOrCopyVRAMData
 	callba ClearAllRedIndicators
 	callba Func_10184
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_102bc
 	ret
@@ -710,7 +710,7 @@ ConcludeEvolutionMode_RedField: ; 0x10fe3
 	ld de, vTilesOB tile $20
 	ld bc, $00e0
 	call LoadVRAMData
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_11036
 	ld a, BANK(StageRedFieldBottomOBJPalette7)
@@ -791,7 +791,7 @@ StartEvolutionMode_BlueField: ; 0x11061
 	call LoadOrCopyVRAMData
 	callba Func_1c2cb
 	callba Func_10184
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_102bc
 	ret
@@ -847,7 +847,7 @@ ConcludeEvolutionMode_BlueField: ; 0x11195
 	ld de, vTilesOB tile $20
 	ld bc, $00e0
 	call LoadVRAMData
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_111f0
 	ld a, BANK(StageBlueFieldBottomOBJPalette7)

--- a/engine/pinball_game/evolution_mode/evolution_mode_blue_field.asm
+++ b/engine/pinball_game/evolution_mode/evolution_mode_blue_field.asm
@@ -74,7 +74,7 @@ HandleEvolutionMode_BlueField: ; 0x20c08
 	ld de, YeahYouGotItText
 	ld hl, wScrollingText1
 	call LoadScrollingText
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_20c74
 	ld a, BANK(StageBlueFieldBottomOBJPalette6)
@@ -160,7 +160,7 @@ ProgressEvolution: ; 0x20c76
 	ld de, vTilesOB tile $20
 	ld bc, $00e0
 	call LoadVRAMData
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_20d25
 	ld a, BANK(StageBlueFieldBottomOBJPalette7)
@@ -471,7 +471,7 @@ CreateEvolutionTrinket_BlueField: ; 0x20f75
 	ld a, [wCurrentStage]
 	bit 0, a
 	callba nz, Func_1c2cb
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_20fc3
 	ld a, BANK(EvolutionTrinketPalettes)
@@ -617,7 +617,7 @@ RecoverPokemon_BlueField:
 	ld a, [wCurrentStage]
 	bit 0, a
 	callba nz, Func_1c2cb
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_21102
 	ld a, BANK(StageBlueFieldBottomOBJPalette6)
@@ -682,7 +682,7 @@ HandleSlotCaveCollision_EvolutionMode_BlueField: ; 0x2112a
 	ld bc, $0180
 	call LoadOrCopyVRAMData
 	pop bc
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_211a8
 	push bc

--- a/engine/pinball_game/evolution_mode/evolution_mode_red_field.asm
+++ b/engine/pinball_game/evolution_mode/evolution_mode_red_field.asm
@@ -77,7 +77,7 @@ HandleEvolutionMode_RedField: ; 0x205e0
 	ld de, YeahYouGotItText
 	ld hl, wScrollingText1
 	call LoadScrollingText
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_2064f
 	ld a, BANK(StageRedFieldBottomOBJPalette6)
@@ -163,7 +163,7 @@ Func_20651: ; 0x20651
 	ld de, vTilesOB tile $20
 	ld bc, $00e0
 	call LoadVRAMData
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_20700
 	ld a, BANK(StageRedFieldBottomOBJPalette7)
@@ -493,7 +493,7 @@ CreateEvolutionTrinket_RedField: ; 0x20977
 	ld a, [wCurrentStage]
 	bit 0, a
 	callba nz, ClearAllRedIndicators
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_209bf
 	ld a, BANK(EvolutionTrinketPalettes)
@@ -616,7 +616,7 @@ RecoverPokemon_RedField:
 	ld a, [wCurrentStage]
 	bit 0, a
 	callba nz, ClearAllRedIndicators
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_20ada
 	ld a, BANK(StageRedFieldBottomOBJPalette6)
@@ -681,7 +681,7 @@ HandleSlotCaveCollision_EvolutionMode_RedField: ; 0x20b02
 	ld bc, $0180
 	call LoadOrCopyVRAMData
 	pop bc
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_20b80
 	push bc

--- a/engine/pinball_game/flippers.asm
+++ b/engine/pinball_game/flippers.asm
@@ -1,7 +1,7 @@
 HandleFlippers: ; 0xe0fe
 	xor a
 	ld [wFlipperCollision], a
-	ld [hFlipperCollisionRadius], a
+	ldh [hFlipperCollisionRadius], a
 	ld [wFlipperXForce], a
 	ld [wFlipperXForce + 1], a
 	call UpdateFlipperStates
@@ -151,17 +151,17 @@ CheckLeftFlipperCollision:
 	ld [$ff00+c], a
 	inc c
 	ld a, [wPreviousLeftFlipperState]
-	ld [hPreviousFlipperState], a
+	ldh [hPreviousFlipperState], a
 	ld a, [wLeftFlipperState + 1]
-	ld [hFlipperState], a
+	ldh [hFlipperState], a
 	call ReadFlipperCollisionAttributes
 	ld a, [wFlipperCollision]
 	and a
 	ret z
 	ld a, [wLeftFlipperStateChange]
-	ld [hFlipperStateChange], a
+	ldh [hFlipperStateChange], a
 	ld a, [wLeftFlipperStateChange + 1]
-	ld [hFlipperStateChange + 1], a
+	ldh [hFlipperStateChange + 1], a
 	ret
 
 CheckRightFlipperCollision: ; 0xe226
@@ -185,36 +185,36 @@ CheckRightFlipperCollision: ; 0xe226
 	ld [$ff00+c], a
 	inc c
 	ld a, [wPreviousRightFlipperState]
-	ld [hPreviousFlipperState], a
+	ldh [hPreviousFlipperState], a
 	ld a, [wRightFlipperState + 1]
-	ld [hFlipperState], a
+	ldh [hFlipperState], a
 	call ReadFlipperCollisionAttributes
 	ld a, [wFlipperCollision]
 	and a
 	ret z
 	; collision with flipper occurred
 	ld a, [wRightFlipperStateChange]
-	ld [hFlipperStateChange], a
+	ldh [hFlipperStateChange], a
 	ld a, [wRightFlipperStateChange + 1]
-	ld [hFlipperStateChange + 1], a
+	ldh [hFlipperStateChange + 1], a
 	ret
 
 ReadFlipperCollisionAttributes: ; 0xe25a
-	ld a, [hBallXPos + 1]
+	ldh a, [hBallXPos + 1]
 	sub 43  ; check if ball is in horizontal range of flippers
 	ret c
 	cp 48
 	ret nc
 	; ball is in horizontal range of flippers
-	ld [hBallXPos + 1], a  ; x offset of flipper horizontal range
-	ld a, [hBallYPos + 1]  ; ball y-position high byte
+	ldh [hBallXPos + 1], a  ; x offset of flipper horizontal range
+	ldh a, [hBallYPos + 1]  ; ball y-position high byte
 	sub 123  ; check if ball is in vertical range of flippers
 	ret c
 	cp 32
 	ret nc
 	; ball is in potential collision with flippers
-	ld [hBallYPos + 1], a
-	ld a, [hPreviousFlipperState]
+	ldh [hBallYPos + 1], a
+	ldh a, [hPreviousFlipperState]
 .collisionCheckLoop
 	push af
 	ld l, 0
@@ -224,7 +224,7 @@ ReadFlipperCollisionAttributes: ; 0xe25a
 	sla h
 	add h
 	ld h, a  ; hl = a * 0x600  (this is the length of the flipper collision attributes)
-	ld a, [hBallXPos + 1]  ; x offset of flipper horizontal range
+	ldh a, [hBallXPos + 1]  ; x offset of flipper horizontal range
 	ld c, a
 	ld b, 0
 	sla c
@@ -239,7 +239,7 @@ ReadFlipperCollisionAttributes: ; 0xe25a
 	rl b   ; bc = (ball x offset) * 32
 	; Each column of the flipper collision attributes is 32 bytes long.
 	add hl, bc  ; hl points to the start of the row in the flipper collision attributes
-	ld a, [hBallYPos + 1]  ; y offset of flipper vertical range
+	ldh a, [hBallYPos + 1]  ; y offset of flipper vertical range
 	ld c, a
 	ld b, 0
 	add hl, bc  ; hl points to the attribute byte in the flipper collision attributes
@@ -275,7 +275,7 @@ ReadFlipperCollisionAttributes: ; 0xe25a
 .collision
 	pop af  ; a = flipper state that resulted in a collision
 	ld a, b  ; a = collision point radius
-	ld [hFlipperCollisionRadius], a
+	ldh [hFlipperCollisionRadius], a
 	ld h, d
 	ld l, e
 	ld a, h
@@ -305,9 +305,9 @@ Func_e2e4:
 	or e
 	or d
 	jr nz, .asm_e2f3
-	ld a, [hBallXPos]
+	ldh a, [hBallXPos]
 	ld e, a
-	ld a, [hBallXPos + 1]
+	ldh a, [hBallXPos + 1]
 	ld d, a
 	ret
 
@@ -630,7 +630,7 @@ HandleFlipperCollision: ; 0xe442
 	ld [wCurCollisionAttribute], a
 	ld [wCurCollisionTileOffset], a
 	ld [wCurCollisionTileOffset + 1], a
-	ld a, [hFlipperCollisionRadius]
+	ldh a, [hFlipperCollisionRadius]
 	sla a
 	ld c, a
 	ld b, 0
@@ -640,9 +640,9 @@ HandleFlipperCollision: ; 0xe442
 	ld c, a
 	ld a, [hl]
 	ld b, a
-	ld a, [hFlipperStateChange]
+	ldh a, [hFlipperStateChange]
 	ld e, a
-	ld a, [hFlipperStateChange + 1]
+	ldh a, [hFlipperStateChange + 1]
 	ld d, a
 	sla e
 	rl d
@@ -677,9 +677,9 @@ DrawFlippers: ; 0xe4a1
 	and a
 	ret z
 	ld hl, FlippersSpritePixelOffsetData
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld d, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld e, a
 	ld a, [hli]
 	sub d
@@ -696,7 +696,7 @@ DrawFlippers: ; 0xe4a1
 	ld a, [hl]
 	cp SPRITE_LEFTFLIPPER_DOWN
 	jr nz, .asm_e4d6
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .asm_e4d4
 	ld a, [wFlippersDisabled]
@@ -710,9 +710,9 @@ DrawFlippers: ; 0xe4a1
 .asm_e4d6
 	call LoadSpriteData
 	pop hl
-	ld a, [hSCX]
+	ldh a, [hSCX]
 	ld d, a
-	ld a, [hSCY]
+	ldh a, [hSCY]
 	ld e, a
 	ld a, [hli]
 	sub d
@@ -728,7 +728,7 @@ DrawFlippers: ; 0xe4a1
 	ld a, [hl]
 	cp SPRITE_RIGHTFLIPPER_DOWN
 	jr nz, .asm_e506
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .asm_e504
 	ld a, [wFlippersDisabled]

--- a/engine/pinball_game/flippers.asm
+++ b/engine/pinball_game/flippers.asm
@@ -364,11 +364,11 @@ Func_e2e4:
 
 .asm_e32f
 	ld a, c
-	ld [$ff8c], a
+	ldh [hFlippersFF8C], a
 	pop bc
 	xor a
-	ld [$ff8d], a
-	ld [$ff8e], a
+	ldh [hFlippersFF8D], a
+	ldh [hFlippersFF8E], a
 .asm_e338
 	jr c, .asm_e344
 	ld a, d
@@ -388,23 +388,23 @@ Func_e2e4:
 	ld h, a
 	scf
 .asm_e34b
-	ld a, [$ff8d]
+	ldh a, [hFlippersFF8D]
 	rla
-	ld [$ff8d], a
-	ld a, [$ff8e]
+	ldh [hFlippersFF8D], a
+	ldh a, [hFlippersFF8E]
 	rla
-	ld [$ff8e], a
+	ldh [hFlippersFF8E], a
 	sla c
 	rl b
 	rl l
 	rl h
-	ld a, [$ff8c]
+	ldh a, [hFlippersFF8C]
 	dec a
-	ld [$ff8c], a
+	ldh [hFlippersFF8C], a
 	jr nz, .asm_e338
-	ld a, [$ff8d]
+	ldh a, [hFlippersFF8D]
 	ld e, a
-	ld a, [$ff8e]
+	ldh a, [hFlippersFF8E]
 	ld d, a
 .asm_e36a
 	pop af
@@ -431,7 +431,7 @@ CalculateFlipperYForce: ; 0xe379
 ; Returns: lb = resulting y force (yes, it's a logical 2-byte register composed of l and b)
 	ld a, b
 	xor d
-	ld [$ffbe], a
+	ldh [hFFBE], a
 	bit 7, b
 	jr z, .bcIsPositive
 	; negate bc so it's positive
@@ -499,7 +499,7 @@ CalculateFlipperYForce: ; 0xe379
 	pop de
 	add hl, de
 	; hlbc = 32-bit result of the multiplication
-	ld a, [$ffbe]
+	ldh a, [hFFBE]
 	bit 7, a
 	ret z
 	; negate hlbc

--- a/engine/pinball_game/load_stage_data/load_blue_field.asm
+++ b/engine/pinball_game/load_stage_data/load_blue_field.asm
@@ -89,7 +89,7 @@ LoadPsyduckOrPoliwagGraphics: ; 0x1c235
 	call _LoadPsyduckOrPoliwagGraphics
 	ld a, [wLeftMapMoveCounter]
 	call LoadPsyduckOrPoliwagNumberGraphics
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1c267
 	ld a, [wLeftMapMoveCounter]
@@ -138,7 +138,7 @@ LoadPsyduckOrPoliwagGraphics: ; 0x1c235
 	ld a, [wRightMapMoveCounter]
 	add $4
 	call LoadPsyduckOrPoliwagNumberGraphics
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1c2b7
 	ld a, [wRightMapMoveCounter]
@@ -224,7 +224,7 @@ Func_1c305: ; 0x1c305
 .asm_1c31f
 	callba Func_1c3ac
 	callba Func_10362
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_10301
 	ld a, [wCapturingMon]
@@ -308,7 +308,7 @@ Func_1c3ca: ; 0x1c3ca
 	dec b
 	jr nz, .asm_1c3cf
 	callba Func_10184
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_102bc
 	ret
@@ -343,7 +343,7 @@ LoadEvolutionTrinketGraphics_BlueField: ; 0x1c3ee
 	ld a, [wEvolutionObjectsDisabled]
 	and a
 	ret z
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld a, BANK(EvolutionTrinketPalettes)

--- a/engine/pinball_game/load_stage_data/load_red_field.asm
+++ b/engine/pinball_game/load_stage_data/load_red_field.asm
@@ -32,7 +32,7 @@ LoadTimerGraphics: ; 0x1404a
 	ld a, [wTimerActive]
 	and a
 	ret z
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret nz
 	ld a, [wd580]
@@ -173,7 +173,7 @@ Func_1414b: ; 0x1414b
 .asm_14165
 	callba Func_141f2
 	callba Func_10362
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_10301
 	ld a, [wCapturingMon]
@@ -257,7 +257,7 @@ Func_14210: ; 0x14210
 	dec b
 	jr nz, .asm_14215
 	callba Func_10184
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, Func_102bc
 	ret
@@ -292,7 +292,7 @@ LoadEvolutionTrinketGraphics_RedField: ; 0x14234
 	ld a, [wEvolutionObjectsDisabled]
 	and a
 	ret z
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld a, BANK(EvolutionTrinketPalettes)
@@ -393,7 +393,7 @@ LoadBallGraphics: ; 0x142fc
 .superMiniBall
 	callba LoadSuperMiniPinballGfx
 .loadBallPalette
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld a, [wBallType]

--- a/engine/pinball_game/menu.asm
+++ b/engine/pinball_game/menu.asm
@@ -34,11 +34,11 @@ HandleInGameMenu: ; 0x86d7
 	ld bc, $00c0
 	call LoadVRAMData
 	ld a, $60
-	ld [hWY], a
+	ldh [hWY], a
 	dec a
-	ld [hLYC], a
+	ldh [hLYC], a
 	ld a, $fd
-	ld [hLCDCMask], a
+	ldh [hLCDCMask], a
 	call HandleInGameMenuSelection
 	ld a, [wInGameMenuIndex]
 	and a
@@ -56,13 +56,13 @@ HandleInGameMenu: ; 0x86d7
 	ld bc, $003c
 	call AdvanceFrames
 	ld a, $86
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, $83
-	ld [hLYC], a
-	ld [hLastLYC], a
+	ldh [hLYC], a
+	ldh [hLastLYC], a
 	ld a, $ff
-	ld [hLCDCMask], a
-	ld a, [hGameBoyColorFlag]
+	ldh [hLCDCMask], a
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .asm_8778
 	ld a, Bank(StageRedFieldTopStatusBarSymbolsGfx_GameBoy)
@@ -110,7 +110,7 @@ HandleInGameMenuSelection: ; 0x87ac
 	call MoveInGameMenuCursor
 	call DrawInGameMenu
 	rst AdvanceFrame
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .waitForAButton
 	lb de, $00, $01
@@ -119,7 +119,7 @@ HandleInGameMenuSelection: ; 0x87ac
 
 MoveInGameMenuCursor: ; 0x87c5
 ; Moves the cursor up or down in the "SAVE"/"CANCEL" in-game menu
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wInGameMenuIndex]
 	bit BIT_D_UP, b

--- a/engine/pinball_game/object_collision/blue_stage_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/blue_stage_resolve_collision.asm
@@ -105,7 +105,7 @@ ResolveBlueStagePinballLaunchCollision: ; 0x1c7d7
 ChooseInitialMap_BlueField: ; 0x1c839
 ; While waiting to launch the pinball, this quickly rotates the billboard with the initial
 ; maps the player can start on.
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, LoadGreyBillboardPaletteData
 .showNextMap
@@ -511,7 +511,7 @@ UpdateSpinnerChargeGraphics_BlueField: ; 0x1cb43
 	sla c
 	ld b, $0
 	ld hl, TileDataPointers_1cb60
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1cb56
 	ld hl, TileDataPointers_1cd10
@@ -567,7 +567,7 @@ LoadBumperGraphics_BlueField: ; 0x1ce7a
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_1ceca
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1ce8a
 	ld hl, TileDataPointers_1cf3a
@@ -861,7 +861,7 @@ UpdatePikachuSaverAnimation_BlueField: ; 0x1d133
 	ret
 
 .asm_1d1c7
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	swap a
 	and $1
 	ld [wPikachuSaverAnimationFrame], a
@@ -1163,7 +1163,7 @@ ResolveBonusMultiplierCollision_BlueField: ; 0x1d438
 	ld a, [wWhichBonusMultiplierRailingId]
 	sub $f
 	jr nz, .hitRightRailing
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .asm_1d45c
 	ld a, $1f
@@ -1190,7 +1190,7 @@ ResolveBonusMultiplierCollision_BlueField: ; 0x1d438
 	jr asm_1d4fa
 
 .hitRightRailing
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .asm_1d497
 	ld a, $21
@@ -1282,7 +1282,7 @@ UpdateBonusMultiplierRailing_BlueField: ; 0x1d51b
 	cp $2
 	jr c, .asm_1d58b
 	cp $3
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	jr c, .asm_1d56a
 	srl a
 	srl a
@@ -1308,7 +1308,7 @@ UpdateBonusMultiplierRailing_BlueField: ; 0x1d51b
 	cp $2
 	ret c
 	cp $3
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	jr c, .asm_1d59b
 	srl a
 	srl a
@@ -1362,7 +1362,7 @@ ShowBonusMultiplierMessage_BlueField: ; 0x1d5bf
 
 _LoadBonusMultiplierRailingGraphics_BlueField: ; 0x1d5f2
 	push af
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .gameboyColor
 	pop af
@@ -1485,7 +1485,7 @@ UpdateBonusMultiplierRailingLight: ; 0x1d692
 .turnOffLight
 	ld a, $0
 	ld [wBonusMultiplierRailingEndLightDuration], a
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .gameboy
 	ld a, $1e
@@ -1623,7 +1623,7 @@ UpdatePoliwag: ; 0x1dc95
 	ret nz
 	call Func_1130
 	ret nz
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1dcd7
 	ld a, [wLeftMapMoveCounter]
@@ -1726,7 +1726,7 @@ UpdatePsyduck: ; 0x1dd2e
 	ret
 
 .asm_1dd74
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1dd89
 	ld a, [wRightMapMoveCounter]
@@ -1828,7 +1828,7 @@ _LoadPsyduckOrPoliwagGraphics: ; 0x1de4b
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_1df66
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .gameboyColor
 	ld hl, TileDataPointers_1e00f
@@ -1854,7 +1854,7 @@ LoadPsyduckOrPoliwagNumberGraphics: ; 0x1de6f
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_1e0a4
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1de87
 	ld hl, TileDataPointers_1e1d6
@@ -1895,7 +1895,7 @@ UpdateMapMoveCounters_BlueFieldBottom: ; 0x1de93
 	dec a
 	ld [wLeftMapMoveCounter], a
 	call LoadPsyduckOrPoliwagNumberGraphics
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .gameboy
 	ld a, [wLeftMapMoveCounter]
@@ -1937,7 +1937,7 @@ UpdateMapMoveCounters_BlueFieldBottom: ; 0x1de93
 	ld [wRightMapMoveCounter], a
 	add $4
 	call LoadPsyduckOrPoliwagNumberGraphics
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .gameboy_2
 	ld a, [wRightMapMoveCounter]
@@ -2146,7 +2146,7 @@ LoadPinballUpgradeTriggerGraphics_BlueField: ; 0x1e484
 ; Input: a = toggle state
 	and a
 	jr z, .toggledOff
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .toggledOnGameboy
 	ld hl, TileDataPointers_1e520
@@ -2157,7 +2157,7 @@ LoadPinballUpgradeTriggerGraphics_BlueField: ; 0x1e484
 	jr .load
 
 .toggledOff
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .toggledOffGameboy
 	ld hl, TileDataPointers_1e526
@@ -2373,7 +2373,7 @@ LoadCAVELightGraphics_BlueField: ; 0x1e636
 ; Input: a = toggle state for CAVE light
 	and a
 	jr z, .toggledOff
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .toggledOnGameboy
 	ld hl, TileDataPointers_1e6d7
@@ -2384,7 +2384,7 @@ LoadCAVELightGraphics_BlueField: ; 0x1e636
 	jr .load
 
 .toggledOff
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .toggledOffGameboy
 	ld hl, TileDataPointers_1e6df
@@ -2696,7 +2696,7 @@ LoadSlotCaveCoverGraphics_BlueField: ; 0x1e8f6
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_1e91e
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1e912
 	ld hl, TileDataPointers_1e970
@@ -2893,7 +2893,7 @@ _ApplySlotForceField_BlueField: ; 0x1ea6a
 
 UpdateArrowIndicators_BlueField: ; 0x1ead4
 ; Updates the 5 blinking arrow indicators in the blue field bottom.
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $f
 	ret nz
 	ld bc, $0000
@@ -2920,7 +2920,7 @@ UpdateArrowIndicators_BlueField: ; 0x1ead4
 	ld a, c
 	cp $2
 	jr nz, .asm_1eadc
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $f
 	ret nz
 	ld a, [wCurrentStage]
@@ -2969,7 +2969,7 @@ LoadArrowIndicatorGraphics_BlueStage: ; 0x1eb41
 	push af
 	sla c
 	ld hl, TileDataPointers_1eb61
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .gameboy
 	ld hl, TileDataPointers_1ed51
@@ -3442,7 +3442,7 @@ UpdateForceFieldGraphics: ; 0x1f18a
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_1f1b5
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .gameboy
 	ld hl, TileDataPointers_1f201

--- a/engine/pinball_game/object_collision/diglett_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/diglett_bonus_resolve_collision.asm
@@ -31,7 +31,7 @@ Func_19bbd: ; 0x19bbd
 	ld c, a
 	ld b, $0
 	ld hl, Data_19bda
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_19bd0
 	ld hl, Data_19c16

--- a/engine/pinball_game/object_collision/gengar_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/gengar_bonus_resolve_collision.asm
@@ -42,7 +42,7 @@ Func_183db: ; 0x183db
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_183f8
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_183ee
 	ld hl, TileDataPointers_1842e
@@ -1450,7 +1450,7 @@ Func_18d72: ; 0x18d72
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_18ddb
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_18d85
 	ld hl, TileDataPointers_18ed1

--- a/engine/pinball_game/object_collision/meowth_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/meowth_bonus_resolve_collision.asm
@@ -264,7 +264,7 @@ Func_24516: ; 0x24516
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_24533
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_24529
 	ld hl, TileDataPointers_2456f
@@ -626,7 +626,7 @@ UpdateMeowthHorizontalMovement: ; 0x24737
 	jr .asm_2475a
 
 .asm_2474a
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $3f
 	ret nz
 	call GenRandom
@@ -692,7 +692,7 @@ UpdateMeowthVerticalMovement: ; 0x2476d
 	ld a, [wNumActiveJewelsTop]
 	cp 3
 	jr z, .asm_247d3
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $3f
 	ret nz
 	call GenRandom
@@ -1884,7 +1884,7 @@ Func_24fa3: ; 0x24fa3
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_25007
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_24ffd
 	ld hl, TileDataPointers_25421

--- a/engine/pinball_game/object_collision/mewtwo_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/mewtwo_bonus_resolve_collision.asm
@@ -39,7 +39,7 @@ Func_194ac: ; 0x194ac
 	ld c, a
 	ld b, $0
 	ld hl, Data_194c9
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_194bf
 	ld hl, Data_194fd

--- a/engine/pinball_game/object_collision/red_stage_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/red_stage_resolve_collision.asm
@@ -516,7 +516,7 @@ _LoadDiglettGraphics: ; 0x149d9
 	ld c, a
 	ld b, $0
 	ld hl, TileListDataPointers_14a11
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_149e9
 	ld hl, TileListDataPointers_14a83
@@ -536,7 +536,7 @@ LoadDiglettNumberGraphics: ; 0x149f5
 	ld c, a
 	ld b, $0
 	ld hl, Data_14af5
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_14a05
 	ld hl, TileListDataPointers_14c8d
@@ -726,7 +726,7 @@ UpdateSpinnerChargeGraphics_RedField: ; 0x14ece
 	sla c
 	ld b, $0
 	ld hl, TileDataPointers_14eeb
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_14ee1
 	ld hl, TileDataPointers_1509b
@@ -805,7 +805,7 @@ LoadCAVELightGraphics_RedField: ; 0x1523c
 ; Input: a = toggle state for CAVE light
 	and a
 	jr z, .toggledOff
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .toggledOnGameboy
 	ld hl, TileDataPointers_152dd
@@ -816,7 +816,7 @@ LoadCAVELightGraphics_RedField: ; 0x1523c
 	jr .load
 
 .toggledOff
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .toggledOffGameboy
 	ld hl, TileDataPointers_152e5
@@ -1041,7 +1041,7 @@ LoadPinballUpgradeTriggerGraphics_RedField: ; 0x15465
 ; Input: a = toggle state
 	and a
 	jr z, .toggledOff
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .toggledOnGameboy
 	ld hl, TileDataPointers_15511
@@ -1052,7 +1052,7 @@ LoadPinballUpgradeTriggerGraphics_RedField: ; 0x15465
 	jr .load
 
 .toggledOff
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .toggledOffGameboy
 	ld hl, TileDataPointers_15517
@@ -1077,7 +1077,7 @@ LoadPinballUpgradeTriggerGraphics_RedField: ; 0x15465
 	ret
 
 LoadDisabledPinballUpgradeTriggerGraphics_RedField: ; 0x15499
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret nz
 	ld b, $3
@@ -1228,7 +1228,7 @@ TransitionPinballUpgrade: ; 0x155a7
 	; fall through
 
 TransitionPinballUpgradePalette: ; 0x155bb
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	; gameboy color
@@ -1476,7 +1476,7 @@ UpdateFieldStructures_RedField: ; 0x159c9
 LoadFieldStructureGraphics_RedField: ; 0x159f4
 ; Based on the current stage collision state, load the proper graphics.
 ; Things that change on the Red field are Ditto, the lightning bolt guard rail, and the roof over the 3 Voltorbs.
-	ld a, [hLCDC]
+	ldh a, [hLCDC]
 	bit 7, a
 	jr z, .asm_15a13
 	ld a, [wd7f2]
@@ -1501,7 +1501,7 @@ LoadFieldStructureGraphics_RedField: ; 0x159f4
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_15a3f
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_15a2d
 	ld hl, TileDataPointers_15d05
@@ -1669,7 +1669,7 @@ LoadBumperGraphics_RedField: ; 0x15fc0
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_16010
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_15fd0
 	ld hl, TileData_16080
@@ -2149,7 +2149,7 @@ LoadSlotCaveCoverGraphics_RedField: ; 0x16425
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_1644d
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_16441
 	ld hl, TileDataPointers_164a1
@@ -2256,7 +2256,7 @@ ResolveRedStagePinballLaunchCollision: ; 0x1652d
 ChooseInitialMap_RedField: ; 0x1658f
 ; While waiting to launch the pinball, this quickly rotates the billboard with the initial
 ; maps the player can start on.
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	callba nz, LoadGreyBillboardPaletteData
 .showNextMap
@@ -2444,7 +2444,7 @@ UpdatePikachuSaverAnimation_RedField: ; 0x1669e
 	ret
 
 .asm_16732
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	swap a
 	and $1
 	ld [wPikachuSaverAnimationFrame], a
@@ -2591,7 +2591,7 @@ LoadStaryuGraphics_Top: ; 0x16859
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_16899
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1686c
 	ld hl, TileDataPointers_16910
@@ -2613,7 +2613,7 @@ LoadStaryuGraphics_Bottom: ; 0x16878
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_1695a
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_1688d
 	ld hl, TileDataPointers_16980
@@ -2632,7 +2632,7 @@ INCLUDE "data/queued_tiledata/red_field/staryu_bumper.asm"
 
 UpdateArrowIndicators_RedField: ; 0x169a6
 ; Updates the 5 blinking arrow indicators in the red field bottom.
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $1f
 	ret nz
 	ld bc, $0000
@@ -2662,7 +2662,7 @@ LoadArrowIndicatorGraphics_RedField: ; 0x169cd
 	push af
 	sla c ;double offset
 	ld hl, TileDataPointers_169ed
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_169db
 	ld hl, TileDataPointers_16bef
@@ -2788,7 +2788,7 @@ UpdateBonusMultiplierRailing_RedField: ; 0x16e51
 	cp $2
 	jr c, .asm_16ec1
 	cp $3
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	jr c, .asm_16ea0
 	srl a
 	srl a
@@ -2814,7 +2814,7 @@ UpdateBonusMultiplierRailing_RedField: ; 0x16e51
 	cp $2
 	ret c
 	cp $3
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	jr c, .asm_16ed1
 	srl a
 	srl a
@@ -2868,7 +2868,7 @@ ShowBonusMultiplierMessage_RedField: ; 0x16ef5
 
 _LoadBonusMultiplierRailingGraphics_RedField: ; 0x16f28
 	push af
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .gameboyColor
 	pop af

--- a/engine/pinball_game/object_collision/seel_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/seel_bonus_resolve_collision.asm
@@ -77,7 +77,7 @@ Func_25d0e: ; 0x25d0e
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_25d2b
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_25d21
 	ld hl, TileDataPointers_25d67
@@ -1151,7 +1151,7 @@ Func_262f4: ; 0x262f4
 	ld c, a
 	ld b, $0
 	ld hl, TileDataPointers_2634a
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_26340
 	ld hl, TileDataPointers_26764

--- a/engine/pinball_game/score.asm
+++ b/engine/pinball_game/score.asm
@@ -108,7 +108,7 @@ ENDR
 	ret
 
 Func_85c7: ; 0x85c7
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	and $3
 	ret nz
 	ld a, [wd478]
@@ -217,28 +217,28 @@ HideScoreIfBallLow: ; 0x8650
 	bit 0, a
 	jr nz, .bottomStage ;if on upper stage, score is up
 	ld a, $86
-	ld [hWY], a
+	ldh [hWY], a
 	ret
 
 .bottomStage
 	ld a, [wBallYPos + 1]
 	cp $84
 	jr nc, .BallLow ;if ballY pos less than or equal to 132, raise score, else lower score
-	ld a, [hWY]
+	ldh a, [hWY]
 	sub $3
 	cp $86
 	jr nc, .DontClampHigh ;if result is less than 132, clamp to 132, else just load it in
 	ld a, $86
 .DontClampHigh
-	ld [hWY], a
+	ldh [hWY], a
 	ret
 
 .BallLow
-	ld a, [hWY]
+	ldh a, [hWY]
 	add $3
 	cp $90
 	jr c, .DontClampLow ;if result is more than 144, clamp to 144, else just load it in
 	ld a, $90
 .DontClampLow
-	ld [hWY], a
+	ldh [hWY], a
 	ret

--- a/engine/pinball_game/slot.asm
+++ b/engine/pinball_game/slot.asm
@@ -14,9 +14,9 @@ DoSlotRewardRoulette: ; 0xed8e
 	ld [wSlotBallIncrease], a
 .waitForFlippers
 	xor a
-	ld [hJoypadState], a
-	ld [hNewlyPressedButtons], a
-	ld [hPressedButtons], a
+	ldh [hJoypadState], a
+	ldh [hNewlyPressedButtons], a
+	ldh [hPressedButtons], a
 	call HandleTilts
 	ld a, [wCurrentStage]
 	bit 0, a
@@ -31,7 +31,7 @@ DoSlotRewardRoulette: ; 0xed8e
 	ld a, [wRightFlipperState + 1]
 	and a
 	jr nz, .waitForFlippers
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	call nz, LoadGreyBillboardPaletteData
 	call GenRandom
@@ -122,7 +122,7 @@ DoSlotRewardRoulette: ; 0xed8e
 	dec b
 	jr nz, .displayRewardLoop
 .loadColoredRewardPicture
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ld a, [wSlotRouletteBillboardPicture]
 	call nz, Func_f2a0
@@ -287,7 +287,7 @@ SlotRewardSmallPoints: ; 0xefb2
 .asm_efd8
 	rst AdvanceFrame
 	pop bc
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and FLIPPERS
 	jr nz, .asm_efe3
 	dec b
@@ -326,7 +326,7 @@ SlotRewardBigPoints: ; 0xeff3
 .asm_f019
 	rst AdvanceFrame
 	pop bc
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and FLIPPERS
 	jr nz, .asm_f024
 	dec b
@@ -435,7 +435,7 @@ SlotBonusMultiplier: ; 0xf0c1
 .asm_f0e7
 	rst AdvanceFrame
 	pop bc
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and FLIPPERS
 	jr nz, .asm_f0f2
 	dec b

--- a/engine/pinball_game/vertical_screen_transition.asm
+++ b/engine/pinball_game/vertical_screen_transition.asm
@@ -12,9 +12,9 @@ FieldVerticalTransition: ; 0xe674
 	pop af
 	ld [wCurrentStage], a
 	xor a
-	ld [hBGP], a
-	ld [hOBP0], a
-	ld [hOBP1], a
+	ldh [hBGP], a
+	ldh [hOBP0], a
+	ldh [hOBP1], a
 	rst AdvanceFrame
 	call ToggleAudioEngineUpdateMethod
 	call DisableLCD
@@ -25,11 +25,11 @@ FieldVerticalTransition: ; 0xe674
 	call ToggleAudioEngineUpdateMethod
 	call EnableLCD
 	ld a, $e4
-	ld [hBGP], a
+	ldh [hBGP], a
 	ld a, $e1
-	ld [hOBP0], a
+	ldh [hOBP0], a
 	ld a, $e4
-	ld [hOBP1], a
+	ldh [hOBP1], a
 	ret
 
 LoadStageData: ; 0xe6c2
@@ -44,9 +44,9 @@ LoadStageData: ; 0xe6c2
 	jr nz, .gotWindowYPos
 	ld a, $90
 .gotWindowYPos
-	ld [hWY], a
+	ldh [hWY], a
 	ld hl, StageGfxPointers_GameBoy
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .loadData
 	ld hl, StageGfxPointers_GameBoyColor
@@ -167,9 +167,9 @@ ScrollScreenToShowPinball: ; 0xed5e
 	ld a, [hl]
 	ld hl, wLeftAndRightTiltPixelsOffset
 	sub [hl]
-	ld [hSCX], a
+	ldh [hSCX], a
 	xor a
 	ld hl, wUpperTiltPixelsOffset
 	sub [hl]
-	ld [hSCY], a
+	ldh [hSCY], a
 	ret

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -258,7 +258,7 @@ Func_281cb:
 	ld d, a
 	ld a, BANK(MonBillboardPalettePointers)
 	call ReadByteFromBank
-	ld [$ff8c], a
+	ldh [hPokedexBillboardPaletteBank], a
 	jr .asm_28214
 
 .asm_281fb
@@ -274,7 +274,7 @@ Func_281cb:
 	ld d, a
 	ld a, BANK(MonAnimatedPalettePointers)
 	call ReadByteFromBank
-	ld [$ff8c], a
+	ldh [hPokedexBillboardPaletteBank], a
 .asm_28214
 	ld h, d
 	ld l, e
@@ -282,11 +282,11 @@ Func_281cb:
 	ld b, $8
 .asm_2821b
 	push bc
-	ld a, [$ff8c]
+	ldh a, [hPokedexBillboardPaletteBank]
 	call ReadByteFromBank
 	inc hl
 	ld c, a
-	ld a, [$ff8c]
+	ldh a, [hPokedexBillboardPaletteBank]
 	call ReadByteFromBank
 	inc hl
 	ld b, a
@@ -2060,20 +2060,20 @@ Func_28d88: ; 0x28d88
 Func_28d97: ; 0x28d97
 	push de
 	ld a, b
-	ld [$ff8c], a
-	ld [$ff8d], a
+	ldh [hVariableWidthFontFF8C], a
+	ldh [hVariableWidthFontFF8D], a
 	ld a, c
-	ld [$ff8f], a
+	ldh [hVariableWidthFontFF8F], a
 	xor a
-	ld [$ff8e], a
-	ld [$ff90], a
-	ld [$ff91], a
+	ldh [hVariableWidthFontFF8E], a
+	ldh [hVariableWidthFontFF90], a
+	ldh [hVariableWidthFontFF91], a
 	call Func_28e73
 .asm_28daa
 	call Func_2957c
 	jr nc, .asm_28dcb
 	push hl
-	ld [$ff92], a
+	ldh [hVariableWidthFontFF92], a
 	cp $ff
 	jr nz, .asm_28dbb
 	call Func_208c
@@ -2085,7 +2085,7 @@ Func_28d97: ; 0x28d97
 	ld hl, CharacterWidths
 	add hl, bc
 	ld a, [hl]
-	ld [$ff93], a
+	ldh [hVariableWidthFontFF93], a
 	call LoadDexVWFCharacter
 .asm_28dc8
 	pop hl
@@ -2114,7 +2114,7 @@ Func_28d97: ; 0x28d97
 .asm_28de9
 	ld hl, wPokedexFontBuffer
 	add hl, bc
-	ld a, [$ff8f]
+	ldh a, [hVariableWidthFontFF8F]
 	ld c, a
 	ld b, $0
 	sla c
@@ -2134,26 +2134,26 @@ Func_28d97: ; 0x28d97
 Func_28e09: ; 0x28e09
 	push de
 	ld a, b
-	ld [$ff8c], a
-	ld [$ff8d], a
+	ldh [hVariableWidthFontFF8C], a
+	ldh [hVariableWidthFontFF8D], a
 	ld a, c
-	ld [$ff8f], a
+	ldh [hVariableWidthFontFF8F], a
 	xor a
-	ld [$ff8e], a
-	ld [$ff90], a
-	ld [$ff91], a
+	ldh [hVariableWidthFontFF8E], a
+	ldh [hVariableWidthFontFF90], a
+	ldh [hVariableWidthFontFF91], a
 	call Func_28e73
 .asm_28e1c
 	call Func_295e1
 	jr nc, .asm_28e35
 	push hl
-	ld [$ff92], a
+	ldh [hVariableWidthFontFF92], a
 	ld c, a
 	ld b, $0
 	ld hl, CharacterWidths
 	add hl, bc
 	ld a, [hl]
-	ld [$ff93], a
+	ldh [hVariableWidthFontFF93], a
 	call LoadDexVWFCharacter
 	pop hl
 	jr nc, .asm_28e1c
@@ -2182,7 +2182,7 @@ Func_28e09: ; 0x28e09
 .asm_28e53
 	ld hl, wPokedexFontBuffer
 	add hl, bc
-	ld a, [$ff8f]
+	ldh a, [hVariableWidthFontFF8F]
 	ld c, a
 	ld b, $0
 	sla c
@@ -2201,7 +2201,7 @@ Func_28e09: ; 0x28e09
 
 Func_28e73: ; 0x28e73
 	push hl
-	ld a, [$ff8f]
+	ldh a, [hVariableWidthFontFF8F]
 	ld c, a
 	ld b, $0
 	sla c

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -10,7 +10,7 @@ PointerTable_28004: ; 0x28004
 
 LoadPokedexScreen: ; 0x2800e
 	ld a, $23
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e4
 	ld [wBGP], a
 	ld a, $93
@@ -18,26 +18,26 @@ LoadPokedexScreen: ; 0x2800e
 	ld a, $e4
 	ld [wOBP1], a
 	xor a
-	ld [hSCX], a
+	ldh [hSCX], a
 	ld a, $8
-	ld [hSCY], a
+	ldh [hSCY], a
 	ld a, $7
-	ld [hWX], a
+	ldh [hWX], a
 	ld a, $8c
-	ld [hWY], a
+	ldh [hWY], a
 	ld a, $3b
-	ld [hLYC], a
-	ld [hLastLYC], a
-	ld [hNextLYCSub], a
-	ld [hLYCSub], a
+	ldh [hLYC], a
+	ldh [hLastLYC], a
+	ldh [hNextLYCSub], a
+	ldh [hLYCSub], a
 	ld hl, hSTAT
 	set 6, [hl]
 	ld hl, rIE
 	set 1, [hl]
 	ld a, $2
-	ld [hStatIntrRoutine], a
+	ldh [hStatIntrRoutine], a
 	ld hl, PointerTable_280a2
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	call LoadVideoData
 	xor a
 	ld [wCurPokedexIndex], a
@@ -118,7 +118,7 @@ Data_280c4: ; 0x280c4
 
 MainPokedexScreen: ; 0x280fe
 	call Func_28513
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_28142
 	ld a, [wd95f]
@@ -159,10 +159,10 @@ MainPokedexScreen: ; 0x280fe
 	ret
 
 .asm_2814f
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_28174
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	bit BIT_START, a
 	jr z, .asm_28168
 	ld a, [wd960]
@@ -186,7 +186,7 @@ MonInfoPokedexScreen: ; 0x28178
 	ld a, [wd956]
 	bit 0, a
 	jr z, .asm_28190
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_2818a
 	call Func_28912
@@ -198,7 +198,7 @@ MonInfoPokedexScreen: ; 0x28178
 	jr .asm_28196
 
 .asm_28190
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and $3
 	jr z, .asm_281a2
 .asm_28196
@@ -209,10 +209,10 @@ MonInfoPokedexScreen: ; 0x28178
 	ret
 
 .asm_281a2
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_281c7
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	bit BIT_START, a
 	jr z, .asm_281bb
 	ld a, [wd960]
@@ -415,7 +415,7 @@ Func_282e9: ; 0x282e9
 	ld a, Bank(MonAnimatedSpriteTypes)
 	call ReadByteFromBank
 	ld c, a
-	ld a, [hFrameCounter]
+	ldh a, [hFrameCounter]
 	swap a
 	and $7
 	cp $7
@@ -444,7 +444,7 @@ Func_282e9: ; 0x282e9
 	ld a, SPRITE_DEX_ARROW
 	call LoadSpriteData
 	call Func_28368
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and $6
 	jr z, .asm_28367
 	ld a, BANK(PokedexTilemap)
@@ -470,13 +470,13 @@ Func_282e9: ; 0x282e9
 	ret
 
 Func_28368: ; 0x28368
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	bit BIT_A_BUTTON, a
 	jr nz, .asm_28371
 	jp Func_284bc
 
 .asm_28371
-	ld a, [hPressedButtons]
+	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [wdaa2]
 	ld e, a
@@ -665,7 +665,7 @@ SpritePaletteIndices_2848c:
 	db $EE, $00
 
 Func_284bc: ; 0x284bc
-	ld a, [hPressedButtons]
+	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [wdaa2]
 	bit 5, b
@@ -723,7 +723,7 @@ ExitPokedexScreen: ; 0x284f9
 	ret
 
 Func_28513: ; 0x28513
-	ld a, [hPressedButtons]
+	ldh a, [hPressedButtons]
 	ld hl, wd95e
 	or [hl]
 	ld [hl], a
@@ -895,7 +895,7 @@ Func_285db: ; 0x285db
 .asm_28647
 	ld c, a
 	push bc
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and a
 	ld a, [wd95b]
 	jr z, .asm_28652
@@ -945,7 +945,7 @@ DexScrollBarSpriteIds:
 DrawCornerInfoPokedexScreen: ; 0x2868b
 ; If player is holding SELECT button, it draws the seen/own count in the top-right corner.
 ; Otherwise, it draws the word "POKeDEX".
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	bit BIT_SELECT, a
 	jr z, .asm_286c8
 	ld bc, $6d03
@@ -1254,15 +1254,15 @@ Func_2887c: ; 0x2887c
 	ld bc, $0100
 	call LoadVRAMData
 	ld a, $3f
-	ld [hLYC], a
+	ldh [hLYC], a
 	ld a, $47
-	ld [hNextLYCSub], a
+	ldh [hNextLYCSub], a
 	ld b, $33
 .asm_28894
 	push bc
 	ld a, $7a
 	sub b
-	ld [hNextLYCSub], a
+	ldh [hNextLYCSub], a
 	rst AdvanceFrame
 	pop bc
 	dec b
@@ -1277,7 +1277,7 @@ Func_288a2: ; 0x288a2
 	push bc
 	ld a, $44
 	add b
-	ld [hNextLYCSub], a
+	ldh [hNextLYCSub], a
 	rst AdvanceFrame
 	pop bc
 	dec b
@@ -1285,8 +1285,8 @@ Func_288a2: ; 0x288a2
 	dec b
 	jr nz, .asm_288a4
 	ld a, $3b
-	ld [hLYC], a
-	ld [hNextLYCSub], a
+	ldh [hLYC], a
+	ldh [hNextLYCSub], a
 	ld a, BANK(PokedexTilemap2)
 	ld hl, PokedexTilemap2 + $100
 	deCoord 0, 8, vBGMap
@@ -1628,7 +1628,7 @@ Func_28ad1: ; 0x28ad1
 	swap a
 	and $f0
 	sub $3c
-	ld [hNextFrameHBlankSCX], a
+	ldh [hNextFrameHBlankSCX], a
 	ret
 
 Func_28add: ; 0x28add
@@ -1678,7 +1678,7 @@ Func_28add: ; 0x28add
 	call LoadOrCopyVRAMData
 	call Func_28cd4
 	pop bc
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	push bc
@@ -1721,7 +1721,7 @@ LoadUncaughtPokemonBackgroundGfx: ; 0x28b76
 	ld bc, $0180
 	call LoadOrCopyVRAMData
 	call Func_28cd4
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld a, BANK(UncaughtPokemonPaletteMap)
@@ -1765,7 +1765,7 @@ LoadSeenPokemonGfx: ; 0x28baf
 	ld bc, $0180
 	call LoadOrCopyVRAMData
 	call Func_28cd4
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld a, BANK(UncaughtPokemonPaletteMap)
@@ -1850,7 +1850,7 @@ Func_28bf5: ; 0x28bf5
 	ld [wCurrentAnimatedMonSpriteFrame], a
 	call Func_28cf8
 	pop bc
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ret z
 	ld hl, MonAnimatedPalettePointers

--- a/engine/pokedex/variable_width_font_character.asm
+++ b/engine/pokedex/variable_width_font_character.asm
@@ -1,51 +1,51 @@
 LoadDexVWFCharacter_: ; 0x8d17
 ; Loads a single variable-width-font character used in various parts of the Pokedex screen.
-	ld a, [$ff92]
+	ldh a, [hVariableWidthFontFF92]
 	cp $80
 	jp c, Func_8e01
-	ld a, [$ff90]
+	ldh a, [hVariableWidthFontFF90]
 	ld c, a
-	ld a, [$ff91]
+	ldh a, [hVariableWidthFontFF91]
 	ld b, a
-	ld a, [$ff93]
+	ldh a, [hVariableWidthFontFF93]
 	ld l, a
 	ld h, $0
 	add hl, bc
-	ld a, [$ff8e]
+	ldh a, [hVariableWidthFontFF8E]
 	cp h
 	jr nz, .asm_8d32
-	ld a, [$ff8d]
+	ldh a, [hVariableWidthFontFF8D]
 	cp l
 .asm_8d32
 	jr nc, .asm_8d5c
-	ld a, [$ff8d]
-	ld [$ff90], a
-	ld a, [$ff8e]
-	ld [$ff91], a
-	ld a, [$ff8d]
+	ldh a, [hVariableWidthFontFF8D]
+	ldh [hVariableWidthFontFF90], a
+	ldh a, [hVariableWidthFontFF8E]
+	ldh [hVariableWidthFontFF91], a
+	ldh a, [hVariableWidthFontFF8D]
 	ld c, a
-	ld a, [$ff8e]
+	ldh a, [hVariableWidthFontFF8E]
 	ld b, a
-	ld a, [$ff8c]
+	ldh a, [hVariableWidthFontFF8C]
 	ld l, a
 	ld h, $0
 	add hl, bc
 	ld a, l
-	ld [$ff8d], a
+	ldh [hVariableWidthFontFF8D], a
 	ld a, h
-	ld [$ff8e], a
+	ldh [hVariableWidthFontFF8E], a
 	srl h
 	rr l
 	srl h
 	rr l
-	ld a, [$ff8f]
+	ldh a, [hVariableWidthFontFF8F]
 	cp l
 	jp c, Func_8df7
 .asm_8d5c
-	ld a, [$ff90]
+	ldh a, [hVariableWidthFontFF90]
 	and $f8
 	ld c, a
-	ld a, [$ff91]
+	ldh a, [hVariableWidthFontFF91]
 	ld b, a
 	sla c
 	rl b
@@ -55,7 +55,7 @@ LoadDexVWFCharacter_: ; 0x8d17
 	add hl, bc
 	ld d, h
 	ld e, l
-	ld a, [$ff92]
+	ldh a, [hVariableWidthFontFF92]
 	swap a
 	ld c, a
 	and $f
@@ -68,7 +68,7 @@ LoadDexVWFCharacter_: ; 0x8d17
 	ld hl, PokedexCharactersGfx
 	add hl, bc
 	push hl
-	ld a, [$ff90]
+	ldh a, [hVariableWidthFontFF90]
 	and $7
 	ld c, a
 	ld b, $0
@@ -140,18 +140,18 @@ LoadDexVWFCharacter_: ; 0x8d17
 	pop bc
 	dec c
 	jr nz, .asm_8dc4
-	ld a, [$ff90]
+	ldh a, [hVariableWidthFontFF90]
 	ld c, a
-	ld a, [$ff91]
+	ldh a, [hVariableWidthFontFF91]
 	ld b, a
-	ld a, [$ff93]
+	ldh a, [hVariableWidthFontFF93]
 	ld l, a
 	ld h, $0
 	add hl, bc
 	ld a, l
-	ld [$ff90], a
+	ldh [hVariableWidthFontFF90], a
 	ld a, h
-	ld [$ff91], a
+	ldh [hVariableWidthFontFF91], a
 	and a
 	ret
 
@@ -163,49 +163,49 @@ Data_8df9: ; 0x8df9
 	db $FF, $7F, $3F, $1F, $0F, $07, $03, $01
 
 Func_8e01: ; 0x8e01
-	ld a, [$ff90]
+	ldh a, [hVariableWidthFontFF90]
 	ld c, a
-	ld a, [$ff91]
+	ldh a, [hVariableWidthFontFF91]
 	ld b, a
-	ld a, [$ff93]
+	ldh a, [hVariableWidthFontFF93]
 	ld l, a
 	ld h, $0
 	add hl, bc
-	ld a, [$ff8e]
+	ldh a, [hVariableWidthFontFF8E]
 	cp h
 	jr nz, .asm_8e15
-	ld a, [$ff8d]
+	ldh a, [hVariableWidthFontFF8D]
 	cp l
 .asm_8e15
 	jr nc, .asm_8e3f
-	ld a, [$ff8d]
-	ld [$ff90], a
-	ld a, [$ff8e]
-	ld [$ff91], a
-	ld a, [$ff8d]
+	ldh a, [hVariableWidthFontFF8D]
+	ldh [hVariableWidthFontFF90], a
+	ldh a, [hVariableWidthFontFF8E]
+	ldh [hVariableWidthFontFF91], a
+	ldh a, [hVariableWidthFontFF8D]
 	ld c, a
-	ld a, [$ff8e]
+	ldh a, [hVariableWidthFontFF8E]
 	ld b, a
-	ld a, [$ff8c]
+	ldh a, [hVariableWidthFontFF8C]
 	ld l, a
 	ld h, $0
 	add hl, bc
 	ld a, l
-	ld [$ff8d], a
+	ldh [hVariableWidthFontFF8D], a
 	ld a, h
-	ld [$ff8e], a
+	ldh [hVariableWidthFontFF8E], a
 	srl h
 	rr l
 	srl h
 	rr l
-	ld a, [$ff8f]
+	ldh a, [hVariableWidthFontFF8F]
 	cp l
 	jp c, Func_8ed6
 .asm_8e3f
-	ld a, [$ff90]
+	ldh a, [hVariableWidthFontFF90]
 	and $f8
 	ld c, a
-	ld a, [$ff91]
+	ldh a, [hVariableWidthFontFF91]
 	ld b, a
 	sla c
 	rl b
@@ -213,7 +213,7 @@ Func_8e01: ; 0x8e01
 	add hl, bc
 	ld d, h
 	ld e, l
-	ld a, [$ff92]
+	ldh a, [hVariableWidthFontFF92]
 	swap a
 	ld c, a
 	and $f
@@ -226,7 +226,7 @@ Func_8e01: ; 0x8e01
 	ld hl, PokedexCharactersGfx + $8
 	add hl, bc
 	push hl
-	ld a, [$ff90]
+	ldh a, [hVariableWidthFontFF90]
 	and $7
 	ld c, a
 	ld b, $0
@@ -298,18 +298,18 @@ Func_8e01: ; 0x8e01
 	pop bc
 	dec c
 	jr nz, .asm_8ea3
-	ld a, [$ff90]
+	ldh a, [hVariableWidthFontFF90]
 	ld c, a
-	ld a, [$ff91]
+	ldh a, [hVariableWidthFontFF91]
 	ld b, a
-	ld a, [$ff93]
+	ldh a, [hVariableWidthFontFF93]
 	ld l, a
 	ld h, $0
 	add hl, bc
 	ld a, l
-	ld [$ff90], a
+	ldh [hVariableWidthFontFF90], a
 	ld a, h
-	ld [$ff91], a
+	ldh [hVariableWidthFontFF91], a
 	and a
 	ret
 
@@ -321,26 +321,26 @@ Data_8ed8: ; 0x8ed8
 	db $FF, $7F, $3F, $1F, $0F, $07, $03, $01
 
 Func_8ee0: ; 0x8ee0
-	ld a, [$ff8d]
-	ld [$ff90], a
-	ld a, [$ff8e]
-	ld [$ff91], a
-	ld a, [$ff8d]
+	ldh a, [hVariableWidthFontFF8D]
+	ldh [hVariableWidthFontFF90], a
+	ldh a, [hVariableWidthFontFF8E]
+	ldh [hVariableWidthFontFF91], a
+	ldh a, [hVariableWidthFontFF8D]
 	ld c, a
-	ld a, [$ff8e]
+	ldh a, [hVariableWidthFontFF8E]
 	ld b, a
-	ld a, [$ff8c]
+	ldh a, [hVariableWidthFontFF8C]
 	ld l, a
 	ld h, $0
 	add hl, bc
 	ld a, l
-	ld [$ff8d], a
+	ldh [hVariableWidthFontFF8D], a
 	ld a, h
-	ld [$ff8e], a
+	ldh [hVariableWidthFontFF8E], a
 	srl h
 	rr l
 	srl h
 	rr l
-	ld a, [$ff8f]
+	ldh a, [hVariableWidthFontFF8F]
 	cp l
 	ret

--- a/engine/select_gameboy_target_menu.asm
+++ b/engine/select_gameboy_target_menu.asm
@@ -13,11 +13,11 @@ SelectGameboyTargetMenuFunctions: ; 0x8004
 
 InitSelectGameboyTargetMenu: ; 0x800a
 	xor a
-	ld [hFFC4], a
-	ld a, [hJoypadState]
+	ldh [hFFC4], a
+	ldh a, [hJoypadState]
 	cp D_UP
 	jr nz, .skipDebugMenu
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .showMenu
 .skipDebugMenu
@@ -29,14 +29,14 @@ InitSelectGameboyTargetMenu: ; 0x800a
 
 .showMenu
 	ld a, $45
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e4
 	ld [wBGP], a
 	ld [wOBP0], a
 	ld [wOBP1], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	call LoadGameboyTargetMenuGfx
 	call ClearSpriteBuffer
 	call SetAllPalettesWhite
@@ -165,14 +165,14 @@ Data_80f4: ; 0x80f4
 	RGB 00, 00, 00
 
 SelectCGBOrDMG: ; 0x8104
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	and (D_DOWN | D_UP)
 	jr z, .directionNotPressed
-	ld a, [hGameBoyColorFlag]
-	ld [hFFC4], a
+	ldh a, [hGameBoyColorFlag]
+	ldh [hFFC4], a
 	xor $1
-	ld [hGameBoyColorFlag], a
+	ldh [hGameBoyColorFlag], a
 	jr .moveCursor
 
 .directionNotPressed
@@ -183,7 +183,7 @@ SelectCGBOrDMG: ; 0x8104
 	ret
 
 .moveCursor
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .cgb
 	ld a, Bank(DMGSelected_TileData)

--- a/engine/titlescreen.asm
+++ b/engine/titlescreen.asm
@@ -10,7 +10,7 @@ TitlescreenFunctions: ; 0xc004
 
 FadeInTitlescreen: ; 0xc00e
 	ld a, $43
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ld a, $e4
 	ld [wBGP], a
 	ld a, $d2
@@ -18,10 +18,10 @@ FadeInTitlescreen: ; 0xc00e
 	ld a, $e1
 	ld [wOBP1], a
 	xor a
-	ld [hSCX], a
-	ld [hSCY], a
+	ldh [hSCX], a
+	ldh [hSCY], a
 	ld hl, TitlescreenFadeInGfxPointers
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	call LoadVideoData
 	ld a, $1
 	ld [wTitleScreenGameStartCursorSelection], a
@@ -59,7 +59,7 @@ TitlescreenFadeInGfx_GameBoyColor: ; 0xc06b
 TitlescreenLoop: ; 0xc089
 	call Func_c0ee
 	call HandleTitlescreenAnimations
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a  ; was A button pressed?
 	jr z, .AButtonNotPressed
 	ld a, [wTitleScreenCursorSelection]
@@ -116,7 +116,7 @@ Func_c0ee: ; 0xc0ee
 	ret
 
 HandleTitlescreenAnimations: ; 0xc0f7
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_c104
 	ld bc, $2040
@@ -134,7 +134,7 @@ Func_c10e: ; 0xc10e
 	ld a, [wTitlescreenContinuePromptAnimationFrame]
 	cp $6
 	ret nz
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit 0, a
 	jr z, .asm_c17c
 	ld de, MUSIC_NOTHING
@@ -210,7 +210,7 @@ Func_c1a2: ; 0xc1a2
 
 Func_c1b1: ; 0xc1b1
 	call HandleTitleScreenContinuePromptAnimation
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_c1c1
 	ld bc, $2040
@@ -253,7 +253,7 @@ GoToHighScoresFromTitlescreen: ; 0xc1e7
 	ret
 
 Func_c1fc: ; 0xc1fc
-	ld a, [hPressedButtons]
+	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [hl]
 	bit 6, b

--- a/home.asm
+++ b/home.asm
@@ -105,7 +105,7 @@ Start: ; 0x150
 	ld [wd7fc], a
 	ld [wd7fd], a
 	ldh [hStatIntrRoutine], a
-	ld [$ffb1], a
+	ldh [hFFB1], a
 	ld [wd8e1], a
 	ld [wd7fe], a
 	ldh [hSGBInit], a
@@ -204,7 +204,7 @@ SoftReset:
 	ld [wd7fc], a
 	ld [wd7fd], a
 	ldh [hStatIntrRoutine], a
-	ld [$ffb1], a
+	ldh [hFFB1], a
 	ld [wd8e1], a
 	ld [wd7fe], a
 	ld hl, hLCDC
@@ -472,7 +472,7 @@ Serial: ; 0x445
 	push hl
 	ld hl, Data_45d
 	push hl
-	ld a, [$ffb1]
+	ldh a, [hFFB1]
 	sla a
 	ld c, a
 	ld b, $0
@@ -1440,12 +1440,12 @@ Func_11d2:
 	ld h, d
 	ld l, e
 	ldh a, [hLoadedROMBank]
-	ld [$ff94], a
+	ldh [hFF94], a
 .asm_11d8
 	ld a, [hli]
 	and a
 	ret z
-	ld [$ff95], a
+	ldh [hFF95], a
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -1460,7 +1460,7 @@ Func_11d2:
 	push hl
 	ld h, b
 	ld l, c
-	ld a, [$ff95]
+	ldh a, [hFF95]
 	ld b, a
 .asm_11f1
 	ld a, [hli]
@@ -1514,7 +1514,7 @@ Func_11d2:
 	dec b
 	jr nz, .asm_11f1
 	pop hl
-	ld a, [$ff94]
+	ldh a, [hFF94]
 	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	jr .asm_11d8
@@ -1525,7 +1525,7 @@ Func_122e:
 	ld h, d
 	ld l, e
 	ldh a, [hLoadedROMBank]
-	ld [$ff94], a
+	ldh [hFF94], a
 .asm_1238
 	ld a, [hli]
 	and a
@@ -1535,7 +1535,7 @@ Func_122e:
 	ret
 
 .asm_1240
-	ld [$ff95], a
+	ldh [hFF95], a
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -1550,7 +1550,7 @@ Func_122e:
 	push hl
 	ld h, b
 	ld l, c
-	ld a, [$ff95]
+	ldh a, [hFF95]
 	ld b, a
 .asm_1256
 	ld a, [hli]
@@ -1559,7 +1559,7 @@ Func_122e:
 	dec b
 	jr nz, .asm_1256
 	pop hl
-	ld a, [$ff94]
+	ldh a, [hFF94]
 	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	jr .asm_1238
@@ -1578,7 +1578,7 @@ LoadPalettes:
 	ld a, [hli]
 	and a
 	ret z
-	ld [$ff94], a
+	ldh [hFF94], a
 	ld a, [hli]
 	bit 6, a
 	ld de, rBGPI
@@ -1601,7 +1601,7 @@ LoadPalettes:
 	push hl
 	ld h, b
 	ld l, c
-	ld a, [$ff94]
+	ldh a, [hFF94]
 	ld b, a
 .loadColor
 	ld a, [hli]
@@ -1669,7 +1669,7 @@ Func_1a59: ; 0x1a59
 	ld hl, rIE
 	set 3, [hl]
 	xor a
-	ld [$ffb1], a
+	ldh [hFFB1], a
 	ld a, $1
 	ld [wd8e1], a
 	ret

--- a/home.asm
+++ b/home.asm
@@ -43,7 +43,7 @@ SECTION "Header", ROM0
 SECTION "Main", ROM0
 
 Start: ; 0x150
-	ld [hGameBoyColorFlag], a
+	ldh [hGameBoyColorFlag], a
 	ld sp, hGameBoyColorFlag
 	di
 	xor a
@@ -89,7 +89,7 @@ Start: ; 0x150
 	ld a, $0
 	ld [MBC5SRamBank], a   ; Set bits 5 and 6 of ROM Bank Number
 	ld a, $1
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld a, $1
 	ld [MBC5RomBankOn], a   ; Enable RAM Banking Mode
 	ld a, $0
@@ -104,11 +104,11 @@ Start: ; 0x150
 	ld [wd7fb], a
 	ld [wd7fc], a
 	ld [wd7fd], a
-	ld [hStatIntrRoutine], a
+	ldh [hStatIntrRoutine], a
 	ld [$ffb1], a
 	ld [wd8e1], a
 	ld [wd7fe], a
-	ld [hSGBInit], a
+	ldh [hSGBInit], a
 	ld hl, hLCDC
 	xor a
 	ld [hli], a
@@ -129,15 +129,15 @@ Start: ; 0x150
 	ld a, Bank(PlaySong_BankF)
 	call SetSongBank
 	call Func_23b
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .asm_222
 	call InitSGB
 	rl a
 	and $1
-	ld [hSGBFlag], a
+	ldh [hSGBFlag], a
 	call SendSGBBorder
-	ld a, [hSGBFlag]
+	ldh a, [hSGBFlag]
 	and a
 	jr z, .asm_222
 	ld a, $1
@@ -155,18 +155,18 @@ Start: ; 0x150
 	ld hl, Main
 	call BankSwitchSimple
 Func_23b: ; 0x23b
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	cp $11
 	jr nz, .asm_248
 	ld a, $1
-	ld [hGameBoyColorFlag], a
-	ld [hGameBoyColorFlagBackup], a
+	ldh [hGameBoyColorFlag], a
+	ldh [hGameBoyColorFlagBackup], a
 	ret
 
 .asm_248
 	xor a
-	ld [hGameBoyColorFlag], a
-	ld [hGameBoyColorFlagBackup], a
+	ldh [hGameBoyColorFlag], a
+	ldh [hGameBoyColorFlagBackup], a
 	ret
 
 SoftReset:
@@ -191,7 +191,7 @@ SoftReset:
 	ld a, $0
 	ld [MBC5SRamBank], a
 	ld a, $1
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld a, $1
 	ld [MBC5RomBankOn], a
 	ld a, $0
@@ -203,7 +203,7 @@ SoftReset:
 	ld [wd7fb], a
 	ld [wd7fc], a
 	ld [wd7fd], a
-	ld [hStatIntrRoutine], a
+	ldh [hStatIntrRoutine], a
 	ld [$ffb1], a
 	ld [wd8e1], a
 	ld [wd7fe], a
@@ -226,7 +226,7 @@ SoftReset:
 	ld [wToggleAudioEngineUpdateMethod], a
 	ld a, BANK(Func_3c000)
 	call SetSongBank
-	ld a, [hSGBFlag]
+	ldh a, [hSGBFlag]
 	and a
 	jr z, .asm_02d5
 	ld a, $1
@@ -238,8 +238,8 @@ SoftReset:
 	ld a, $ff
 	ld [wRNGModulus], a
 	call ResetRNG
-	ld a, [hGameBoyColorFlag]
-	ld [hGameBoyColorFlagBackup], a
+	ldh a, [hGameBoyColorFlag]
+	ldh [hGameBoyColorFlagBackup], a
 	xor a
 	ld [wBootCheck], a
 	ld a, Bank(Main)
@@ -253,7 +253,7 @@ VBlank: ; 0x2f2
 	push de
 	push hl
 	call hPushSprite ; sprite DMA transfer
-	ld a, [hLCDC]
+	ldh a, [hLCDC]
 	ld [rLCDC], a
 	call Func_113a
 	ei
@@ -291,22 +291,22 @@ VBlank: ; 0x2f2
 	ld a, [hli]
 	ld [$ff00+c], a
 .asm_328
-	ld a, [hLYC]
-	ld [hLastLYC], a
-	ld a, [hNextLYCSub]
-	ld [hLYCSub], a
-	ld a, [hNextFrameHBlankSCX]
-	ld [hHBlankSCX], a
-	ld a, [hNextFrameHBlankSCY]
-	ld [hHBlankSCY], a
+	ldh a, [hLYC]
+	ldh [hLastLYC], a
+	ldh a, [hNextLYCSub]
+	ldh [hLYCSub], a
+	ldh a, [hNextFrameHBlankSCX]
+	ldh [hHBlankSCX], a
+	ldh a, [hNextFrameHBlankSCY]
+	ldh [hHBlankSCY], a
 	call ReadJoypad
 	ld a, [wBootCheck]
 	and a
 	jr nz, .skipBootCheck
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	cp $f
 	jr nz, .skipBootCheck
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and $f
 	jr z, .skipBootCheck
 	ld hl, sp + 8
@@ -395,8 +395,8 @@ FadeAndSoftReset:
 	ld [rSC], a
 	ld [rIE], a
 	ld [rNR52], a
-	ld a, [hGameBoyColorFlagBackup]
-	ld [hGameBoyColorFlag], a
+	ldh a, [hGameBoyColorFlagBackup]
+	ldh [hGameBoyColorFlag], a
 	jp SoftReset
 
 LCDCStatus: ; 0x3ec
@@ -404,7 +404,7 @@ LCDCStatus: ; 0x3ec
 	push bc
 	push de
 	push hl
-	ld a, [hStatIntrRoutine]
+	ldh a, [hStatIntrRoutine]
 	sla a
 	ld c, a
 	ld b, 0
@@ -417,7 +417,7 @@ LCDCStatus: ; 0x3ec
 
 StatIntrDone: ; 0x3ff
 	ld a, $1
-	ld [hStatIntrFired], a
+	ldh [hStatIntrFired], a
 	pop hl
 	pop de
 	pop bc
@@ -560,13 +560,13 @@ CallInFollowingTable: ; 0x532
 
 BankSwitchSimple: ; 0x549
 ; Switches to Bank in register a and jumps to hl.
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a  ; Load Bank
 	jp hl
 
 BankSwitch: ; 0x54f
 	ld e, a
-	ld a, [hLoadedROMBank]  ; currently-loaded Bank
+	ldh a, [hLoadedROMBank]  ; currently-loaded Bank
 	cp e
 	jr z, .doJump
 	push af
@@ -582,25 +582,25 @@ BankSwitch: ; 0x54f
 	ld d, [hl]
 	ld [hl], $0
 	ld [MBC5RomBank], a
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [hl], d
 	pop de
 	pop hl
 	ret
 
 .doJump
-	ld a, [hFarCallTempE]
+	ldh a, [hFarCallTempE]
 	ld e, a
-	ld a, [hFarCallTempA]
+	ldh a, [hFarCallTempA]
 	jp hl
 
 DisableLCD: ; 0x576
 	ld a, [rLCDC]
 	bit 7, a
 	ret z
-	ld a, [hLCDC]
+	ldh a, [hLCDC]
 	res 7, a
-	ld [hLCDC], a
+	ldh [hLCDC], a
 .asm_581
 	ld a, [rLCDC]
 	bit 7, a
@@ -608,13 +608,13 @@ DisableLCD: ; 0x576
 	ret
 
 EnableLCD: ; 0x588
-	ld a, [hFFC4]
+	ldh a, [hFFC4]
 	and a
 	call nz, .UpdatePals
-	ld a, [hLCDC]
+	ldh a, [hLCDC]
 	set 7, a
 	ld [rLCDC], a
-	ld [hLCDC], a
+	ldh [hLCDC], a
 	ret
 
 .UpdatePals
@@ -686,20 +686,22 @@ VBlankIntEnable:
 	ret
 
 WriteDMACodeToHRAM: ; 0x5f7
-; Initializes registers hPushSprite - hFarCallTempA
-	ld c, $80
-	ld b, $a  ; number of bytes to load
+; Initializes registers hPushSprite - hPushSprite.end
+	assert HIGH(hPushSprite) == $FF
+	assert DMARoutine.end - DMARoutine == hPushSprite.end - hPushSprite
+	ld c, LOW(hPushSprite)
+	ld b, hPushSprite.end - hPushSprite  ; number of bytes to load
 	ld hl, DMARoutine
 .loop
 	ld a, [hli]
-	ld [$ff00+c], a  ; add register c to $ff00, and store register a into the resulting address
+	ldh [c], a  ; add register c to $ff00, and store register a into the resulting address
 	inc c
 	dec b
 	jr nz, .loop
 	ret
 
 DMARoutine:
-; This routine is initially loaded into hPushSprite - hFarCallTempA by WriteDMACodeToHRAM.
+; This routine is initially loaded into hPushSprite by WriteDMACodeToHRAM.
 	ld a, (wSpriteBuffer >> 8)
 	ld [rDMA], a   ; start DMA
 	ld a, $28
@@ -707,6 +709,7 @@ DMARoutine:
 	dec a
 	jr nz, .waitLoop
 	ret
+.end
 
 WaitForLCD: ; 0x60f
 ; Wait for LCD controller to stop reading from both OAM and VRAM because
@@ -1033,9 +1036,9 @@ StatIntrTogglePinballWindow:
 	inc c
 	cp c
 	jp nc, StatIntrDone
-	ld a, [hLCDCMask]
+	ldh a, [hLCDCMask]
 	ld c, a
-	ld a, [hLCDC]
+	ldh a, [hLCDC]
 	xor $10 ; toggle window tile data
 	and c
 	ld c, a
@@ -1052,16 +1055,16 @@ StatIntrTogglePinballWindow:
 
 StatIntrTogglePokedexWindow: ; 0xfea
 	ld hl, hLastLYC
-	ld a, [hLYCSub]
+	ldh a, [hLYCSub]
 	cp [hl]
 	jr nz, .asm_1015
 	ld a, [rLY]
 	cp [hl]
 	jp nz, StatIntrDone
-	ld a, [hLCDC]
+	ldh a, [hLCDC]
 	xor $18 ; toggle window tile data and tile map
 	ld c, a
-	ld a, [hHBlankSCX]
+	ldh a, [hHBlankSCX]
 	ld b, a
 	ld hl, rSTAT
 .waitForHBlank
@@ -1080,12 +1083,12 @@ StatIntrTogglePokedexWindow: ; 0xfea
 	ld a, [rLY]
 	cp [hl]
 	jr nz, .asm_1037
-	ld a, [hLastLYC]
+	ldh a, [hLastLYC]
 	ld hl, hLYCSub
 	sub [hl]
 	add $40
 	ld c, a
-	ld a, [hLYCSub]
+	ldh a, [hLYCSub]
 	ld b, a
 	ld hl, rSTAT
 .waitForHBlank_2
@@ -1103,10 +1106,10 @@ StatIntrTogglePokedexWindow: ; 0xfea
 	ld a, [rLY]
 	cp [hl]
 	jp nz, StatIntrDone
-	ld a, [hLCDC]
+	ldh a, [hLCDC]
 	xor $18 ; toggle window tile data and tile map
 	ld c, a
-	ld a, [hHBlankSCX]
+	ldh a, [hHBlankSCX]
 	ld b, a
 	ld hl, rSTAT
 .waitForHBlank_3
@@ -1130,9 +1133,9 @@ StatIntrToggleHighScoresWindow:
 	cp [hl]
 	jr nz, .asm_1080
 .asm_1069
-	ld a, [hLYCSub]
+	ldh a, [hLYCSub]
 	ld c, a
-	ld a, [hHBlankSCX]
+	ldh a, [hHBlankSCX]
 	ld b, a
 	ld hl, rSTAT
 .waitForHBlank
@@ -1154,7 +1157,7 @@ StatIntrToggleHighScoresWindow:
 	cp [hl]
 	jp nz, StatIntrDone
 .asm_108d
-	ld a, [hHBlankSCY]
+	ldh a, [hHBlankSCY]
 	ld b, a
 	ld hl, rSTAT
 .waitForHBlank_2
@@ -1240,11 +1243,11 @@ QueueGraphicsToLoadWithFunc: ; 0x10c5
 	inc h
 	ld [hl], d
 	ld e, $ff
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	dec bc
 	ld a, [bc]
@@ -1258,7 +1261,7 @@ QueueGraphicsToLoadWithFunc: ; 0x10c5
 	add $4
 	ld [hl], a
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, wd7fb
 	ld l, [hl]
@@ -1312,10 +1315,10 @@ Func_113a: ; 0x113a
 	inc h
 	ld d, [hl]
 	inc h
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [hl]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	inc h
 	ld a, [hl]
@@ -1324,7 +1327,7 @@ Func_113a: ; 0x113a
 	ld l, a
 	call JumpToHL
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	pop hl
 	inc l
@@ -1436,7 +1439,7 @@ Func_11c7:
 Func_11d2:
 	ld h, d
 	ld l, e
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	ld [$ff94], a
 .asm_11d8
 	ld a, [hli]
@@ -1452,7 +1455,7 @@ Func_11d2:
 	ld a, [hli]
 	ld b, a
 	ld a, [hli]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	push hl
 	ld h, b
@@ -1512,7 +1515,7 @@ Func_11d2:
 	jr nz, .asm_11f1
 	pop hl
 	ld a, [$ff94]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	jr .asm_11d8
 
@@ -1521,7 +1524,7 @@ Func_122e:
 	ld [rVBK], a
 	ld h, d
 	ld l, e
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	ld [$ff94], a
 .asm_1238
 	ld a, [hli]
@@ -1542,7 +1545,7 @@ Func_122e:
 	ld a, [hli]
 	ld b, a
 	ld a, [hli]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	push hl
 	ld h, b
@@ -1557,7 +1560,7 @@ Func_122e:
 	jr nz, .asm_1256
 	pop hl
 	ld a, [$ff94]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	jr .asm_1238
 
@@ -1590,10 +1593,10 @@ LoadPalettes:
 	ld c, a
 	ld a, [hli]
 	ld b, a
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [hli]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	push hl
 	ld h, b
@@ -1609,7 +1612,7 @@ LoadPalettes:
 	jr nz, .loadColor
 	pop hl
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	jr .loop
 
@@ -1684,7 +1687,7 @@ Func_1a89: ; 0x1a89
 	ret
 
 .asm_1a9f
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit 1, a
 	jp nz, Func_1bd3
 	rst AdvanceFrame
@@ -1742,10 +1745,10 @@ Func_1ae2: ; 0x1ae2
 	ld a, [wd869]
 	ld h, a
 	add hl, bc
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [wd86a]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 REPT 15
 	ld a, [hli]
@@ -1756,7 +1759,7 @@ ENDR
 	ld [de], a
 	inc de
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	pop hl
 	pop bc
@@ -1776,7 +1779,7 @@ Func_1b3d: ; 0x1b3d
 	ret
 
 .asm_1b56
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	jp nz, Func_1bd3
 	rst AdvanceFrame
@@ -1798,7 +1801,7 @@ Func_1b60: ; 0x1b60
 	ret
 
 .asm_1b7e
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	jp nz, Func_1bd3
 	rst AdvanceFrame
@@ -1818,7 +1821,7 @@ Func_1b88: ; 0x1b88
 	ret
 
 .asm_1b9d
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	jp nz, Func_1bd3
 	rst AdvanceFrame
@@ -1875,10 +1878,10 @@ Unused_Func_1ed9:
 	ld d, $0
 	sla e
 	rl d
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, $2
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, $4f06
 	jr asm_1f3b
@@ -1892,10 +1895,10 @@ Unused_Func_1ef2:
 	ld d, $0
 	sla e
 	rl d
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, $2
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, $4f06
 	jr asm_1f3b
@@ -1910,10 +1913,10 @@ LoadSpriteData2: ; 0x1f0b
 	ld d, $0
 	sla e
 	rl d
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, Bank(SpriteDataPointers2)
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, SpriteDataPointers2
 	jr asm_1f3b
@@ -1928,10 +1931,10 @@ LoadSpriteData: ; 0x1f24
 	ld d, $0
 	sla e
 	rl d  ; multiply de by 2
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, Bank(SpriteDataPointers)
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, SpriteDataPointers
 asm_1f3b: ; 0x1f3b
@@ -1966,7 +1969,7 @@ asm_1f3b: ; 0x1f3b
 	ld a, l
 	ld [wSpriteBufferSize], a
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	pop hl
 	pop de
@@ -1982,10 +1985,10 @@ Unused_Func_1f68:
 	ld d, $0
 	sla e
 	rl d
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, $2
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, $4f06
 	jr asm_1fca
@@ -1999,10 +2002,10 @@ Unused_Func_1f81:
 	ld d, $0
 	sla e
 	rl d
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, $2
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, $4f06
 	jr asm_1fca
@@ -2015,10 +2018,10 @@ Func_1f9a:
 	ld d, $0
 	sla e
 	rl d
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, BANK(SpriteDataPointers2)
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, SpriteDataPointers2
 	jr asm_1fca
@@ -2031,10 +2034,10 @@ Func_1fb3:
 	ld d, $0
 	sla e
 	rl d
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, BANK(SpriteDataPointers)
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, SpriteDataPointers
 asm_1fca:
@@ -2073,7 +2076,7 @@ asm_1fca:
 	ld a, l
 	ld [wSpriteBufferSize], a
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	pop hl
 	pop de
@@ -2133,43 +2136,43 @@ CallTable_2049: ; 0x2049
 
 LoadDexVWFCharacter: ; 0x206d
 ; Loads a single variable-width-font character used in various parts of the Pokedex screen.
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, Bank(LoadDexVWFCharacter_)
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	call LoadDexVWFCharacter_
 	jr c, .asm_2084
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	and a
 	ret
 
 .asm_2084
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	scf
 	ret
 
 Func_208c: ; 0x208c
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, Bank(Func_8ee0)
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	call Func_8ee0
 	jr c, .asm_20a3
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	and a
 	ret
 
 .asm_20a3
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	scf
 	ret
@@ -2178,7 +2181,7 @@ MultiplyBbyCUnsigned: ; 0x20ab
 	; u16 bc = (u8)b * (u8)c
 	push af
 	xor a
-	ld [hSignedMathSignBuffer], a
+	ldh [hSignedMathSignBuffer], a
 	jr MultiplyBbyCSigned.asm_20c6
 
 MultiplyBbyCSigned:
@@ -2186,7 +2189,7 @@ MultiplyBbyCSigned:
 	push af
 	ld a, b
 	xor c
-	ld [hSignedMathSignBuffer], a
+	ldh [hSignedMathSignBuffer], a
 	bit 7, b
 	jr z, .asm_20be
 	ld a, b
@@ -2252,7 +2255,7 @@ MultiplyBbyCSigned:
 	rr l
 	ld b, h
 	ld c, l
-	ld a, [hSignedMathSignBuffer]
+	ldh a, [hSignedMathSignBuffer]
 	rlca
 	jr nc, .done
 	ld a, c
@@ -2278,7 +2281,7 @@ MultiplyVectorComponentByAngleFactor: ; 0x210b
 	push hl
 	ld a, b
 	xor d
-	ld [hSignedMathSignBuffer2], a
+	ldh [hSignedMathSignBuffer2], a
 	bit 7, b
 	jr z, .positive
 	; negate bc
@@ -2307,7 +2310,7 @@ MultiplyVectorComponentByAngleFactor: ; 0x210b
 	ld c, e
 	call MultiplyBbyCUnsigned
 	add hl, bc
-	ld a, [hSignedMathSignBuffer2]
+	ldh a, [hSignedMathSignBuffer2]
 	rlca
 	jr nc, .positive2
 	; negate hl
@@ -2337,7 +2340,7 @@ Sine: ; 0x2149
 	; Output: e = sin(a)
 	;         d = 0 if sin(a) is positive, $ff if sin(a) is negative
 	push hl
-	ld [hSignedMathSignBuffer], a
+	ldh [hSignedMathSignBuffer], a
 	and $7f ; ensure angle is between 0 and 180 degrees
 	cp $40
 	jr c, .firstQuadrant
@@ -2352,7 +2355,7 @@ Sine: ; 0x2149
 	ld e, [hl]
 	pop hl
 	ld d, $0
-	ld a, [hSignedMathSignBuffer]
+	ldh a, [hSignedMathSignBuffer]
 	sla a
 	ret nc
 	ld d, $ff
@@ -2461,24 +2464,24 @@ RotateVector: ; 0x21e7
 	push hl
 	push bc
 	push de
-	ld [hRotationAngleBuffer], a
+	ldh [hRotationAngleBuffer], a
 	call Cosine
 	ld a, e
-	ld [hCosineResultBuffer], a
+	ldh [hCosineResultBuffer], a
 	ld a, d
-	ld [hCosineResultBuffer + 1], a
+	ldh [hCosineResultBuffer + 1], a
 	; xComponent * cos(angle)
 	call MultiplyVectorComponentByAngleFactor
 	ld l, c
 	ld h, b
 	pop bc
 	push bc
-	ld a, [hRotationAngleBuffer]
+	ldh a, [hRotationAngleBuffer]
 	call Sine
 	ld a, e
-	ld [hSineResultBuffer], a
+	ldh [hSineResultBuffer], a
 	ld a, d
-	ld [hSineResultBuffer + 1], a
+	ldh [hSineResultBuffer + 1], a
 	; yComponent * sin(angle)
 	call MultiplyVectorComponentByAngleFactor
 	add hl, bc  ; hl = xComponent * cos(angle) + yComponent * sin(angle)
@@ -2486,9 +2489,9 @@ RotateVector: ; 0x21e7
 	pop bc
 	push hl
 	push de
-	ld a, [hSineResultBuffer]
+	ldh a, [hSineResultBuffer]
 	ld e, a
-	ld a, [hSineResultBuffer + 1]
+	ldh a, [hSineResultBuffer + 1]
 	cpl
 	ld d, a
 	; xComponent * -sin(angle)
@@ -2496,9 +2499,9 @@ RotateVector: ; 0x21e7
 	ld l, c
 	ld h, b
 	pop bc
-	ld a, [hCosineResultBuffer]
+	ldh a, [hCosineResultBuffer]
 	ld e, a
-	ld a, [hCosineResultBuffer + 1]
+	ldh a, [hCosineResultBuffer + 1]
 	ld d, a
 	; yComponent * cos(angle)
 	call MultiplyVectorComponentByAngleFactor
@@ -2682,10 +2685,10 @@ CheckStageCollision: ; 0x22b5
 	ld a, [wStageCollisionMapPointer + 1]
 	ld b, a
 	add hl, bc  ; hl = address of ball tile's collision attribute
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [wStageCollisionMapBank]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld bc, 32 - 1  ; stage's number of tiles wide - 1
 	ld a, [hli]
@@ -2698,12 +2701,12 @@ CheckStageCollision: ; 0x22b5
 	ld a, [hl]
 	ld [wLowerRightCollisionAttribute], a
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [wStageCollisionMasksBank]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, [wSubTileBallXPos]
 	sla a
@@ -2781,7 +2784,7 @@ CheckStageCollision: ; 0x22b5
 	dec b
 	jr nz, .testCollisionPointLoop
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld hl, wCollisionPointTests
 	ld de, wd7d9
@@ -2867,10 +2870,10 @@ CheckStageCollision: ; 0x22b5
 	ld [wIsBallColliding], a
 	and a
 	ret z
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, Bank(CollisionForceAngles)
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	push de
 	; Based on the start and end collision point indices, look
@@ -2906,7 +2909,7 @@ CheckStageCollision: ; 0x22b5
 	ld [wBallXPos + 1], a
 	pop de
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, d
 	swap a
@@ -3242,7 +3245,7 @@ LoadFlippersPalette: ; 0x2862
 	ld a, [wFlippersDisabled]
 	and a
 	jr nz, .flippersDisabled
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .done
 	ld a, Bank(ActiveFlippersPalette)
@@ -3254,7 +3257,7 @@ LoadFlippersPalette: ; 0x2862
 	ret
 
 .flippersDisabled
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .done2
 	ld a, Bank(DisabledFlippersPalette)

--- a/home/audio.asm
+++ b/home/audio.asm
@@ -1,9 +1,9 @@
 
 PlaySong: ; 0x490
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [wCurrentSongBank]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, e
 	ld [wStageSong], a
@@ -11,7 +11,7 @@ PlaySong: ; 0x490
 	ld [wStageSongBank], a
 	call PlaySong_BankF  ; this function is replicated in multiple banks.
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -31,14 +31,14 @@ PlaySoundEffect: ; 0x4af
 	ld a, d
 	ld [wSFXTimer], a
 	ld d, $0
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [wCurrentSongBank]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	call PlaySoundEffect_BankF  ; this function is replicated in multiple banks
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -61,26 +61,26 @@ PlaySFXIfNoneActive: ; 0x4d8
 PlayCry: ; 0x4ef
 ; Plays a Pokemon cry.
 ; Input:  e = mon id
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [wCurrentSongBank]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	call PlayCry_BankF  ; this function is replicated in multiple banks
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
 UpdateSFX: ; 0x504
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, [wCurrentSongBank]
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	call Func_3c180
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, [wd801]
 	inc a

--- a/home/copy.asm
+++ b/home/copy.asm
@@ -77,11 +77,11 @@ FarCopyData: ; 0x666 spooky
 ;        bc = number of bytes to copy
 	bit 7, h
 	jr nz, .copyFromSRAM
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	scf
 	jr .copyData
@@ -102,7 +102,7 @@ FarCopyData: ; 0x666 spooky
 	pop af
 	ret nc
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -112,14 +112,14 @@ ReadByteFromBank: ; 0x68f
 ; Output: a = byte at a:hl
 	push de
 	ld d, a
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	ld e, a
 	ld a, d
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld d, [hl]
 	ld a, e
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, d
 	pop de
@@ -179,11 +179,11 @@ LoadVideoData: ; 0x6a4
 	jp c, FarCopyCGBPals  ; if lowest bit of bc is set
 	jp .nopJump
 .nopJump
-	ld [hROMBankBuffer], a  ; save bank of data to be loaded
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a  ; save bank of data to be loaded
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]  ; a contains bank of data to be loaded
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]  ; a contains bank of data to be loaded
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a  ; switch bank to the bank of data to be loaded
 	srl b
 	rr c
@@ -201,7 +201,7 @@ LoadVideoData: ; 0x6a4
 	xor a
 	ld [rVBK], a  ; set VRAM Bank to Bank 0
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a  ; reload the previous ROM Bank
 	ret
 
@@ -210,11 +210,11 @@ FarCopyCGBPals: ; 0x6fd
 ; hl: source
 ; e: dest offset
 ; bc: size
-	ld [hROMBankBuffer], a  ; save bank of data to be loaded
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a  ; save bank of data to be loaded
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]  ; a contains bank of data to be loaded
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]  ; a contains bank of data to be loaded
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a  ; switch bank to the bank of data to be loaded
 	ld a, e
 	bit 6, a
@@ -228,7 +228,7 @@ FarCopyCGBPals: ; 0x6fd
 	call .copyPaletteData
 .no_obp
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -263,11 +263,11 @@ LoadVRAMData: ; 0x73f
 ;         bc = number of bytes to copy
 	bit 7, h
 	jr nz, .asm_752
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	scf
 	jr .asm_756
@@ -322,7 +322,7 @@ LoadVRAMData: ; 0x73f
 	pop af
 	ret nc
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -334,11 +334,11 @@ FarCopyPalettes: ; 0x790
 	jp nz, Func_7dc
 	bit 7, h
 	jr nz, .asm_7ad
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	scf
 	jr .asm_7b1
@@ -377,18 +377,18 @@ FarCopyPalettes: ; 0x790
 	pop af
 	ret nc
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
 Func_7dc: ; 0x7dc
 	bit 7, h
 	jr nz, .asm_7ef
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	scf
 	jr .asm_7f3
@@ -461,7 +461,7 @@ Func_7dc: ; 0x7dc
 	pop af
 	ret nc
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -498,11 +498,11 @@ Func_858: ; 0x858
 
 LoadBillboardPaletteMap: ; 0x86f
 ; Loads the background palette map for a 6x4-tile billboard picture.
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, [rLCDC]
 	bit 7, a
@@ -538,7 +538,7 @@ LoadBillboardPaletteMap: ; 0x86f
 	xor a
 	ld [rVBK], a
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -575,16 +575,16 @@ LoadBillboardPaletteMap: ; 0x86f
 	dec b
 	jr nz, .asm_8ae
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
 Func_8e1: ; 0x8e1
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, [rLCDC]
 	bit 7, a
@@ -598,7 +598,7 @@ Func_8e1: ; 0x8e1
 	dec b
 	jr nz, .asm_8f5
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -613,6 +613,6 @@ Func_8e1: ; 0x8e1
 	dec b
 	jr nz, .asm_907
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret

--- a/home/ir.asm
+++ b/home/ir.asm
@@ -71,7 +71,7 @@ Func_1c32: ; 0x1c32
 
 Func_1c39:
 	xor a
-	ld [hNumFramesSinceLastVBlank], a
+	ldh [hNumFramesSinceLastVBlank], a
 	ld a, $1
 	ld [wd8e9], a
 .asm_1c41
@@ -80,7 +80,7 @@ Func_1c39:
 	ld a, [$ff00+c]
 	and b
 	jr z, Func_1c50
-	ld a, [hNumFramesSinceLastVBlank]
+	ldh a, [hNumFramesSinceLastVBlank]
 	and a
 	jr nz, Func_1ca1
 	jr .asm_1c41

--- a/home/joypad.asm
+++ b/home/joypad.asm
@@ -23,22 +23,22 @@ ReadJoypad: ; 0xab8
 	and $f
 	or b
 	cpl  ; a contains currently-pressed buttons
-	ld [hJoypadState], a
+	ldh [hJoypadState], a
 	ld a, $30
 	ld [rJOYP], a
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	ld hl, hPreviousJoypadState
 	xor [hl]  ; a contains buttons that are different from previous frame
 	push af
 	ld hl, hJoypadState
 	and [hl]  ; a contains newly-pressed buttons compared to last frame
-	ld [hNewlyPressedButtons], a
-	ld [hPressedButtons], a
+	ldh [hNewlyPressedButtons], a
+	ldh [hPressedButtons], a
 	pop af
 	ld hl, hPreviousJoypadState
 	and [hl]  ; a contains newly-pressed buttons compared to two frames ago
-	ld [hPrevPreviousJoypadState], a
-	ld a, [hJoypadState]
+	ldh [hPrevPreviousJoypadState], a
+	ldh a, [hJoypadState]
 	and a
 	jr z, .asm_b15
 	ld hl, hPreviousJoypadState
@@ -49,26 +49,26 @@ ReadJoypad: ; 0xab8
 	ld hl, hJoyRepeatDelay
 	dec [hl]
 	jr nz, .asm_b1a
-	ld a, [hJoypadState]
-	ld [hPressedButtons], a
+	ldh a, [hJoypadState]
+	ldh [hPressedButtons], a
 	ld a, [wd807]
-	ld [hJoyRepeatDelay], a
+	ldh [hJoyRepeatDelay], a
 	jr .asm_b1a
 
 .asm_b15
 	ld a, [wd806]
-	ld [hJoyRepeatDelay], a
+	ldh [hJoyRepeatDelay], a
 .asm_b1a
-	ld a, [hJoypadState]
-	ld [hPreviousJoypadState], a
+	ldh a, [hJoypadState]
+	ldh [hPreviousJoypadState], a
 	ld hl, wJoypadStatesPersistent
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	or [hl]
 	ld [hli], a
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	or [hl]
 	ld [hli], a
-	ld a, [hPressedButtons]
+	ldh a, [hPressedButtons]
 	or [hl]
 	ld [hli], a
 	ret
@@ -82,14 +82,14 @@ ClearPersistentJoypadStates: ; 0xb2e
 	ret
 
 IsKeyPressed2: ; 0xb36
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and [hl]
 	jr z, .asm_b3e
 	cp [hl]
 	jr z, .asm_b48
 .asm_b3e
 	inc hl
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and [hl]
 	ret z
 	cp [hl]
@@ -107,22 +107,22 @@ IsKeyPressed: ; 0xb4c
 ; input:   hl = pointer to key config byte pair (e.g. wKeyConfigLeftFlipper)
 ; output:  zero flag is set if a corresponding key is pressed
 ;          zero flag is reset if no corresponding key is pressed
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and [hl]
 	jr z, .asm_b58
 	cp [hl]
 	jr nz, .asm_b58
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and [hl]
 	ret nz
 .asm_b58
 	inc hl
-	ld a, [hJoypadState]
+	ldh a, [hJoypadState]
 	and [hl]
 	ret z
 	cp [hl]
 	jr nz, .asm_b64
-	ld a, [hNewlyPressedButtons]
+	ldh a, [hNewlyPressedButtons]
 	and [hl]
 	ret
 

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -1,12 +1,12 @@
 SetAllPalettesWhite: ; 0xb66
 ; Sets all BG and OBJ palettes to white.
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .gameboyColor
 	xor a
-	ld [hBGP], a
-	ld [hOBP0], a
-	ld [hOBP1], a
+	ldh [hBGP], a
+	ldh [hOBP0], a
+	ldh [hOBP1], a
 	ret
 
 .gameboyColor
@@ -65,7 +65,7 @@ SetAllPalettesWhite: ; 0xb66
 
 FadeIn: ; 0xbbe
 ; Fades palettes in from white screen.
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jp nz, FadeIn_GameboyColor
 	; Regular Gameboy
@@ -250,7 +250,7 @@ GetNextFadedPalette: ; 0xc60
 
 FadeOut: ; 0xcb5
 ; Fades palettes out to a white screen.
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jp nz, FadeOut_GameboyColor
 	; Regular Gameboy

--- a/home/sgb.asm
+++ b/home/sgb.asm
@@ -1,10 +1,10 @@
 FarSendSGBPackets: ; 0x12a1
 ; send 16*b bytes at a:hl via the joypad register
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, [hl]
 	and $7
@@ -48,7 +48,7 @@ FarSendSGBPackets: ; 0x12a1
 
 .quit
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
@@ -112,11 +112,11 @@ InitSGB: ; 0x12f8
 	ret
 
 FarSendSGBPacket_BGMapRows: ; 0x1353
-	ld [hROMBankBuffer], a
-	ld a, [hLoadedROMBank]
+	ldh [hROMBankBuffer], a
+	ldh a, [hLoadedROMBank]
 	push af
-	ld a, [hROMBankBuffer]
-	ld [hLoadedROMBank], a
+	ldh a, [hROMBankBuffer]
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	push af
 	push hl
@@ -149,17 +149,17 @@ FarSendSGBPacket_BGMapRows: ; 0x1353
 	call FarSendSGBPackets
 	ld bc, $0006
 	call SGBWait1750
-	ld a, [hBGP]
+	ldh a, [hBGP]
 	ld [rBGP], a
-	ld a, [hLCDC]
+	ldh a, [hLCDC]
 	ld [rLCDC], a
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 
 SendSGBBorder: ; 0x13a8
-	ld a, [hSGBFlag]
+	ldh a, [hSGBFlag]
 	and a
 	ret z
 	ld bc, $0078
@@ -243,10 +243,10 @@ SendSGBBorder: ; 0x13a8
 	ret
 
 SignalStartSGBBorderTransmission: ; 0x1489
-	ld a, [hSGBFlag]
+	ldh a, [hSGBFlag]
 	and a
 	ret z
-	ld a, [hSGBInit]
+	ldh a, [hSGBInit]
 	and a
 	ret nz
 	ld a, BANK(Data_3aa66)
@@ -255,16 +255,16 @@ SignalStartSGBBorderTransmission: ; 0x1489
 	ld bc, $0004
 	call SGBWait1750
 	ld a, $ff
-	ld [hSGBInit], a
+	ldh [hSGBInit], a
 	ret
 
 SGBNormal: ; 0x14a4
-	ld a, [hSGBFlag]
+	ldh a, [hSGBFlag]
 	and a
 	ret z
 	ld bc, $0002
 	call SGBWait1750
-	ld a, [hSGBInit]
+	ldh a, [hSGBInit]
 	and a
 	ret z
 	ld a, BANK(Data_3aa76)
@@ -273,5 +273,5 @@ SGBNormal: ; 0x14a4
 	ld bc, $0004
 	call SGBWait1750
 	xor a
-	ld [hSGBInit], a
+	ldh [hSGBInit], a
 	ret

--- a/home/text.asm
+++ b/home/text.asm
@@ -2,7 +2,7 @@ INCLUDE "text/scrolling_text.asm"
 
 EnableBottomText: ; 0x30db
 	ld a, $86
-	ld [hWY], a ;force text bar up
+	ldh [hWY], a ;force text bar up
 	ld a, $1
 	ld [wBottomTextEnabled], a
 	ld [wDisableDrawScoreboardInfo], a
@@ -186,7 +186,7 @@ LoadSpecialTextChar: ; 0x31e1 copy special font data into VRAM based on the cont
 	push de
 	push hl
 	ld c, a
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	ld a, c
 	jr z, .asm_31ed
@@ -682,7 +682,7 @@ UpdateBottomText: ; 0x33e3
 	ret nz ;if text has displayed, we are done, else
 	ld [wBottomTextEnabled], a ; disable bottom text
 	call FillBottomMessageBufferWithBlackTile ;fill with default data?
-	ld a, [hGameBoyColorFlag]
+	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .gameboyColor
 	ld a, Bank(StageRedFieldTopStatusBarSymbolsGfx_GameBoy)
@@ -702,9 +702,9 @@ UpdateBottomText: ; 0x33e3
 
 MainLoopUntilTextIsClear: ; 0x3475
 	xor a
-	ld [hJoypadState], a
-	ld [hNewlyPressedButtons], a
-	ld [hPressedButtons], a
+	ldh [hJoypadState], a
+	ldh [hNewlyPressedButtons], a
+	ldh [hPressedButtons], a
 	call HandleTilts
 	ld a, [wCurrentStage]
 	bit 0, a ;handle flippers if the stage has any

--- a/home/tilt.asm
+++ b/home/tilt.asm
@@ -204,10 +204,10 @@ ApplyTiltForces: ; 0x36c1
 	sla c
 	rl b
 	add hl, bc
-	ld a, [hLoadedROMBank]
+	ldh a, [hLoadedROMBank]
 	push af
 	ld a, BANK(TiltLeftOnlyForce)
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ld a, [wBallXVelocity]
 	add [hl]
@@ -225,7 +225,7 @@ ApplyTiltForces: ; 0x36c1
 	adc [hl]
 	ld [wBallYVelocity + 1], a
 	pop af
-	ld [hLoadedROMBank], a
+	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	ret
 

--- a/hram.asm
+++ b/hram.asm
@@ -1,63 +1,78 @@
-DEF hPushSprite EQU $FF80
+SECTION "HRAM", HRAM
 
-DEF hFarCallTempA EQU $FF8A
-DEF hFarCallTempE EQU $FF8B
-DEF hJoypadState  EQU $FF98  ; current state of buttons. See joy_constants.asm for which bits
-                             ; correspond to which buttons.
-DEF hNewlyPressedButtons      EQU $FF99  ; buttons that were pressed in the current frame.
-DEF hPressedButtons           EQU $FF9A  ; buttons that were pressed last frame and current frame(?)
-DEF hPrevPreviousJoypadState  EQU $FF9B  ; joypad state from two frames ago. See joy_constants.asm for
+hPushSprite :: ds 10 ; 0xFF80
+.end ::
+
+hFarCallTempA :: db ; 0xFF8A
+hFarCallTempE :: db ; 0xFF8B
+
+hRotationAngleBuffer :: db ; 0xFF8C
+hCosineResultBuffer  :: dw ; 0xFF8D
+hSineResultBuffer    :: dw ; 0xFF8F
+
+ds 7
+
+hJoypadState             :: db ; 0xFF98  ; current state of buttons. See joy_constants.asm for which bits
+                                         ; correspond to which buttons.
+hNewlyPressedButtons     :: db ; 0xFF99  ; buttons that were pressed in the current frame.
+hPressedButtons          :: db ; 0xFF9A  ; buttons that were pressed last frame and current frame(?)
+hPrevPreviousJoypadState :: db ; 0xFF9B  ; joypad state from two frames ago. See joy_constants.asm for
                                          ; which bits correspond to which buttons. (need a better name for this...)
-DEF hPreviousJoypadState  EQU $FF9C      ; prevoius frame's joypad state. See joy_constants.asm for
+hPreviousJoypadState     :: db ; 0xFF9C  ; previous frame's joypad state. See joy_constants.asm for
                                          ; which bits correspond to which buttons.
 
-DEF hJoyRepeatDelay EQU $FF9D
+hJoyRepeatDelay :: db ; 0xFF9D
 
-DEF hLCDC               EQU $FF9E
-DEF hSTAT               EQU $FF9F
-DEF hSCY                EQU $FFA0
-DEF hSCX                EQU $FFA1
-DEF hLYC                EQU $FFA2
-DEF hBGP                EQU $FFA3
-DEF hOBP0               EQU $FFA4
-DEF hOBP1               EQU $FFA5
-DEF hWY                 EQU $FFA6
-DEF hWX                 EQU $FFA7
-DEF hLastLYC            EQU $FFA8
-DEF hNextLYCSub         EQU $FFA9
-DEF hLYCSub             EQU $FFAA
-DEF hNextFrameHBlankSCX EQU $FFAB
-DEF hHBlankSCX          EQU $FFAC
-DEF hNextFrameHBlankSCY EQU $FFAD
-DEF hHBlankSCY          EQU $FFAE
-DEF hLCDCMask           EQU $FFAF
-DEF hStatIntrRoutine    EQU $FFB0
+hLCDC               :: db ; 0xFF9E
+hSTAT               :: db ; 0xFF9F
+hSCY                :: db ; 0xFFA0
+hSCX                :: db ; 0xFFA1
+hLYC                :: db ; 0xFFA2
+hBGP                :: db ; 0xFFA3
+hOBP0               :: db ; 0xFFA4
+hOBP1               :: db ; 0xFFA5
+hWY                 :: db ; 0xFFA6
+hWX                 :: db ; 0xFFA7
+hLastLYC            :: db ; 0xFFA8
+hNextLYCSub         :: db ; 0xFFA9
+hLYCSub             :: db ; 0xFFAA
+hNextFrameHBlankSCX :: db ; 0xFFAB
+hHBlankSCX          :: db ; 0xFFAC
+hNextFrameHBlankSCY :: db ; 0xFFAD
+hHBlankSCY          :: db ; 0xFFAE
+hLCDCMask           :: db ; 0xFFAF
+hStatIntrRoutine    :: db ; 0xFFB0
 
-DEF hNumFramesSinceLastVBlank EQU $FFB2
-DEF hFrameCounter             EQU $FFB3
-DEF hVBlankCount              EQU $FFB4
-DEF hStatIntrFired            EQU $FFB5
-DEF hSignedMathSignBuffer     EQU $FFB6
-DEF hSignedMathSignBuffer2    EQU $FFB7
+ds 1
 
-DEF hBallXPos EQU $FFBA
-DEF hBallYPos EQU $FFBC
+hNumFramesSinceLastVBlank :: db ; 0xFFB2
+hFrameCounter             :: db ; 0xFFB3
+hVBlankCount              :: db ; 0xFFB4
+hStatIntrFired            :: db ; 0xFFB5
+hSignedMathSignBuffer     :: db ; 0xFFB6
+hSignedMathSignBuffer2    :: db ; 0xFFB7
 
-DEF hFlipperStateChange   EQU $FFC0
-DEF hPreviousFlipperState EQU $FFC2
-DEF hFlipperState         EQU $FFC3
+ds 2
 
-DEF hRotationAngleBuffer EQU $FF8C
-DEF hCosineResultBuffer  EQU $FF8D
-DEF hSineResultBuffer    EQU $FF8F
+hBallXPos :: dw ; 0xFFBA
+hBallYPos :: dw ; 0xFFBC
 
-DEF hFlipperCollisionRadius  EQU $FFBF
+ds 1
 
-DEF hFFC4 = $FFC4
+hFlipperCollisionRadius  :: db ; 0xFFBF
 
-DEF hLoadedROMBank          EQU $FFF8  ; this is updated whenever the code switches ROM Banks
-DEF hROMBankBuffer          EQU $FFFA
-DEF hSGBFlag                EQU $FFFB
-DEF hSGBInit                EQU $FFFC
-DEF hGameBoyColorFlagBackup EQU $FFFD
-DEF hGameBoyColorFlag       EQU $FFFE  ; this is set to $01 if a GameBoy Color is running the game. $00, otherwise.
+hFlipperStateChange   :: dw ; 0xFFC0
+hPreviousFlipperState :: db ; 0xFFC2
+hFlipperState         :: db ; 0xFFC3
+
+hFFC4 :: db ; 0xFFC4
+
+SECTION "HRAM.2", HRAM
+
+hLoadedROMBank          :: db ; 0xFFF8  ; this is updated whenever the code switches ROM Banks
+ds 1
+hROMBankBuffer          :: db ; 0xFFFA
+hSGBFlag                :: db ; 0xFFFB
+hSGBInit                :: db ; 0xFFFC
+hGameBoyColorFlagBackup :: db ; 0xFFFD
+hGameBoyColorFlag       :: db ; 0xFFFE  ; this is set to $01 if a GameBoy Color is running the game. $00, otherwise.

--- a/hram.asm
+++ b/hram.asm
@@ -6,11 +6,38 @@ hPushSprite :: ds 10 ; 0xFF80
 hFarCallTempA :: db ; 0xFF8A
 hFarCallTempE :: db ; 0xFF8B
 
+	UNION
 hRotationAngleBuffer :: db ; 0xFF8C
 hCosineResultBuffer  :: dw ; 0xFF8D
 hSineResultBuffer    :: dw ; 0xFF8F
+	NEXTU
+hBillboardPicPointer        :: dw ; 0xFF8C
+hBillboardPicBank           :: db ; 0xFF8E
+hBillboardPaletteMapPointer :: dw ; 0xFF8F
+hBillboardPaletteMapBank    :: db ; 0xFF91
+	NEXTU
+hPokedexBillboardPaletteBank :: db ; 0xFF8C
+	NEXTU
+hFlippersFF8C :: db ; 0xFF8C
+hFlippersFF8D :: db ; 0xFF8D
+hFlippersFF8E :: db ; 0xFF8E
+	NEXTU
+hHighscoresFF8C :: dw ; 0xFF8C
+hHighscoresFF8E :: db ; 0xFF8E
+	NEXTU
+hVariableWidthFontFF8C :: db ; 0xFF8C
+hVariableWidthFontFF8D :: db ; 0xFF8D
+hVariableWidthFontFF8E :: db ; 0xFF8E
+hVariableWidthFontFF8F :: db ; 0xFF8F
+hVariableWidthFontFF90 :: db ; 0xFF90
+hVariableWidthFontFF91 :: db ; 0xFF91
+hVariableWidthFontFF92 :: db ; 0xFF92
+hVariableWidthFontFF93 :: db ; 0xFF93
+	ENDU
 
-ds 7
+hFF94 :: db ; 0xFF94
+hFF95 :: db ; 0xFF95
+ds 2
 
 hJoypadState             :: db ; 0xFF98  ; current state of buttons. See joy_constants.asm for which bits
                                          ; correspond to which buttons.
@@ -42,8 +69,7 @@ hNextFrameHBlankSCY :: db ; 0xFFAD
 hHBlankSCY          :: db ; 0xFFAE
 hLCDCMask           :: db ; 0xFFAF
 hStatIntrRoutine    :: db ; 0xFFB0
-
-ds 1
+hFFB1               :: db ; 0xFFB1
 
 hNumFramesSinceLastVBlank :: db ; 0xFFB2
 hFrameCounter             :: db ; 0xFFB3
@@ -57,7 +83,7 @@ ds 2
 hBallXPos :: dw ; 0xFFBA
 hBallYPos :: dw ; 0xFFBC
 
-ds 1
+hFFBE :: db ; 0xFFBE
 
 hFlipperCollisionRadius  :: db ; 0xFFBF
 

--- a/macros.asm
+++ b/macros.asm
@@ -77,7 +77,7 @@ MACRO bigdw ; big-endian word
 ENDM
 
 MACRO callba
-	ld [hFarCallTempA], a
+	ldh [hFarCallTempA], a
 	IF _NARG > 1
 		ld a, BANK(\2)
 		ld hl, \2


### PR DESCRIPTION
Aligning with how other pret repositories handle hram

- Use `ldh` when referring to hram labels, since ldh optimization doesn't work on labels and ldh optimization is being deprecated anyway
- add labels to the end of `DMARoutine` and `hPushSprite`, and `assert` that the allocated space in `hPushSprite` is the same as the space needed to copy `DMARoutine`
- Give labels to previously-unlabeled hram loads and stores
  - in regards to the `$FF8C` union: I didn't go out of my way to figure out what the variables mean, but I did try moving the variables out of the union and I didn't notice any oddities when I did so