### PR TITLE
Mass Renaming. Sha1 Verified

### DIFF
--- a/data/queued_tiledata/ball_upgrade.asm
+++ b/data/queued_tiledata/ball_upgrade.asm
@@ -63,7 +63,7 @@ TransitionToMasterBallPointers:
 	dw TransitionToMasterBall_TileData_11
 
 TransitionToPokeBall_TileData_1:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $40)
 	dw PinballPokeballGfx + $0
@@ -71,7 +71,7 @@ TransitionToPokeBall_TileData_1:
 	db $00
 
 TransitionToPokeBall_TileData_2:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $43)
 	dw PinballPokeballGfx + $30
@@ -79,7 +79,7 @@ TransitionToPokeBall_TileData_2:
 	db $00
 
 TransitionToPokeBall_TileData_3:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $46)
 	dw PinballPokeballGfx + $60
@@ -87,7 +87,7 @@ TransitionToPokeBall_TileData_3:
 	db $00
 
 TransitionToPokeBall_TileData_4:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $49)
 	dw PinballPokeballGfx + $90
@@ -95,7 +95,7 @@ TransitionToPokeBall_TileData_4:
 	db $00
 
 TransitionToPokeBall_TileData_5:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $4c)
 	dw PinballPokeballGfx + $c0
@@ -103,7 +103,7 @@ TransitionToPokeBall_TileData_5:
 	db $00
 
 TransitionToPokeBall_TileData_6:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $4f)
 	dw PinballPokeballGfx + $f0
@@ -111,7 +111,7 @@ TransitionToPokeBall_TileData_6:
 	db $00
 
 TransitionToPokeBall_TileData_7:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $52)
 	dw PinballPokeballGfx + $120
@@ -119,7 +119,7 @@ TransitionToPokeBall_TileData_7:
 	db $00
 
 TransitionToPokeBall_TileData_8:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $55)
 	dw PinballPokeballGfx + $150
@@ -127,7 +127,7 @@ TransitionToPokeBall_TileData_8:
 	db $00
 
 TransitionToPokeBall_TileData_9:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $58)
 	dw PinballPokeballGfx + $180
@@ -135,7 +135,7 @@ TransitionToPokeBall_TileData_9:
 	db $00
 
 TransitionToPokeBall_TileData_10:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $5b)
 	dw PinballPokeballGfx + $1b0
@@ -143,7 +143,7 @@ TransitionToPokeBall_TileData_10:
 	db $00
 
 TransitionToPokeBall_TileData_11:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw (vTilesOB tile $5e)
 	dw PinballPokeballGfx + $1e0
@@ -151,7 +151,7 @@ TransitionToPokeBall_TileData_11:
 	db $00
 
 TransitionToGreatBall_TileData_1:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $40)
 	dw PinballGreatballGfx + $0
@@ -159,7 +159,7 @@ TransitionToGreatBall_TileData_1:
 	db $00
 
 TransitionToGreatBall_TileData_2:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $43)
 	dw PinballGreatballGfx + $30
@@ -167,7 +167,7 @@ TransitionToGreatBall_TileData_2:
 	db $00
 
 TransitionToGreatBall_TileData_3:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $46)
 	dw PinballGreatballGfx + $60
@@ -175,7 +175,7 @@ TransitionToGreatBall_TileData_3:
 	db $00
 
 TransitionToGreatBall_TileData_4:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $49)
 	dw PinballGreatballGfx + $90
@@ -183,7 +183,7 @@ TransitionToGreatBall_TileData_4:
 	db $00
 
 TransitionToGreatBall_TileData_5:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $4c)
 	dw PinballGreatballGfx + $c0
@@ -191,7 +191,7 @@ TransitionToGreatBall_TileData_5:
 	db $00
 
 TransitionToGreatBall_TileData_6:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $4f)
 	dw PinballGreatballGfx + $f0
@@ -199,7 +199,7 @@ TransitionToGreatBall_TileData_6:
 	db $00
 
 TransitionToGreatBall_TileData_7:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $52)
 	dw PinballGreatballGfx + $120
@@ -207,7 +207,7 @@ TransitionToGreatBall_TileData_7:
 	db $00
 
 TransitionToGreatBall_TileData_8:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $55)
 	dw PinballGreatballGfx + $150
@@ -215,7 +215,7 @@ TransitionToGreatBall_TileData_8:
 	db $00
 
 TransitionToGreatBall_TileData_9:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $58)
 	dw PinballGreatballGfx + $180
@@ -223,7 +223,7 @@ TransitionToGreatBall_TileData_9:
 	db $00
 
 TransitionToGreatBall_TileData_10:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $5b)
 	dw PinballGreatballGfx + $1b0
@@ -231,7 +231,7 @@ TransitionToGreatBall_TileData_10:
 	db $00
 
 TransitionToGreatBall_TileData_11:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw (vTilesOB tile $5e)
 	dw PinballGreatballGfx + $1e0
@@ -239,7 +239,7 @@ TransitionToGreatBall_TileData_11:
 	db $00
 
 TransitionToUltraBall_TileData_1:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $40)
 	dw PinballUltraballGfx + $0
@@ -247,7 +247,7 @@ TransitionToUltraBall_TileData_1:
 	db $00
 
 TransitionToUltraBall_TileData_2:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $43)
 	dw PinballUltraballGfx + $30
@@ -255,7 +255,7 @@ TransitionToUltraBall_TileData_2:
 	db $00
 
 TransitionToUltraBall_TileData_3:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $46)
 	dw PinballUltraballGfx + $60
@@ -263,7 +263,7 @@ TransitionToUltraBall_TileData_3:
 	db $00
 
 TransitionToUltraBall_TileData_4:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $49)
 	dw PinballUltraballGfx + $90
@@ -271,7 +271,7 @@ TransitionToUltraBall_TileData_4:
 	db $00
 
 TransitionToUltraBall_TileData_5:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $4c)
 	dw PinballUltraballGfx + $c0
@@ -279,7 +279,7 @@ TransitionToUltraBall_TileData_5:
 	db $00
 
 TransitionToUltraBall_TileData_6:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $4f)
 	dw PinballUltraballGfx + $f0
@@ -287,7 +287,7 @@ TransitionToUltraBall_TileData_6:
 	db $00
 
 TransitionToUltraBall_TileData_7:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $52)
 	dw PinballUltraballGfx + $120
@@ -295,7 +295,7 @@ TransitionToUltraBall_TileData_7:
 	db $00
 
 TransitionToUltraBall_TileData_8:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $55)
 	dw PinballUltraballGfx + $150
@@ -303,7 +303,7 @@ TransitionToUltraBall_TileData_8:
 	db $00
 
 TransitionToUltraBall_TileData_9:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $58)
 	dw PinballUltraballGfx + $180
@@ -311,7 +311,7 @@ TransitionToUltraBall_TileData_9:
 	db $00
 
 TransitionToUltraBall_TileData_10:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $5b)
 	dw PinballUltraballGfx + $1b0
@@ -319,7 +319,7 @@ TransitionToUltraBall_TileData_10:
 	db $00
 
 TransitionToUltraBall_TileData_11:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw (vTilesOB tile $5e)
 	dw PinballUltraballGfx + $1e0
@@ -327,7 +327,7 @@ TransitionToUltraBall_TileData_11:
 	db $00
 
 TransitionToMasterBall_TileData_1:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $40)
 	dw PinballMasterballGfx + $0
@@ -335,7 +335,7 @@ TransitionToMasterBall_TileData_1:
 	db $00
 
 TransitionToMasterBall_TileData_2:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $43)
 	dw PinballMasterballGfx + $30
@@ -343,7 +343,7 @@ TransitionToMasterBall_TileData_2:
 	db $00
 
 TransitionToMasterBall_TileData_3:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $46)
 	dw PinballMasterballGfx + $60
@@ -351,7 +351,7 @@ TransitionToMasterBall_TileData_3:
 	db $00
 
 TransitionToMasterBall_TileData_4:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $49)
 	dw PinballMasterballGfx + $90
@@ -359,7 +359,7 @@ TransitionToMasterBall_TileData_4:
 	db $00
 
 TransitionToMasterBall_TileData_5:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $4c)
 	dw PinballMasterballGfx + $c0
@@ -367,7 +367,7 @@ TransitionToMasterBall_TileData_5:
 	db $00
 
 TransitionToMasterBall_TileData_6:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $4f)
 	dw PinballMasterballGfx + $f0
@@ -375,7 +375,7 @@ TransitionToMasterBall_TileData_6:
 	db $00
 
 TransitionToMasterBall_TileData_7:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $52)
 	dw PinballMasterballGfx + $120
@@ -383,7 +383,7 @@ TransitionToMasterBall_TileData_7:
 	db $00
 
 TransitionToMasterBall_TileData_8:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $55)
 	dw PinballMasterballGfx + $150
@@ -391,7 +391,7 @@ TransitionToMasterBall_TileData_8:
 	db $00
 
 TransitionToMasterBall_TileData_9:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $58)
 	dw PinballMasterballGfx + $180
@@ -399,7 +399,7 @@ TransitionToMasterBall_TileData_9:
 	db $00
 
 TransitionToMasterBall_TileData_10:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw (vTilesOB tile $5b)
 	dw PinballMasterballGfx + $1b0
@@ -407,7 +407,7 @@ TransitionToMasterBall_TileData_10:
 	db $00
 
 TransitionToMasterBall_TileData_11:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw (vTilesOB tile $5e)
 	dw PinballMasterballGfx + $1e0

--- a/data/queued_tiledata/billboard.asm
+++ b/data/queued_tiledata/billboard.asm
@@ -325,7 +325,7 @@ SlotOnBillboardTileDataList: ; 0x3046a
 	dw SlotOnBillboardTileData8
 
 PalletTownBillboardTileData1: ; 0x3047b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw PalletTownPic
@@ -333,7 +333,7 @@ PalletTownBillboardTileData1: ; 0x3047b
 	db $00
 
 PalletTownBillboardTileData2: ; 0x30485
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw PalletTownPic + $30
@@ -341,7 +341,7 @@ PalletTownBillboardTileData2: ; 0x30485
 	db $00
 
 PalletTownBillboardTileData3: ; 0x3048f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw PalletTownPic + $60
@@ -349,7 +349,7 @@ PalletTownBillboardTileData3: ; 0x3048f
 	db $00
 
 PalletTownBillboardTileData4: ; 0x30499
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw PalletTownPic + $90
@@ -357,7 +357,7 @@ PalletTownBillboardTileData4: ; 0x30499
 	db $00
 
 PalletTownBillboardTileData5: ; 0x304a3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw PalletTownPic + $C0
@@ -365,7 +365,7 @@ PalletTownBillboardTileData5: ; 0x304a3
 	db $00
 
 PalletTownBillboardTileData6: ; 0x304ad
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw PalletTownPic + $F0
@@ -373,7 +373,7 @@ PalletTownBillboardTileData6: ; 0x304ad
 	db $00
 
 PalletTownBillboardTileData7: ; 0x304b7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw PalletTownPic + $120
@@ -381,7 +381,7 @@ PalletTownBillboardTileData7: ; 0x304b7
 	db $00
 
 PalletTownBillboardTileData8: ; 0x304c1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw PalletTownPic + $150
@@ -389,7 +389,7 @@ PalletTownBillboardTileData8: ; 0x304c1
 	db $00
 
 ViridianCityBillboardTileData1: ; 0x304cb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw ViridianCityPic
@@ -397,7 +397,7 @@ ViridianCityBillboardTileData1: ; 0x304cb
 	db $00
 
 ViridianCityBillboardTileData2: ; 0x304d5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw ViridianCityPic + $30
@@ -405,7 +405,7 @@ ViridianCityBillboardTileData2: ; 0x304d5
 	db $00
 
 ViridianCityBillboardTileData3: ; 0x304df
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw ViridianCityPic + $60
@@ -413,7 +413,7 @@ ViridianCityBillboardTileData3: ; 0x304df
 	db $00
 
 ViridianCityBillboardTileData4: ; 0x304e9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw ViridianCityPic + $90
@@ -421,7 +421,7 @@ ViridianCityBillboardTileData4: ; 0x304e9
 	db $00
 
 ViridianCityBillboardTileData5: ; 0x304f3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw ViridianCityPic + $C0
@@ -429,7 +429,7 @@ ViridianCityBillboardTileData5: ; 0x304f3
 	db $00
 
 ViridianCityBillboardTileData6: ; 0x304fd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw ViridianCityPic + $F0
@@ -437,7 +437,7 @@ ViridianCityBillboardTileData6: ; 0x304fd
 	db $00
 
 ViridianCityBillboardTileData7: ; 0x30507
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw ViridianCityPic + $120
@@ -445,7 +445,7 @@ ViridianCityBillboardTileData7: ; 0x30507
 	db $00
 
 ViridianCityBillboardTileData8: ; 0x30511
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw ViridianCityPic + $150
@@ -453,7 +453,7 @@ ViridianCityBillboardTileData8: ; 0x30511
 	db $00
 
 ViridianForestBillboardTileData1: ; 0x3051b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw ViridianForestPic
@@ -461,7 +461,7 @@ ViridianForestBillboardTileData1: ; 0x3051b
 	db $00
 
 ViridianForestBillboardTileData2: ; 0x30525
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw ViridianForestPic + $30
@@ -469,7 +469,7 @@ ViridianForestBillboardTileData2: ; 0x30525
 	db $00
 
 ViridianForestBillboardTileData3: ; 0x3052f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw ViridianForestPic + $60
@@ -477,7 +477,7 @@ ViridianForestBillboardTileData3: ; 0x3052f
 	db $00
 
 ViridianForestBillboardTileData4: ; 0x30539
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw ViridianForestPic + $90
@@ -485,7 +485,7 @@ ViridianForestBillboardTileData4: ; 0x30539
 	db $00
 
 ViridianForestBillboardTileData5: ; 0x30543
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw ViridianForestPic + $C0
@@ -493,7 +493,7 @@ ViridianForestBillboardTileData5: ; 0x30543
 	db $00
 
 ViridianForestBillboardTileData6: ; 0x3054d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw ViridianForestPic + $F0
@@ -501,7 +501,7 @@ ViridianForestBillboardTileData6: ; 0x3054d
 	db $00
 
 ViridianForestBillboardTileData7: ; 0x30557
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw ViridianForestPic + $120
@@ -509,7 +509,7 @@ ViridianForestBillboardTileData7: ; 0x30557
 	db $00
 
 ViridianForestBillboardTileData8: ; 0x30561
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw ViridianForestPic + $150
@@ -517,7 +517,7 @@ ViridianForestBillboardTileData8: ; 0x30561
 	db $00
 
 PewterCityBillboardTileData1: ; 0x3056b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw PewterCityPic
@@ -525,7 +525,7 @@ PewterCityBillboardTileData1: ; 0x3056b
 	db $00
 
 PewterCityBillboardTileData2: ; 0x30575
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw PewterCityPic + $30
@@ -533,7 +533,7 @@ PewterCityBillboardTileData2: ; 0x30575
 	db $00
 
 PewterCityBillboardTileData3: ; 0x3057f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw PewterCityPic + $60
@@ -541,7 +541,7 @@ PewterCityBillboardTileData3: ; 0x3057f
 	db $00
 
 PewterCityBillboardTileData4: ; 0x30589
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw PewterCityPic + $90
@@ -549,7 +549,7 @@ PewterCityBillboardTileData4: ; 0x30589
 	db $00
 
 PewterCityBillboardTileData5: ; 0x30593
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw PewterCityPic + $C0
@@ -557,7 +557,7 @@ PewterCityBillboardTileData5: ; 0x30593
 	db $00
 
 PewterCityBillboardTileData6: ; 0x3059d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw PewterCityPic + $F0
@@ -565,7 +565,7 @@ PewterCityBillboardTileData6: ; 0x3059d
 	db $00
 
 PewterCityBillboardTileData7: ; 0x305a7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw PewterCityPic + $120
@@ -573,7 +573,7 @@ PewterCityBillboardTileData7: ; 0x305a7
 	db $00
 
 PewterCityBillboardTileData8: ; 0x305b1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw PewterCityPic + $150
@@ -581,7 +581,7 @@ PewterCityBillboardTileData8: ; 0x305b1
 	db $00
 
 MtMoonBillboardTileData1: ; 0x305bb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw MtMoonPic
@@ -589,7 +589,7 @@ MtMoonBillboardTileData1: ; 0x305bb
 	db $00
 
 MtMoonBillboardTileData2: ; 0x305c5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw MtMoonPic + $30
@@ -597,7 +597,7 @@ MtMoonBillboardTileData2: ; 0x305c5
 	db $00
 
 MtMoonBillboardTileData3: ; 0x305cf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw MtMoonPic + $60
@@ -605,7 +605,7 @@ MtMoonBillboardTileData3: ; 0x305cf
 	db $00
 
 MtMoonBillboardTileData4: ; 0x305d9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw MtMoonPic + $90
@@ -613,7 +613,7 @@ MtMoonBillboardTileData4: ; 0x305d9
 	db $00
 
 MtMoonBillboardTileData5: ; 0x305e3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw MtMoonPic + $C0
@@ -621,7 +621,7 @@ MtMoonBillboardTileData5: ; 0x305e3
 	db $00
 
 MtMoonBillboardTileData6: ; 0x305ed
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw MtMoonPic + $F0
@@ -629,7 +629,7 @@ MtMoonBillboardTileData6: ; 0x305ed
 	db $00
 
 MtMoonBillboardTileData7: ; 0x305f7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw MtMoonPic + $120
@@ -637,7 +637,7 @@ MtMoonBillboardTileData7: ; 0x305f7
 	db $00
 
 MtMoonBillboardTileData8: ; 0x30601
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw MtMoonPic + $150
@@ -645,7 +645,7 @@ MtMoonBillboardTileData8: ; 0x30601
 	db $00
 
 CeruleanCityBillboardTileData1: ; 0x3060b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw CeruleanCityPic
@@ -653,7 +653,7 @@ CeruleanCityBillboardTileData1: ; 0x3060b
 	db $00
 
 CeruleanCityBillboardTileData2: ; 0x30615
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw CeruleanCityPic + $30
@@ -661,7 +661,7 @@ CeruleanCityBillboardTileData2: ; 0x30615
 	db $00
 
 CeruleanCityBillboardTileData3: ; 0x3061f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw CeruleanCityPic + $60
@@ -669,7 +669,7 @@ CeruleanCityBillboardTileData3: ; 0x3061f
 	db $00
 
 CeruleanCityBillboardTileData4: ; 0x30629
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw CeruleanCityPic + $90
@@ -677,7 +677,7 @@ CeruleanCityBillboardTileData4: ; 0x30629
 	db $00
 
 CeruleanCityBillboardTileData5: ; 0x30633
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw CeruleanCityPic + $C0
@@ -685,7 +685,7 @@ CeruleanCityBillboardTileData5: ; 0x30633
 	db $00
 
 CeruleanCityBillboardTileData6: ; 0x3063d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw CeruleanCityPic + $F0
@@ -693,7 +693,7 @@ CeruleanCityBillboardTileData6: ; 0x3063d
 	db $00
 
 CeruleanCityBillboardTileData7: ; 0x30647
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw CeruleanCityPic + $120
@@ -701,7 +701,7 @@ CeruleanCityBillboardTileData7: ; 0x30647
 	db $00
 
 CeruleanCityBillboardTileData8: ; 0x30651
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw CeruleanCityPic + $150
@@ -709,7 +709,7 @@ CeruleanCityBillboardTileData8: ; 0x30651
 	db $00
 
 VermilionCitySeasideBillboardTileData1: ; 0x3065b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw VermilionCitySeasidePic
@@ -717,7 +717,7 @@ VermilionCitySeasideBillboardTileData1: ; 0x3065b
 	db $00
 
 VermilionCitySeasideBillboardTileData2: ; 0x30665
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw VermilionCitySeasidePic + $30
@@ -725,7 +725,7 @@ VermilionCitySeasideBillboardTileData2: ; 0x30665
 	db $00
 
 VermilionCitySeasideBillboardTileData3: ; 0x3066f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw VermilionCitySeasidePic + $60
@@ -733,7 +733,7 @@ VermilionCitySeasideBillboardTileData3: ; 0x3066f
 	db $00
 
 VermilionCitySeasideBillboardTileData4: ; 0x30679
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw VermilionCitySeasidePic + $90
@@ -741,7 +741,7 @@ VermilionCitySeasideBillboardTileData4: ; 0x30679
 	db $00
 
 VermilionCitySeasideBillboardTileData5: ; 0x30683
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw VermilionCitySeasidePic + $C0
@@ -749,7 +749,7 @@ VermilionCitySeasideBillboardTileData5: ; 0x30683
 	db $00
 
 VermilionCitySeasideBillboardTileData6: ; 0x3068d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw VermilionCitySeasidePic + $F0
@@ -757,7 +757,7 @@ VermilionCitySeasideBillboardTileData6: ; 0x3068d
 	db $00
 
 VermilionCitySeasideBillboardTileData7: ; 0x30697
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw VermilionCitySeasidePic + $120
@@ -765,7 +765,7 @@ VermilionCitySeasideBillboardTileData7: ; 0x30697
 	db $00
 
 VermilionCitySeasideBillboardTileData8: ; 0x306a1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw VermilionCitySeasidePic + $150
@@ -773,7 +773,7 @@ VermilionCitySeasideBillboardTileData8: ; 0x306a1
 	db $00
 
 VermilionCityStreetsBillboardTileData1: ; 0x306ab
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw VermilionCityStreetsPic
@@ -781,7 +781,7 @@ VermilionCityStreetsBillboardTileData1: ; 0x306ab
 	db $00
 
 VermilionCityStreetsBillboardTileData2: ; 0x306b5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw VermilionCityStreetsPic + $30
@@ -789,7 +789,7 @@ VermilionCityStreetsBillboardTileData2: ; 0x306b5
 	db $00
 
 VermilionCityStreetsBillboardTileData3: ; 0x306bf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw VermilionCityStreetsPic + $60
@@ -797,7 +797,7 @@ VermilionCityStreetsBillboardTileData3: ; 0x306bf
 	db $00
 
 VermilionCityStreetsBillboardTileData4: ; 0x306c9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw VermilionCityStreetsPic + $90
@@ -805,7 +805,7 @@ VermilionCityStreetsBillboardTileData4: ; 0x306c9
 	db $00
 
 VermilionCityStreetsBillboardTileData5: ; 0x306d3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw VermilionCityStreetsPic + $C0
@@ -813,7 +813,7 @@ VermilionCityStreetsBillboardTileData5: ; 0x306d3
 	db $00
 
 VermilionCityStreetsBillboardTileData6: ; 0x306dd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw VermilionCityStreetsPic + $F0
@@ -821,7 +821,7 @@ VermilionCityStreetsBillboardTileData6: ; 0x306dd
 	db $00
 
 VermilionCityStreetsBillboardTileData7: ; 0x306e7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw VermilionCityStreetsPic + $120
@@ -829,7 +829,7 @@ VermilionCityStreetsBillboardTileData7: ; 0x306e7
 	db $00
 
 VermilionCityStreetsBillboardTileData8: ; 0x306f1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw VermilionCityStreetsPic + $150
@@ -837,7 +837,7 @@ VermilionCityStreetsBillboardTileData8: ; 0x306f1
 	db $00
 
 RockMountainBillboardTileData1: ; 0x306fb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw RockMountainPic
@@ -845,7 +845,7 @@ RockMountainBillboardTileData1: ; 0x306fb
 	db $00
 
 RockMountainBillboardTileData2: ; 0x30705
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw RockMountainPic + $30
@@ -853,7 +853,7 @@ RockMountainBillboardTileData2: ; 0x30705
 	db $00
 
 RockMountainBillboardTileData3: ; 0x3070f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw RockMountainPic + $60
@@ -861,7 +861,7 @@ RockMountainBillboardTileData3: ; 0x3070f
 	db $00
 
 RockMountainBillboardTileData4: ; 0x30719
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw RockMountainPic + $90
@@ -869,7 +869,7 @@ RockMountainBillboardTileData4: ; 0x30719
 	db $00
 
 RockMountainBillboardTileData5: ; 0x30723
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw RockMountainPic + $C0
@@ -877,7 +877,7 @@ RockMountainBillboardTileData5: ; 0x30723
 	db $00
 
 RockMountainBillboardTileData6: ; 0x3072d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw RockMountainPic + $F0
@@ -885,7 +885,7 @@ RockMountainBillboardTileData6: ; 0x3072d
 	db $00
 
 RockMountainBillboardTileData7: ; 0x30737
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw RockMountainPic + $120
@@ -893,7 +893,7 @@ RockMountainBillboardTileData7: ; 0x30737
 	db $00
 
 RockMountainBillboardTileData8: ; 0x30741
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw RockMountainPic + $150
@@ -901,7 +901,7 @@ RockMountainBillboardTileData8: ; 0x30741
 	db $00
 
 LavenderTownBillboardTileData1: ; 0x3074b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw LavenderTownPic
@@ -909,7 +909,7 @@ LavenderTownBillboardTileData1: ; 0x3074b
 	db $00
 
 LavenderTownBillboardTileData2: ; 0x30755
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw LavenderTownPic + $30
@@ -917,7 +917,7 @@ LavenderTownBillboardTileData2: ; 0x30755
 	db $00
 
 LavenderTownBillboardTileData3: ; 0x3075f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw LavenderTownPic + $60
@@ -925,7 +925,7 @@ LavenderTownBillboardTileData3: ; 0x3075f
 	db $00
 
 LavenderTownBillboardTileData4: ; 0x30769
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw LavenderTownPic + $90
@@ -933,7 +933,7 @@ LavenderTownBillboardTileData4: ; 0x30769
 	db $00
 
 LavenderTownBillboardTileData5: ; 0x30773
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw LavenderTownPic + $C0
@@ -941,7 +941,7 @@ LavenderTownBillboardTileData5: ; 0x30773
 	db $00
 
 LavenderTownBillboardTileData6: ; 0x3077d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw LavenderTownPic + $F0
@@ -949,7 +949,7 @@ LavenderTownBillboardTileData6: ; 0x3077d
 	db $00
 
 LavenderTownBillboardTileData7: ; 0x30787
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw LavenderTownPic + $120
@@ -957,7 +957,7 @@ LavenderTownBillboardTileData7: ; 0x30787
 	db $00
 
 LavenderTownBillboardTileData8: ; 0x30791
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw LavenderTownPic + $150
@@ -965,7 +965,7 @@ LavenderTownBillboardTileData8: ; 0x30791
 	db $00
 
 CeladonCityBillboardTileData1: ; 0x3079b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw CeladonCityPic
@@ -973,7 +973,7 @@ CeladonCityBillboardTileData1: ; 0x3079b
 	db $00
 
 CeladonCityBillboardTileData2: ; 0x307a5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw CeladonCityPic + $30
@@ -981,7 +981,7 @@ CeladonCityBillboardTileData2: ; 0x307a5
 	db $00
 
 CeladonCityBillboardTileData3: ; 0x307af
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw CeladonCityPic + $60
@@ -989,7 +989,7 @@ CeladonCityBillboardTileData3: ; 0x307af
 	db $00
 
 CeladonCityBillboardTileData4: ; 0x307b9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw CeladonCityPic + $90
@@ -997,7 +997,7 @@ CeladonCityBillboardTileData4: ; 0x307b9
 	db $00
 
 CeladonCityBillboardTileData5: ; 0x307c3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw CeladonCityPic + $C0
@@ -1005,7 +1005,7 @@ CeladonCityBillboardTileData5: ; 0x307c3
 	db $00
 
 CeladonCityBillboardTileData6: ; 0x307cd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw CeladonCityPic + $F0
@@ -1013,7 +1013,7 @@ CeladonCityBillboardTileData6: ; 0x307cd
 	db $00
 
 CeladonCityBillboardTileData7: ; 0x307d7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw CeladonCityPic + $120
@@ -1021,7 +1021,7 @@ CeladonCityBillboardTileData7: ; 0x307d7
 	db $00
 
 CeladonCityBillboardTileData8: ; 0x307e1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw CeladonCityPic + $150
@@ -1029,7 +1029,7 @@ CeladonCityBillboardTileData8: ; 0x307e1
 	db $00
 
 CyclingRoadBillboardTileData1: ; 0x307eb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw CyclingRoadPic
@@ -1037,7 +1037,7 @@ CyclingRoadBillboardTileData1: ; 0x307eb
 	db $00
 
 CyclingRoadBillboardTileData2: ; 0x307f5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw CyclingRoadPic + $30
@@ -1045,7 +1045,7 @@ CyclingRoadBillboardTileData2: ; 0x307f5
 	db $00
 
 CyclingRoadBillboardTileData3: ; 0x307ff
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw CyclingRoadPic + $60
@@ -1053,7 +1053,7 @@ CyclingRoadBillboardTileData3: ; 0x307ff
 	db $00
 
 CyclingRoadBillboardTileData4: ; 0x30809
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw CyclingRoadPic + $90
@@ -1061,7 +1061,7 @@ CyclingRoadBillboardTileData4: ; 0x30809
 	db $00
 
 CyclingRoadBillboardTileData5: ; 0x30813
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw CyclingRoadPic + $C0
@@ -1069,7 +1069,7 @@ CyclingRoadBillboardTileData5: ; 0x30813
 	db $00
 
 CyclingRoadBillboardTileData6: ; 0x3081d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw CyclingRoadPic + $F0
@@ -1077,7 +1077,7 @@ CyclingRoadBillboardTileData6: ; 0x3081d
 	db $00
 
 CyclingRoadBillboardTileData7: ; 0x30827
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw CyclingRoadPic + $120
@@ -1085,7 +1085,7 @@ CyclingRoadBillboardTileData7: ; 0x30827
 	db $00
 
 CyclingRoadBillboardTileData8: ; 0x30831
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw CyclingRoadPic + $150
@@ -1093,7 +1093,7 @@ CyclingRoadBillboardTileData8: ; 0x30831
 	db $00
 
 FuchsiaCityBillboardTileData1: ; 0x3083b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw FuchsiaCityPic
@@ -1101,7 +1101,7 @@ FuchsiaCityBillboardTileData1: ; 0x3083b
 	db $00
 
 FuchsiaCityBillboardTileData2: ; 0x30845
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw FuchsiaCityPic + $30
@@ -1109,7 +1109,7 @@ FuchsiaCityBillboardTileData2: ; 0x30845
 	db $00
 
 FuchsiaCityBillboardTileData3: ; 0x3084f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw FuchsiaCityPic + $60
@@ -1117,7 +1117,7 @@ FuchsiaCityBillboardTileData3: ; 0x3084f
 	db $00
 
 FuchsiaCityBillboardTileData4: ; 0x30859
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw FuchsiaCityPic + $90
@@ -1125,7 +1125,7 @@ FuchsiaCityBillboardTileData4: ; 0x30859
 	db $00
 
 FuchsiaCityBillboardTileData5: ; 0x30863
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw FuchsiaCityPic + $C0
@@ -1133,7 +1133,7 @@ FuchsiaCityBillboardTileData5: ; 0x30863
 	db $00
 
 FuchsiaCityBillboardTileData6: ; 0x3086d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw FuchsiaCityPic + $F0
@@ -1141,7 +1141,7 @@ FuchsiaCityBillboardTileData6: ; 0x3086d
 	db $00
 
 FuchsiaCityBillboardTileData7: ; 0x30877
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw FuchsiaCityPic + $120
@@ -1149,7 +1149,7 @@ FuchsiaCityBillboardTileData7: ; 0x30877
 	db $00
 
 FuchsiaCityBillboardTileData8: ; 0x30881
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw FuchsiaCityPic + $150
@@ -1157,7 +1157,7 @@ FuchsiaCityBillboardTileData8: ; 0x30881
 	db $00
 
 SafariZoneBillboardTileData1: ; 0x3088b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw SafariZonePic
@@ -1165,7 +1165,7 @@ SafariZoneBillboardTileData1: ; 0x3088b
 	db $00
 
 SafariZoneBillboardTileData2: ; 0x30895
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw SafariZonePic + $30
@@ -1173,7 +1173,7 @@ SafariZoneBillboardTileData2: ; 0x30895
 	db $00
 
 SafariZoneBillboardTileData3: ; 0x3089f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw SafariZonePic + $60
@@ -1181,7 +1181,7 @@ SafariZoneBillboardTileData3: ; 0x3089f
 	db $00
 
 SafariZoneBillboardTileData4: ; 0x308a9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw SafariZonePic + $90
@@ -1189,7 +1189,7 @@ SafariZoneBillboardTileData4: ; 0x308a9
 	db $00
 
 SafariZoneBillboardTileData5: ; 0x308b3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw SafariZonePic + $C0
@@ -1197,7 +1197,7 @@ SafariZoneBillboardTileData5: ; 0x308b3
 	db $00
 
 SafariZoneBillboardTileData6: ; 0x308bd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw SafariZonePic + $F0
@@ -1205,7 +1205,7 @@ SafariZoneBillboardTileData6: ; 0x308bd
 	db $00
 
 SafariZoneBillboardTileData7: ; 0x308c7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw SafariZonePic + $120
@@ -1213,7 +1213,7 @@ SafariZoneBillboardTileData7: ; 0x308c7
 	db $00
 
 SafariZoneBillboardTileData8: ; 0x308d1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw SafariZonePic + $150
@@ -1221,7 +1221,7 @@ SafariZoneBillboardTileData8: ; 0x308d1
 	db $00
 
 SaffronCityBillboardTileData1: ; 0x308db
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw SaffronCityPic
@@ -1229,7 +1229,7 @@ SaffronCityBillboardTileData1: ; 0x308db
 	db $00
 
 SaffronCityBillboardTileData2: ; 0x308e5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw SaffronCityPic + $30
@@ -1237,7 +1237,7 @@ SaffronCityBillboardTileData2: ; 0x308e5
 	db $00
 
 SaffronCityBillboardTileData3: ; 0x308ef
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw SaffronCityPic + $60
@@ -1245,7 +1245,7 @@ SaffronCityBillboardTileData3: ; 0x308ef
 	db $00
 
 SaffronCityBillboardTileData4: ; 0x308f9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw SaffronCityPic + $90
@@ -1253,7 +1253,7 @@ SaffronCityBillboardTileData4: ; 0x308f9
 	db $00
 
 SaffronCityBillboardTileData5: ; 0x30903
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw SaffronCityPic + $C0
@@ -1261,7 +1261,7 @@ SaffronCityBillboardTileData5: ; 0x30903
 	db $00
 
 SaffronCityBillboardTileData6: ; 0x3090d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw SaffronCityPic + $F0
@@ -1269,7 +1269,7 @@ SaffronCityBillboardTileData6: ; 0x3090d
 	db $00
 
 SaffronCityBillboardTileData7: ; 0x30917
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw SaffronCityPic + $120
@@ -1277,7 +1277,7 @@ SaffronCityBillboardTileData7: ; 0x30917
 	db $00
 
 SaffronCityBillboardTileData8: ; 0x30921
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw SaffronCityPic + $150
@@ -1285,7 +1285,7 @@ SaffronCityBillboardTileData8: ; 0x30921
 	db $00
 
 SeafoamIslandsBillboardTileData1: ; 0x3092b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw SeafoamIslandsPic
@@ -1293,7 +1293,7 @@ SeafoamIslandsBillboardTileData1: ; 0x3092b
 	db $00
 
 SeafoamIslandsBillboardTileData2: ; 0x30935
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw SeafoamIslandsPic + $30
@@ -1301,7 +1301,7 @@ SeafoamIslandsBillboardTileData2: ; 0x30935
 	db $00
 
 SeafoamIslandsBillboardTileData3: ; 0x3093f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw SeafoamIslandsPic + $60
@@ -1309,7 +1309,7 @@ SeafoamIslandsBillboardTileData3: ; 0x3093f
 	db $00
 
 SeafoamIslandsBillboardTileData4: ; 0x30949
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw SeafoamIslandsPic + $90
@@ -1317,7 +1317,7 @@ SeafoamIslandsBillboardTileData4: ; 0x30949
 	db $00
 
 SeafoamIslandsBillboardTileData5: ; 0x30953
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw SeafoamIslandsPic + $C0
@@ -1325,7 +1325,7 @@ SeafoamIslandsBillboardTileData5: ; 0x30953
 	db $00
 
 SeafoamIslandsBillboardTileData6: ; 0x3095d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw SeafoamIslandsPic + $F0
@@ -1333,7 +1333,7 @@ SeafoamIslandsBillboardTileData6: ; 0x3095d
 	db $00
 
 SeafoamIslandsBillboardTileData7: ; 0x30967
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw SeafoamIslandsPic + $120
@@ -1341,7 +1341,7 @@ SeafoamIslandsBillboardTileData7: ; 0x30967
 	db $00
 
 SeafoamIslandsBillboardTileData8: ; 0x30971
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw SeafoamIslandsPic + $150
@@ -1349,7 +1349,7 @@ SeafoamIslandsBillboardTileData8: ; 0x30971
 	db $00
 
 CinnabarIslandBillboardTileData1: ; 0x3097b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw CinnabarIslandPic
@@ -1357,7 +1357,7 @@ CinnabarIslandBillboardTileData1: ; 0x3097b
 	db $00
 
 CinnabarIslandBillboardTileData2: ; 0x30985
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw CinnabarIslandPic + $30
@@ -1365,7 +1365,7 @@ CinnabarIslandBillboardTileData2: ; 0x30985
 	db $00
 
 CinnabarIslandBillboardTileData3: ; 0x3098f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw CinnabarIslandPic + $60
@@ -1373,7 +1373,7 @@ CinnabarIslandBillboardTileData3: ; 0x3098f
 	db $00
 
 CinnabarIslandBillboardTileData4: ; 0x30999
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw CinnabarIslandPic + $90
@@ -1381,7 +1381,7 @@ CinnabarIslandBillboardTileData4: ; 0x30999
 	db $00
 
 CinnabarIslandBillboardTileData5: ; 0x309a3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw CinnabarIslandPic + $C0
@@ -1389,7 +1389,7 @@ CinnabarIslandBillboardTileData5: ; 0x309a3
 	db $00
 
 CinnabarIslandBillboardTileData6: ; 0x309ad
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw CinnabarIslandPic + $F0
@@ -1397,7 +1397,7 @@ CinnabarIslandBillboardTileData6: ; 0x309ad
 	db $00
 
 CinnabarIslandBillboardTileData7: ; 0x309b7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw CinnabarIslandPic + $120
@@ -1405,7 +1405,7 @@ CinnabarIslandBillboardTileData7: ; 0x309b7
 	db $00
 
 CinnabarIslandBillboardTileData8: ; 0x309c1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw CinnabarIslandPic + $150
@@ -1413,7 +1413,7 @@ CinnabarIslandBillboardTileData8: ; 0x309c1
 	db $00
 
 IndigoPlateauBillboardTileData1: ; 0x309cb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw IndigoPlateauPic
@@ -1421,7 +1421,7 @@ IndigoPlateauBillboardTileData1: ; 0x309cb
 	db $00
 
 IndigoPlateauBillboardTileData2: ; 0x309d5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw IndigoPlateauPic + $30
@@ -1429,7 +1429,7 @@ IndigoPlateauBillboardTileData2: ; 0x309d5
 	db $00
 
 IndigoPlateauBillboardTileData3: ; 0x309df
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw IndigoPlateauPic + $60
@@ -1437,7 +1437,7 @@ IndigoPlateauBillboardTileData3: ; 0x309df
 	db $00
 
 IndigoPlateauBillboardTileData4: ; 0x309e9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw IndigoPlateauPic + $90
@@ -1445,7 +1445,7 @@ IndigoPlateauBillboardTileData4: ; 0x309e9
 	db $00
 
 IndigoPlateauBillboardTileData5: ; 0x309f3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw IndigoPlateauPic + $C0
@@ -1453,7 +1453,7 @@ IndigoPlateauBillboardTileData5: ; 0x309f3
 	db $00
 
 IndigoPlateauBillboardTileData6: ; 0x309fd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw IndigoPlateauPic + $F0
@@ -1461,7 +1461,7 @@ IndigoPlateauBillboardTileData6: ; 0x309fd
 	db $00
 
 IndigoPlateauBillboardTileData7: ; 0x30a07
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw IndigoPlateauPic + $120
@@ -1469,7 +1469,7 @@ IndigoPlateauBillboardTileData7: ; 0x30a07
 	db $00
 
 IndigoPlateauBillboardTileData8: ; 0x30a11
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw IndigoPlateauPic + $150
@@ -1477,7 +1477,7 @@ IndigoPlateauBillboardTileData8: ; 0x30a11
 	db $00
 
 HurryUp2OnBillboardTileData1: ; 0x30a1b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw HurryUp2OnPic
@@ -1485,7 +1485,7 @@ HurryUp2OnBillboardTileData1: ; 0x30a1b
 	db $00
 
 HurryUp2OnBillboardTileData2: ; 0x30a25
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw HurryUp2OnPic + $30
@@ -1493,7 +1493,7 @@ HurryUp2OnBillboardTileData2: ; 0x30a25
 	db $00
 
 HurryUp2OnBillboardTileData3: ; 0x30a2f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw HurryUp2OnPic + $60
@@ -1501,7 +1501,7 @@ HurryUp2OnBillboardTileData3: ; 0x30a2f
 	db $00
 
 HurryUp2OnBillboardTileData4: ; 0x30a39
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw HurryUp2OnPic + $90
@@ -1509,7 +1509,7 @@ HurryUp2OnBillboardTileData4: ; 0x30a39
 	db $00
 
 HurryUp2OnBillboardTileData5: ; 0x30a43
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw HurryUp2OnPic + $C0
@@ -1517,7 +1517,7 @@ HurryUp2OnBillboardTileData5: ; 0x30a43
 	db $00
 
 HurryUp2OnBillboardTileData6: ; 0x30a4d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw HurryUp2OnPic + $F0
@@ -1525,7 +1525,7 @@ HurryUp2OnBillboardTileData6: ; 0x30a4d
 	db $00
 
 HurryUp2OnBillboardTileData7: ; 0x30a57
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw HurryUp2OnPic + $120
@@ -1533,7 +1533,7 @@ HurryUp2OnBillboardTileData7: ; 0x30a57
 	db $00
 
 HurryUp2OnBillboardTileData8: ; 0x30a61
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw HurryUp2OnPic + $150
@@ -1541,7 +1541,7 @@ HurryUp2OnBillboardTileData8: ; 0x30a61
 	db $00
 
 HurryUpOnBillboardTileData1: ; 0x30a6b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw HurryUpOnPic
@@ -1549,7 +1549,7 @@ HurryUpOnBillboardTileData1: ; 0x30a6b
 	db $00
 
 HurryUpOnBillboardTileData2: ; 0x30a75
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw HurryUpOnPic + $30
@@ -1557,7 +1557,7 @@ HurryUpOnBillboardTileData2: ; 0x30a75
 	db $00
 
 HurryUpOnBillboardTileData3: ; 0x30a7f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw HurryUpOnPic + $60
@@ -1565,7 +1565,7 @@ HurryUpOnBillboardTileData3: ; 0x30a7f
 	db $00
 
 HurryUpOnBillboardTileData4: ; 0x30a89
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw HurryUpOnPic + $90
@@ -1573,7 +1573,7 @@ HurryUpOnBillboardTileData4: ; 0x30a89
 	db $00
 
 HurryUpOnBillboardTileData5: ; 0x30a93
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw HurryUpOnPic + $C0
@@ -1581,7 +1581,7 @@ HurryUpOnBillboardTileData5: ; 0x30a93
 	db $00
 
 HurryUpOnBillboardTileData6: ; 0x30a9d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw HurryUpOnPic + $F0
@@ -1589,7 +1589,7 @@ HurryUpOnBillboardTileData6: ; 0x30a9d
 	db $00
 
 HurryUpOnBillboardTileData7: ; 0x30aa7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw HurryUpOnPic + $120
@@ -1597,7 +1597,7 @@ HurryUpOnBillboardTileData7: ; 0x30aa7
 	db $00
 
 HurryUpOnBillboardTileData8: ; 0x30ab1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw HurryUpOnPic + $150
@@ -1605,7 +1605,7 @@ HurryUpOnBillboardTileData8: ; 0x30ab1
 	db $00
 
 GoToNextOnBillboardTileData1: ; 0x30abb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw GoToNextOnPic
@@ -1613,7 +1613,7 @@ GoToNextOnBillboardTileData1: ; 0x30abb
 	db $00
 
 GoToNextOnBillboardTileData2: ; 0x30ac5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw GoToNextOnPic + $30
@@ -1621,7 +1621,7 @@ GoToNextOnBillboardTileData2: ; 0x30ac5
 	db $00
 
 GoToNextOnBillboardTileData3: ; 0x30acf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw GoToNextOnPic + $60
@@ -1629,7 +1629,7 @@ GoToNextOnBillboardTileData3: ; 0x30acf
 	db $00
 
 GoToNextOnBillboardTileData4: ; 0x30ad9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw GoToNextOnPic + $90
@@ -1637,7 +1637,7 @@ GoToNextOnBillboardTileData4: ; 0x30ad9
 	db $00
 
 GoToNextOnBillboardTileData5: ; 0x30ae3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw GoToNextOnPic + $C0
@@ -1645,7 +1645,7 @@ GoToNextOnBillboardTileData5: ; 0x30ae3
 	db $00
 
 GoToNextOnBillboardTileData6: ; 0x30aed
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw GoToNextOnPic + $F0
@@ -1653,7 +1653,7 @@ GoToNextOnBillboardTileData6: ; 0x30aed
 	db $00
 
 GoToNextOnBillboardTileData7: ; 0x30af7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw GoToNextOnPic + $120
@@ -1661,7 +1661,7 @@ GoToNextOnBillboardTileData7: ; 0x30af7
 	db $00
 
 GoToNextOnBillboardTileData8: ; 0x30b01
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw GoToNextOnPic + $150
@@ -1669,7 +1669,7 @@ GoToNextOnBillboardTileData8: ; 0x30b01
 	db $00
 
 GoToGengarBonusOnBillboardTileData1: ; 0x30b0b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw GoToGengarBonusOnPic
@@ -1677,7 +1677,7 @@ GoToGengarBonusOnBillboardTileData1: ; 0x30b0b
 	db $00
 
 GoToGengarBonusOnBillboardTileData2: ; 0x30b15
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw GoToGengarBonusOnPic + $30
@@ -1685,7 +1685,7 @@ GoToGengarBonusOnBillboardTileData2: ; 0x30b15
 	db $00
 
 GoToGengarBonusOnBillboardTileData3: ; 0x30b1f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw GoToGengarBonusOnPic + $60
@@ -1693,7 +1693,7 @@ GoToGengarBonusOnBillboardTileData3: ; 0x30b1f
 	db $00
 
 GoToGengarBonusOnBillboardTileData4: ; 0x30b29
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw GoToGengarBonusOnPic + $90
@@ -1701,7 +1701,7 @@ GoToGengarBonusOnBillboardTileData4: ; 0x30b29
 	db $00
 
 GoToGengarBonusOnBillboardTileData5: ; 0x30b33
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw GoToGengarBonusOnPic + $C0
@@ -1709,7 +1709,7 @@ GoToGengarBonusOnBillboardTileData5: ; 0x30b33
 	db $00
 
 GoToGengarBonusOnBillboardTileData6: ; 0x30b3d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw GoToGengarBonusOnPic + $F0
@@ -1717,7 +1717,7 @@ GoToGengarBonusOnBillboardTileData6: ; 0x30b3d
 	db $00
 
 GoToGengarBonusOnBillboardTileData7: ; 0x30b47
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw GoToGengarBonusOnPic + $120
@@ -1725,7 +1725,7 @@ GoToGengarBonusOnBillboardTileData7: ; 0x30b47
 	db $00
 
 GoToGengarBonusOnBillboardTileData8: ; 0x30b51
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw GoToGengarBonusOnPic + $150
@@ -1733,7 +1733,7 @@ GoToGengarBonusOnBillboardTileData8: ; 0x30b51
 	db $00
 
 GoToMewtwoBonusOnBillboardTileData1: ; 0x30b5b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw GoToMewtwoBonusOnPic
@@ -1741,7 +1741,7 @@ GoToMewtwoBonusOnBillboardTileData1: ; 0x30b5b
 	db $00
 
 GoToMewtwoBonusOnBillboardTileData2: ; 0x30b65
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw GoToMewtwoBonusOnPic + $30
@@ -1749,7 +1749,7 @@ GoToMewtwoBonusOnBillboardTileData2: ; 0x30b65
 	db $00
 
 GoToMewtwoBonusOnBillboardTileData3: ; 0x30b6f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw GoToMewtwoBonusOnPic + $60
@@ -1757,7 +1757,7 @@ GoToMewtwoBonusOnBillboardTileData3: ; 0x30b6f
 	db $00
 
 GoToMewtwoBonusOnBillboardTileData4: ; 0x30b79
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw GoToMewtwoBonusOnPic + $90
@@ -1765,7 +1765,7 @@ GoToMewtwoBonusOnBillboardTileData4: ; 0x30b79
 	db $00
 
 GoToMewtwoBonusOnBillboardTileData5: ; 0x30b83
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw GoToMewtwoBonusOnPic + $C0
@@ -1773,7 +1773,7 @@ GoToMewtwoBonusOnBillboardTileData5: ; 0x30b83
 	db $00
 
 GoToMewtwoBonusOnBillboardTileData6: ; 0x30b8d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw GoToMewtwoBonusOnPic + $F0
@@ -1781,7 +1781,7 @@ GoToMewtwoBonusOnBillboardTileData6: ; 0x30b8d
 	db $00
 
 GoToMewtwoBonusOnBillboardTileData7: ; 0x30b97
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw GoToMewtwoBonusOnPic + $120
@@ -1789,7 +1789,7 @@ GoToMewtwoBonusOnBillboardTileData7: ; 0x30b97
 	db $00
 
 GoToMewtwoBonusOnBillboardTileData8: ; 0x30ba1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw GoToMewtwoBonusOnPic + $150
@@ -1797,7 +1797,7 @@ GoToMewtwoBonusOnBillboardTileData8: ; 0x30ba1
 	db $00
 
 GoToMeowthBonusOnBillboardTileData1: ; 0x30bab
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw GoToMeowthBonusOnPic
@@ -1805,7 +1805,7 @@ GoToMeowthBonusOnBillboardTileData1: ; 0x30bab
 	db $00
 
 GoToMeowthBonusOnBillboardTileData2: ; 0x30bb5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw GoToMeowthBonusOnPic + $30
@@ -1813,7 +1813,7 @@ GoToMeowthBonusOnBillboardTileData2: ; 0x30bb5
 	db $00
 
 GoToMeowthBonusOnBillboardTileData3: ; 0x30bbf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw GoToMeowthBonusOnPic + $60
@@ -1821,7 +1821,7 @@ GoToMeowthBonusOnBillboardTileData3: ; 0x30bbf
 	db $00
 
 GoToMeowthBonusOnBillboardTileData4: ; 0x30bc9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw GoToMeowthBonusOnPic + $90
@@ -1829,7 +1829,7 @@ GoToMeowthBonusOnBillboardTileData4: ; 0x30bc9
 	db $00
 
 GoToMeowthBonusOnBillboardTileData5: ; 0x30bd3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw GoToMeowthBonusOnPic + $C0
@@ -1837,7 +1837,7 @@ GoToMeowthBonusOnBillboardTileData5: ; 0x30bd3
 	db $00
 
 GoToMeowthBonusOnBillboardTileData6: ; 0x30bdd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw GoToMeowthBonusOnPic + $F0
@@ -1845,7 +1845,7 @@ GoToMeowthBonusOnBillboardTileData6: ; 0x30bdd
 	db $00
 
 GoToMeowthBonusOnBillboardTileData7: ; 0x30be7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw GoToMeowthBonusOnPic + $120
@@ -1853,7 +1853,7 @@ GoToMeowthBonusOnBillboardTileData7: ; 0x30be7
 	db $00
 
 GoToMeowthBonusOnBillboardTileData8: ; 0x30bf1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw GoToMeowthBonusOnPic + $150
@@ -1861,7 +1861,7 @@ GoToMeowthBonusOnBillboardTileData8: ; 0x30bf1
 	db $00
 
 GoToDiglettBonusOnBillboardTileData1: ; 0x30bfb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw GoToDiglettBonusOnPic
@@ -1869,7 +1869,7 @@ GoToDiglettBonusOnBillboardTileData1: ; 0x30bfb
 	db $00
 
 GoToDiglettBonusOnBillboardTileData2: ; 0x30c05
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw GoToDiglettBonusOnPic + $30
@@ -1877,7 +1877,7 @@ GoToDiglettBonusOnBillboardTileData2: ; 0x30c05
 	db $00
 
 GoToDiglettBonusOnBillboardTileData3: ; 0x30c0f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw GoToDiglettBonusOnPic + $60
@@ -1885,7 +1885,7 @@ GoToDiglettBonusOnBillboardTileData3: ; 0x30c0f
 	db $00
 
 GoToDiglettBonusOnBillboardTileData4: ; 0x30c19
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw GoToDiglettBonusOnPic + $90
@@ -1893,7 +1893,7 @@ GoToDiglettBonusOnBillboardTileData4: ; 0x30c19
 	db $00
 
 GoToDiglettBonusOnBillboardTileData5: ; 0x30c23
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw GoToDiglettBonusOnPic + $C0
@@ -1901,7 +1901,7 @@ GoToDiglettBonusOnBillboardTileData5: ; 0x30c23
 	db $00
 
 GoToDiglettBonusOnBillboardTileData6: ; 0x30c2d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw GoToDiglettBonusOnPic + $F0
@@ -1909,7 +1909,7 @@ GoToDiglettBonusOnBillboardTileData6: ; 0x30c2d
 	db $00
 
 GoToDiglettBonusOnBillboardTileData7: ; 0x30c37
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw GoToDiglettBonusOnPic + $120
@@ -1917,7 +1917,7 @@ GoToDiglettBonusOnBillboardTileData7: ; 0x30c37
 	db $00
 
 GoToDiglettBonusOnBillboardTileData8: ; 0x30c41
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw GoToDiglettBonusOnPic + $150
@@ -1925,7 +1925,7 @@ GoToDiglettBonusOnBillboardTileData8: ; 0x30c41
 	db $00
 
 GoToSeelBonusOnBillboardTileData1: ; 0x30c4b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw GoToSeelBonusOnPic
@@ -1933,7 +1933,7 @@ GoToSeelBonusOnBillboardTileData1: ; 0x30c4b
 	db $00
 
 GoToSeelBonusOnBillboardTileData2: ; 0x30c55
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw GoToSeelBonusOnPic + $30
@@ -1941,7 +1941,7 @@ GoToSeelBonusOnBillboardTileData2: ; 0x30c55
 	db $00
 
 GoToSeelBonusOnBillboardTileData3: ; 0x30c5f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw GoToSeelBonusOnPic + $60
@@ -1949,7 +1949,7 @@ GoToSeelBonusOnBillboardTileData3: ; 0x30c5f
 	db $00
 
 GoToSeelBonusOnBillboardTileData4: ; 0x30c69
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw GoToSeelBonusOnPic + $90
@@ -1957,7 +1957,7 @@ GoToSeelBonusOnBillboardTileData4: ; 0x30c69
 	db $00
 
 GoToSeelBonusOnBillboardTileData5: ; 0x30c73
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw GoToSeelBonusOnPic + $C0
@@ -1965,7 +1965,7 @@ GoToSeelBonusOnBillboardTileData5: ; 0x30c73
 	db $00
 
 GoToSeelBonusOnBillboardTileData6: ; 0x30c7d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw GoToSeelBonusOnPic + $F0
@@ -1973,7 +1973,7 @@ GoToSeelBonusOnBillboardTileData6: ; 0x30c7d
 	db $00
 
 GoToSeelBonusOnBillboardTileData7: ; 0x30c87
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw GoToSeelBonusOnPic + $120
@@ -1981,7 +1981,7 @@ GoToSeelBonusOnBillboardTileData7: ; 0x30c87
 	db $00
 
 GoToSeelBonusOnBillboardTileData8: ; 0x30c91
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw GoToSeelBonusOnPic + $150
@@ -1989,7 +1989,7 @@ GoToSeelBonusOnBillboardTileData8: ; 0x30c91
 	db $00
 
 SlotOnBillboardTileData1: ; 0x30c9b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $10
 	dw SlotOnPic
@@ -1997,7 +1997,7 @@ SlotOnBillboardTileData1: ; 0x30c9b
 	db $00
 
 SlotOnBillboardTileData2: ; 0x30ca5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $13
 	dw SlotOnPic + $30
@@ -2005,7 +2005,7 @@ SlotOnBillboardTileData2: ; 0x30ca5
 	db $00
 
 SlotOnBillboardTileData3: ; 0x30caf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $16
 	dw SlotOnPic + $60
@@ -2013,7 +2013,7 @@ SlotOnBillboardTileData3: ; 0x30caf
 	db $00
 
 SlotOnBillboardTileData4: ; 0x30cb9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $19
 	dw SlotOnPic + $90
@@ -2021,7 +2021,7 @@ SlotOnBillboardTileData4: ; 0x30cb9
 	db $00
 
 SlotOnBillboardTileData5: ; 0x30cc3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1C
 	dw SlotOnPic + $C0
@@ -2029,7 +2029,7 @@ SlotOnBillboardTileData5: ; 0x30cc3
 	db $00
 
 SlotOnBillboardTileData6: ; 0x30ccd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $1F
 	dw SlotOnPic + $F0
@@ -2037,7 +2037,7 @@ SlotOnBillboardTileData6: ; 0x30ccd
 	db $00
 
 SlotOnBillboardTileData7: ; 0x30cd7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $22
 	dw SlotOnPic + $120
@@ -2045,7 +2045,7 @@ SlotOnBillboardTileData7: ; 0x30cd7
 	db $00
 
 SlotOnBillboardTileData8: ; 0x30ce1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $25
 	dw SlotOnPic + $150
@@ -2226,7 +2226,7 @@ PalletTownBillboardBGPaletteData: ; 0x30da8
 	db $00 ; terminator
 
 PalletTownBillboardBGPaletteMapData: ; 0x30db1
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2261,7 +2261,7 @@ ViridianCityBillboardBGPaletteData: ; 0x30dcd
 	db $00 ; terminator
 
 ViridianCityBillboardBGPaletteMapData: ; 0x30dd6
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2296,7 +2296,7 @@ ViridianForestBillboardBGPaletteData: ; 0x30df2
 	db $00 ; terminator
 
 ViridianForestBillboardBGPaletteMapData: ; 0x30dfb
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2331,7 +2331,7 @@ PewterCityBillboardBGPaletteData: ; 0x30e17
 	db $00 ; terminator
 
 PewterCityBillboardBGPaletteMapData: ; 0x30e20
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2366,7 +2366,7 @@ MtMoonBillboardBGPaletteData: ; 0x30e3c
 	db $00 ; terminator
 
 MtMoonBillboardBGPaletteMapData: ; 0x30e45
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2401,7 +2401,7 @@ CeruleanCityBillboardBGPaletteData: ; 0x30e61
 	db $00 ; terminator
 
 CeruleanCityBillboardBGPaletteMapData: ; 0x30e6a
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2436,7 +2436,7 @@ VermilionSeasideBillboardBGPaletteData: ; 0x30e86
 	db $00 ; terminator
 
 VermilionSeasideBillboardBGPaletteMapData: ; 0x30e8f
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2471,7 +2471,7 @@ VermilionStreetsBillboardBGPaletteData: ; 0x30eab
 	db $00 ; terminator
 
 VermilionStreetsBillboardBGPaletteMapData: ; 0x30eb4
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2506,7 +2506,7 @@ RockMountainBillboardBGPaletteData: ; 0x30ed0
 	db $00 ; terminator
 
 RockMountainBillboardBGPaletteMapData: ; 0x30ed9
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2541,7 +2541,7 @@ LavenderTownBillboardBGPaletteData: ; 0x30ef5
 	db $00 ; terminator
 
 LavenderTownBillboardBGPaletteMapData: ; 0x30efe
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2576,7 +2576,7 @@ CeladonCityBillboardBGPaletteData: ; 0x30f1a
 	db $00 ; terminator
 
 CeladonCityBillboardBGPaletteMapData: ; 0x30f23
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2611,7 +2611,7 @@ CyclingRoadBillboardBGPaletteData: ; 0x30f3f
 	db $00 ; terminator
 
 CyclingRoadBillboardBGPaletteMapData: ; 0x30f48
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2646,7 +2646,7 @@ FuchsiaCityBillboardBGPaletteData: ; 0x30f64
 	db $00 ; terminator
 
 FuchsiaCityBillboardBGPaletteMapData: ; 0x30f6d
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2681,7 +2681,7 @@ SafariZoneBillboardBGPaletteData: ; 0x30f89
 	db $00 ; terminator
 
 SafariZoneBillboardBGPaletteMapData: ; 0x30f92
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2716,7 +2716,7 @@ SaffronCityBillboardBGPaletteData: ; 0x30fae
 	db $00 ; terminator
 
 SaffronCityBillboardBGPaletteMapData: ; 0x30fb7
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2751,7 +2751,7 @@ SeafoamIslandsBillboardBGPaletteData: ; 0x30fd3
 	db $00 ; terminator
 
 SeafoamIslandsBillboardBGPaletteMapData: ; 0x30fdc
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2786,7 +2786,7 @@ CinnabarIslandBillboardBGPaletteData: ; 0x30ff8
 	db $00 ; terminator
 
 CinnabarIslandBillboardBGPaletteMapData: ; 0x31001
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2821,7 +2821,7 @@ IndigoPlateauBillboardBGPaletteData: ; 0x3101d
 	db $00 ; terminator
 
 IndigoPlateauBillboardBGPaletteMapData: ; 0x31026
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2856,7 +2856,7 @@ HurryUp2OnBillboardBGPaletteData: ; 0x31042
 	db $00 ; terminator
 
 HurryUp2OnBillboardBGPaletteMapData: ; 0x3104b
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2891,7 +2891,7 @@ HurryUpOnBillboardBGPaletteData: ; 0x31067
 	db $00 ; terminator
 
 HurryUpOnBillboardBGPaletteMapData: ; 0x31070
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2926,7 +2926,7 @@ GoToNextOnBillboardBGPaletteData: ; 0x3108c
 	db $00 ; terminator
 
 GoToNextOnBillboardBGPaletteMapData: ; 0x31095
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2961,7 +2961,7 @@ GoToGengarBonusOnBillboardBGPaletteData: ; 0x310b1
 	db $00 ; terminator
 
 GoToGengarBonusOnBillboardBGPaletteMapData: ; 0x310ba
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -2996,7 +2996,7 @@ GoToMewtwoBonusOnBillboardBGPaletteData: ; 0x310d6
 	db $00 ; terminator
 
 GoToMewtwoBonusOnBillboardBGPaletteMapData: ; 0x310df
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -3031,7 +3031,7 @@ GoToMeowthBonusOnBillboardBGPaletteData: ; 0x310fb
 	db $00 ; terminator
 
 GoToMeowthBonusOnBillboardBGPaletteMapData: ; 0x31104
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -3066,7 +3066,7 @@ GoToDiglettBonusOnBillboardBGPaletteData: ; 0x31120
 	db $00 ; terminator
 
 GoToDiglettBonusOnBillboardBGPaletteMapData: ; 0x31129
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -3101,7 +3101,7 @@ GoToSeelBonusOnBillboardBGPaletteData: ; 0x31145
 	db $00 ; terminator
 
 GoToSeelBonusOnBillboardBGPaletteMapData: ; 0x3114e
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes
@@ -3136,7 +3136,7 @@ SlotOnBillboardBGPaletteData: ; 0x3116a
 	db $00 ; terminator
 
 SlotOnBillboardBGPaletteMapData: ; 0x31173
-	dw Func_122e
+	dw LoadVRAMTilemapData
 	db $18 ; total number of bytes
 
 	db $06 ; number of bytes

--- a/data/queued_tiledata/blue_field/arrow_indicators.asm
+++ b/data/queued_tiledata/blue_field/arrow_indicators.asm
@@ -314,7 +314,7 @@ TileData_1ec79: ; 0x1ec79
 	db $00 ; terminator
 
 TileData_1ec89: ; 0x1ec89
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $15
 	dw StageBlueFieldBottomBaseGameBoyGfx + $950
@@ -322,7 +322,7 @@ TileData_1ec89: ; 0x1ec89
 	db $00
 
 TileData_1ec93: ; 0x1ec93
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $15
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1F40
@@ -330,7 +330,7 @@ TileData_1ec93: ; 0x1ec93
 	db $00
 
 TileData_1ec9d: ; 0x1ec9d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $15
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1F60
@@ -338,7 +338,7 @@ TileData_1ec9d: ; 0x1ec9d
 	db $00
 
 TileData_1eca7: ; 0x1eca7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $15
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1F80
@@ -346,7 +346,7 @@ TileData_1eca7: ; 0x1eca7
 	db $00
 
 TileData_1ecb1: ; 0x1ecb1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $19
 	dw StageBlueFieldBottomBaseGameBoyGfx + $990
@@ -354,7 +354,7 @@ TileData_1ecb1: ; 0x1ecb1
 	db $00
 
 TileData_1ecbb: ; 0x1ecbb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1B
 	dw StageBlueFieldBottomBaseGameBoyGfx + $9B0
@@ -362,7 +362,7 @@ TileData_1ecbb: ; 0x1ecbb
 	db $00
 
 TileData_1ecc5: ; 0x1ecc5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $19
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2270
@@ -370,7 +370,7 @@ TileData_1ecc5: ; 0x1ecc5
 	db $00
 
 TileData_1eccf: ; 0x1eccf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1B
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2290
@@ -378,7 +378,7 @@ TileData_1eccf: ; 0x1eccf
 	db $00
 
 TileData_1ecd9: ; 0x1ecd9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $19
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $22B0
@@ -386,7 +386,7 @@ TileData_1ecd9: ; 0x1ecd9
 	db $00
 
 TileData_1ece3: ; 0x1ece3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1B
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $22D0
@@ -394,7 +394,7 @@ TileData_1ece3: ; 0x1ece3
 	db $00
 
 TileData_1eced: ; 0x1eced
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $19
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $22F0
@@ -402,7 +402,7 @@ TileData_1eced: ; 0x1eced
 	db $00
 
 TileData_1ecf7: ; 0x1ecf7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1B
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2310
@@ -410,7 +410,7 @@ TileData_1ecf7: ; 0x1ecf7
 	db $00
 
 TileData_1ed01: ; 0x1ed01
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $23
 	dw StageBlueFieldBottomBaseGameBoyGfx + $A30
@@ -418,7 +418,7 @@ TileData_1ed01: ; 0x1ed01
 	db $00
 
 TileData_1ed0b: ; 0x1ed0b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $25
 	dw StageBlueFieldBottomBaseGameBoyGfx + $A50
@@ -426,7 +426,7 @@ TileData_1ed0b: ; 0x1ed0b
 	db $00
 
 TileData_1ed15: ; 0x1ed15
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $23
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1C00
@@ -434,7 +434,7 @@ TileData_1ed15: ; 0x1ed15
 	db $00
 
 TileData_1ed1f: ; 0x1ed1f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $25
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1C20
@@ -442,7 +442,7 @@ TileData_1ed1f: ; 0x1ed1f
 	db $00
 
 TileData_1ed29: ; 0x1ed29
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $23
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1C40
@@ -450,7 +450,7 @@ TileData_1ed29: ; 0x1ed29
 	db $00
 
 TileData_1ed33: ; 0x1ed33
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $25
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1C60
@@ -458,7 +458,7 @@ TileData_1ed33: ; 0x1ed33
 	db $00
 
 TileData_1e3d: ; 0x1e3d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $23
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1C80
@@ -466,7 +466,7 @@ TileData_1e3d: ; 0x1e3d
 	db $00
 
 TileData_1ed47: ; 0x1ed47
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $25
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1CA0

--- a/data/queued_tiledata/blue_field/bonus_multiplier_railings.asm
+++ b/data/queued_tiledata/blue_field/bonus_multiplier_railings.asm
@@ -145,7 +145,7 @@ BonusMultiplierRailingTileData_1d761: ; 0x1d761
 	dw BonusMultiplierRailingTileData_1d93C
 
 BonusMultiplierRailingTileData_1d766: ; 0x1d766
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d60
@@ -153,7 +153,7 @@ BonusMultiplierRailingTileData_1d766: ; 0x1d766
 	db $00
 
 BonusMultiplierRailingTileData_1d770: ; 0x1d770
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1cc0
@@ -161,7 +161,7 @@ BonusMultiplierRailingTileData_1d770: ; 0x1d770
 	db $00
 
 BonusMultiplierRailingTileData_1d77a: ; 0x1d77a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d70
@@ -169,7 +169,7 @@ BonusMultiplierRailingTileData_1d77a: ; 0x1d77a
 	db $00
 
 BonusMultiplierRailingTileData_1d784: ; 0x1d784
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1cd0
@@ -177,7 +177,7 @@ BonusMultiplierRailingTileData_1d784: ; 0x1d784
 	db $00
 
 BonusMultiplierRailingTileData_1d78e: ; 0x1d78e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d80
@@ -185,7 +185,7 @@ BonusMultiplierRailingTileData_1d78e: ; 0x1d78e
 	db $00
 
 BonusMultiplierRailingTileData_1d798: ; 0x1d798
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1ce0
@@ -193,7 +193,7 @@ BonusMultiplierRailingTileData_1d798: ; 0x1d798
 	db $00
 
 BonusMultiplierRailingTileData_1d7a2: ; 0x1d7a2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d90
@@ -201,7 +201,7 @@ BonusMultiplierRailingTileData_1d7a2: ; 0x1d7a2
 	db $00
 
 BonusMultiplierRailingTileData_1d7AC: ; 0x1d7AC
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1cf0
@@ -209,7 +209,7 @@ BonusMultiplierRailingTileData_1d7AC: ; 0x1d7AC
 	db $00
 
 BonusMultiplierRailingTileData_1d7b6: ; 0x1d7b6
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1da0
@@ -217,7 +217,7 @@ BonusMultiplierRailingTileData_1d7b6: ; 0x1d7b6
 	db $00
 
 BonusMultiplierRailingTileData_1d7C0: ; 0x1d7C0
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d00
@@ -225,7 +225,7 @@ BonusMultiplierRailingTileData_1d7C0: ; 0x1d7C0
 	db $00
 
 BonusMultiplierRailingTileData_1d7ca: ; 0x1d7ca
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1db0
@@ -233,7 +233,7 @@ BonusMultiplierRailingTileData_1d7ca: ; 0x1d7ca
 	db $00
 
 BonusMultiplierRailingTileData_1d7D4: ; 0x1d7D4
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d10
@@ -241,7 +241,7 @@ BonusMultiplierRailingTileData_1d7D4: ; 0x1d7D4
 	db $00
 
 BonusMultiplierRailingTileData_1d7de: ; 0x1d7de
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1dc0
@@ -249,7 +249,7 @@ BonusMultiplierRailingTileData_1d7de: ; 0x1d7de
 	db $00
 
 BonusMultiplierRailingTileData_1d7E8: ; 0x1d7E8
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d20
@@ -257,7 +257,7 @@ BonusMultiplierRailingTileData_1d7E8: ; 0x1d7E8
 	db $00
 
 BonusMultiplierRailingTileData_1d7f2: ; 0x1d7f2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1dd0
@@ -265,7 +265,7 @@ BonusMultiplierRailingTileData_1d7f2: ; 0x1d7f2
 	db $00
 
 BonusMultiplierRailingTileData_1d7FC: ; 0x1d7FC
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d30
@@ -273,7 +273,7 @@ BonusMultiplierRailingTileData_1d7FC: ; 0x1d7FC
 	db $00
 
 BonusMultiplierRailingTileData_1d806: ; 0x1d806
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1de0
@@ -281,7 +281,7 @@ BonusMultiplierRailingTileData_1d806: ; 0x1d806
 	db $00
 
 BonusMultiplierRailingTileData_1d810: ; 0x1d810
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d40
@@ -289,7 +289,7 @@ BonusMultiplierRailingTileData_1d810: ; 0x1d810
 	db $00
 
 BonusMultiplierRailingTileData_1d81a: ; 0x1d81a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $27
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1df0
@@ -297,7 +297,7 @@ BonusMultiplierRailingTileData_1d81a: ; 0x1d81a
 	db $00
 
 BonusMultiplierRailingTileData_1d824: ; 0x1d824
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1d50
@@ -305,7 +305,7 @@ BonusMultiplierRailingTileData_1d824: ; 0x1d824
 	db $00
 
 BonusMultiplierRailingTileData_1d82e: ; 0x1d82e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1ea0
@@ -313,7 +313,7 @@ BonusMultiplierRailingTileData_1d82e: ; 0x1d82e
 	db $00
 
 BonusMultiplierRailingTileData_1d838: ; 0x1d838
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e00
@@ -321,7 +321,7 @@ BonusMultiplierRailingTileData_1d838: ; 0x1d838
 	db $00
 
 BonusMultiplierRailingTileData_1d842: ; 0x1d842
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1eb0
@@ -329,7 +329,7 @@ BonusMultiplierRailingTileData_1d842: ; 0x1d842
 	db $00
 
 BonusMultiplierRailingTileData_1d84C: ; 0x1d84C
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e10
@@ -337,7 +337,7 @@ BonusMultiplierRailingTileData_1d84C: ; 0x1d84C
 	db $00
 
 BonusMultiplierRailingTileData_1d856: ; 0x1d856
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1ec0
@@ -345,7 +345,7 @@ BonusMultiplierRailingTileData_1d856: ; 0x1d856
 	db $00
 
 BonusMultiplierRailingTileData_1d860: ; 0x1d860
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e20
@@ -353,7 +353,7 @@ BonusMultiplierRailingTileData_1d860: ; 0x1d860
 	db $00
 
 BonusMultiplierRailingTileData_1d86a: ; 0x1d86a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1ed0
@@ -361,7 +361,7 @@ BonusMultiplierRailingTileData_1d86a: ; 0x1d86a
 	db $00
 
 BonusMultiplierRailingTileData_1d874: ; 0x1d874
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e30
@@ -369,7 +369,7 @@ BonusMultiplierRailingTileData_1d874: ; 0x1d874
 	db $00
 
 BonusMultiplierRailingTileData_1d87e: ; 0x1d87e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1ee0
@@ -377,7 +377,7 @@ BonusMultiplierRailingTileData_1d87e: ; 0x1d87e
 	db $00
 
 BonusMultiplierRailingTileData_1d888: ; 0x1d888
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e40
@@ -385,7 +385,7 @@ BonusMultiplierRailingTileData_1d888: ; 0x1d888
 	db $00
 
 BonusMultiplierRailingTileData_1d892: ; 0x1d892
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1ef0
@@ -393,7 +393,7 @@ BonusMultiplierRailingTileData_1d892: ; 0x1d892
 	db $00
 
 BonusMultiplierRailingTileData_1d89C: ; 0x1d89C
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e50
@@ -401,7 +401,7 @@ BonusMultiplierRailingTileData_1d89C: ; 0x1d89C
 	db $00
 
 BonusMultiplierRailingTileData_1d8a6: ; 0x1d8a6
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1f00
@@ -409,7 +409,7 @@ BonusMultiplierRailingTileData_1d8a6: ; 0x1d8a6
 	db $00
 
 BonusMultiplierRailingTileData_1d8B0: ; 0x1d8B0
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e60
@@ -417,7 +417,7 @@ BonusMultiplierRailingTileData_1d8B0: ; 0x1d8B0
 	db $00
 
 BonusMultiplierRailingTileData_1d8ba: ; 0x1d8ba
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1f10
@@ -425,7 +425,7 @@ BonusMultiplierRailingTileData_1d8ba: ; 0x1d8ba
 	db $00
 
 BonusMultiplierRailingTileData_1d8C4: ; 0x1d8C4
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e70
@@ -433,7 +433,7 @@ BonusMultiplierRailingTileData_1d8C4: ; 0x1d8C4
 	db $00
 
 BonusMultiplierRailingTileData_1d8ce: ; 0x1d8ce
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1f20
@@ -441,7 +441,7 @@ BonusMultiplierRailingTileData_1d8ce: ; 0x1d8ce
 	db $00
 
 BonusMultiplierRailingTileData_1d8D8: ; 0x1d8D8
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e80
@@ -449,7 +449,7 @@ BonusMultiplierRailingTileData_1d8D8: ; 0x1d8D8
 	db $00
 
 BonusMultiplierRailingTileData_1d8e2: ; 0x1d8e2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $28
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1f30
@@ -457,7 +457,7 @@ BonusMultiplierRailingTileData_1d8e2: ; 0x1d8e2
 	db $00
 
 BonusMultiplierRailingTileData_1d8EC: ; 0x1d8EC
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1e90
@@ -465,7 +465,7 @@ BonusMultiplierRailingTileData_1d8EC: ; 0x1d8EC
 	db $00
 
 BonusMultiplierRailingTileData_1d8f6: ; 0x1d8f6
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $29
 	dw StageBlueFieldBottomBaseGameBoyGfx + $A90
@@ -473,7 +473,7 @@ BonusMultiplierRailingTileData_1d8f6: ; 0x1d8f6
 	db $00
 
 BonusMultiplierRailingTileData_1d900: ; 0x1d900
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $2C
 	dw StageBlueFieldBottomBaseGameBoyGfx + $AC0
@@ -481,7 +481,7 @@ BonusMultiplierRailingTileData_1d900: ; 0x1d900
 	db $00
 
 BonusMultiplierRailingTileData_1d90a: ; 0x1d90a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $29
 	dw StageBlueFieldBottomBaseGameBoyGfx + $AE0
@@ -489,7 +489,7 @@ BonusMultiplierRailingTileData_1d90a: ; 0x1d90a
 	db $00
 
 BonusMultiplierRailingTileData_1d914: ; 0x1d914
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $2C
 	dw StageBlueFieldBottomBaseGameBoyGfx + $B10
@@ -497,7 +497,7 @@ BonusMultiplierRailingTileData_1d914: ; 0x1d914
 	db $00
 
 BonusMultiplierRailingTileData_1d91e: ; 0x1d91e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $33
 	dw StageBlueFieldBottomBaseGameBoyGfx + $B30
@@ -505,7 +505,7 @@ BonusMultiplierRailingTileData_1d91e: ; 0x1d91e
 	db $00
 
 BonusMultiplierRailingTileData_1d928: ; 0x1d928
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $36
 	dw StageBlueFieldBottomBaseGameBoyGfx + $B60
@@ -513,7 +513,7 @@ BonusMultiplierRailingTileData_1d928: ; 0x1d928
 	db $00
 
 BonusMultiplierRailingTileData_1d932: ; 0x1d932
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $33
 	dw StageBlueFieldBottomBaseGameBoyGfx + $B80
@@ -521,7 +521,7 @@ BonusMultiplierRailingTileData_1d932: ; 0x1d932
 	db $00
 
 BonusMultiplierRailingTileData_1d93C: ; 0x1d93C
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $36
 	dw StageBlueFieldBottomBaseGameBoyGfx + $BB0

--- a/data/queued_tiledata/blue_field/poliwag_psyduck.asm
+++ b/data/queued_tiledata/blue_field/poliwag_psyduck.asm
@@ -69,7 +69,7 @@ TileData_1df9f: ; 0x1df9f
 	db $00 ; terminator
 
 TileData_1dfab: ; 0x1dfab
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4E
 	dw StageBlueFieldBottomBaseGameBoyGfx + $CE0
@@ -77,7 +77,7 @@ TileData_1dfab: ; 0x1dfab
 	db $00
 
 TileData_1dfb5: ; 0x1dfb5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $51
 	dw StageBlueFieldBottomBaseGameBoyGfx + $D10
@@ -85,7 +85,7 @@ TileData_1dfb5: ; 0x1dfb5
 	db $00
 
 TileData_1dfbf: ; 0x1dfbf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4E
 	dw StageBlueFieldBottomBaseGameBoyGfx + $D30
@@ -93,7 +93,7 @@ TileData_1dfbf: ; 0x1dfbf
 	db $00
 
 TileData_1dfc9: ; 0x1dfc9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $51
 	dw StageBlueFieldBottomBaseGameBoyGfx + $D60
@@ -101,7 +101,7 @@ TileData_1dfc9: ; 0x1dfc9
 	db $00
 
 TileData_1dfd3: ; 0x1dfd3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $20B0
@@ -109,7 +109,7 @@ TileData_1dfd3: ; 0x1dfd3
 	db $00
 
 TileData_1dfdd: ; 0x1dfdd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $51
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $20E0
@@ -117,7 +117,7 @@ TileData_1dfdd: ; 0x1dfdd
 	db $00
 
 TileData_1dfe7: ; 0x1dfe7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2100
@@ -125,7 +125,7 @@ TileData_1dfe7: ; 0x1dfe7
 	db $00
 
 TileData_1dff1: ; 0x1dff1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $51
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2130
@@ -133,7 +133,7 @@ TileData_1dff1: ; 0x1dff1
 	db $00
 
 TileData_1dffb: ; 0x1dffb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2150
@@ -141,7 +141,7 @@ TileData_1dffb: ; 0x1dffb
 	db $00
 
 TileData_1e005: ; 0x1e005
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $51
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2180
@@ -369,7 +369,7 @@ TileData_1e0ed: ; 0x1e0ed
 	dw TileData_1e1cc
 
 TileData_1e0f0: ; 0x1e0f0
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageBlueFieldBottomBaseGameBoyGfx + $C10
@@ -377,7 +377,7 @@ TileData_1e0f0: ; 0x1e0f0
 	db $00
 
 TileData_1e0fa: ; 0x1e0fa
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageBlueFieldBottomBaseGameBoyGfx + $C40
@@ -385,7 +385,7 @@ TileData_1e0fa: ; 0x1e0fa
 	db $00
 
 TileData_1e104: ; 0x1e104
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $47
 	dw StageBlueFieldBottomBaseGameBoyGfx + $C70
@@ -393,7 +393,7 @@ TileData_1e104: ; 0x1e104
 	db $00
 
 TileData_1e10e: ; 0x1e10e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1FC0
@@ -401,7 +401,7 @@ TileData_1e10e: ; 0x1e10e
 	db $00
 
 TileData_1e118: ; 0x1e118
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2050
@@ -409,7 +409,7 @@ TileData_1e118: ; 0x1e118
 	db $00
 
 TileData_1e122: ; 0x1e122
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2080
@@ -417,7 +417,7 @@ TileData_1e122: ; 0x1e122
 	db $00
 
 TileData_1e12c: ; 0x1e12c
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1FF0
@@ -425,7 +425,7 @@ TileData_1e12c: ; 0x1e12c
 	db $00
 
 TileData_1e136: ; 0x1e136
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2050
@@ -433,7 +433,7 @@ TileData_1e136: ; 0x1e136
 	db $00
 
 TileData_1e140: ; 0x1e140
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2080
@@ -441,7 +441,7 @@ TileData_1e140: ; 0x1e140
 	db $00
 
 TileData_1e14a: ; 0x1e14a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2020
@@ -449,7 +449,7 @@ TileData_1e14a: ; 0x1e14a
 	db $00
 
 TileData_1e154: ; 0x1e154
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2050
@@ -457,7 +457,7 @@ TileData_1e154: ; 0x1e154
 	db $00
 
 TileData_1e15e: ; 0x1e15e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2080
@@ -465,7 +465,7 @@ TileData_1e15e: ; 0x1e15e
 	db $00
 
 TileData_1e168: ; 0x1e168
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $58
 	dw StageBlueFieldBottomBaseGameBoyGfx + $D80
@@ -473,7 +473,7 @@ TileData_1e168: ; 0x1e168
 	db $00
 
 TileData_1e172: ; 0x1e172
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $5A
 	dw StageBlueFieldBottomBaseGameBoyGfx + $DA0
@@ -481,7 +481,7 @@ TileData_1e172: ; 0x1e172
 	db $00
 
 TileData_1e17c: ; 0x1e17c
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $58
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $21A0
@@ -489,7 +489,7 @@ TileData_1e17c: ; 0x1e17c
 	db $00
 
 TileData_1e186: ; 0x1e186
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $5A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $21E0
@@ -497,7 +497,7 @@ TileData_1e186: ; 0x1e186
 	db $00
 
 TileData_1e190: ; 0x1e190
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $58
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $21A0
@@ -505,7 +505,7 @@ TileData_1e190: ; 0x1e190
 	db $00
 
 TileData_1e19a: ; 0x1e19a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $5A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2210
@@ -513,7 +513,7 @@ TileData_1e19a: ; 0x1e19a
 	db $00
 
 TileData_1e1a4: ; 0x1e1a4
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $58
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $21C0
@@ -521,7 +521,7 @@ TileData_1e1a4: ; 0x1e1a4
 	db $00
 
 TileData_1e1ae: ; 0x1e1ae
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $5A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2240
@@ -529,7 +529,7 @@ TileData_1e1ae: ; 0x1e1ae
 	db $00
 
 TileData_1e1b8: ; 0x1e1b8
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageBlueFieldBottomBaseGameBoyGfx + $C40
@@ -537,7 +537,7 @@ TileData_1e1b8: ; 0x1e1b8
 	db $00
 
 TileData_1e1c2: ; 0x1e1c2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $47
 	dw StageBlueFieldBottomBaseGameBoyGfx + $C70
@@ -545,7 +545,7 @@ TileData_1e1c2: ; 0x1e1c2
 	db $00
 
 TileData_1e1cc: ; 0x1e1cc
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $58
 	dw StageBlueFieldBottomBaseGameBoyGfx + $D80

--- a/data/queued_tiledata/blue_field/slot_cave.asm
+++ b/data/queued_tiledata/blue_field/slot_cave.asm
@@ -43,7 +43,7 @@ TileData_1e93f: ; 0x1e93f
 	db $00 ; terminator
 
 TileData_1e948: ; 0x1e948
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1F
 	dw StageBlueFieldBottomBaseGameBoyGfx + $9F0
@@ -51,7 +51,7 @@ TileData_1e948: ; 0x1e948
 	db $00
 
 TileData_1e952: ; 0x1e952
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $21
 	dw StageBlueFieldBottomBaseGameBoyGfx + $A10
@@ -59,7 +59,7 @@ TileData_1e952: ; 0x1e952
 	db $00
 
 TileData_1e95c: ; 0x1e95c
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1F
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1BC0
@@ -67,7 +67,7 @@ TileData_1e95c: ; 0x1e95c
 	db $00
 
 TileData_1e966: ; 0x1e966
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $21
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1BE0

--- a/data/queued_tiledata/blue_field/spinner.asm
+++ b/data/queued_tiledata/blue_field/spinner.asm
@@ -97,7 +97,7 @@ TileData_1cbcb: ; 0x1cbcb
 	dw TileData_1cd06
 
 TileData_1cbd0: ; 0xcbd0
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageBlueFieldTopBaseGameBoyGfx + $c20
@@ -105,7 +105,7 @@ TileData_1cbd0: ; 0xcbd0
 	db $00 ; terminator
 
 TileData_1cbda: ; 0xcbda
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageBlueFieldTopBaseGameBoyGfx + $c40
@@ -113,7 +113,7 @@ TileData_1cbda: ; 0xcbda
 	db $00 ; terminator
 
 TileData_1cbe4: ; 0xcbe4
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1800
@@ -121,7 +121,7 @@ TileData_1cbe4: ; 0xcbe4
 	db $00 ; terminator
 
 TileData_1cbee: ; 0xcbee
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1820
@@ -129,7 +129,7 @@ TileData_1cbee: ; 0xcbee
 	db $00 ; terminator
 
 TileData_1cbf8: ; 0xcbf8
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1840
@@ -137,7 +137,7 @@ TileData_1cbf8: ; 0xcbf8
 	db $00 ; terminator
 
 TileData_1cc02: ; 0xcc02
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1860
@@ -145,7 +145,7 @@ TileData_1cc02: ; 0xcc02
 	db $00 ; terminator
 
 TileData_1cc0c: ; 0xcc0c
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1880
@@ -153,7 +153,7 @@ TileData_1cc0c: ; 0xcc0c
 	db $00 ; terminator
 
 TileData_1cc16: ; 0xcc16
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $18A0
@@ -161,7 +161,7 @@ TileData_1cc16: ; 0xcc16
 	db $00 ; terminator
 
 TileData_1cc20: ; 0xcc20
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $18C0
@@ -169,7 +169,7 @@ TileData_1cc20: ; 0xcc20
 	db $00 ; terminator
 
 TileData_1cc2a: ; 0xcc2a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $18E0
@@ -177,7 +177,7 @@ TileData_1cc2a: ; 0xcc2a
 	db $00 ; terminator
 
 TileData_1cc34: ; 0xcc34
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1900
@@ -185,7 +185,7 @@ TileData_1cc34: ; 0xcc34
 	db $00 ; terminator
 
 TileData_1cc3e: ; 0xcc3e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1920
@@ -193,7 +193,7 @@ TileData_1cc3e: ; 0xcc3e
 	db $00 ; terminator
 
 TileData_1cc48: ; 0xcc48
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1940
@@ -201,7 +201,7 @@ TileData_1cc48: ; 0xcc48
 	db $00 ; terminator
 
 TileData_1cc52: ; 0xcc52
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1960
@@ -209,7 +209,7 @@ TileData_1cc52: ; 0xcc52
 	db $00 ; terminator
 
 TileData_1cc5c: ; 0xcc5c
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1980
@@ -217,7 +217,7 @@ TileData_1cc5c: ; 0xcc5c
 	db $00 ; terminator
 
 TileData_1cc66: ; 0xcc66
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $19A0
@@ -225,7 +225,7 @@ TileData_1cc66: ; 0xcc66
 	db $00 ; terminator
 
 TileData_1cc70: ; 0xcc70
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $19C0
@@ -233,7 +233,7 @@ TileData_1cc70: ; 0xcc70
 	db $00 ; terminator
 
 TileData_1cc7a: ; 0xcc7a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $19E0
@@ -241,7 +241,7 @@ TileData_1cc7a: ; 0xcc7a
 	db $00 ; terminator
 
 TileData_1cc84: ; 0xcc84
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1A00
@@ -249,7 +249,7 @@ TileData_1cc84: ; 0xcc84
 	db $00 ; terminator
 
 TileData_1cc8e: ; 0xcc8e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1A20
@@ -257,7 +257,7 @@ TileData_1cc8e: ; 0xcc8e
 	db $00 ; terminator
 
 TileData_1cc98: ; 0xcc98
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1A40
@@ -265,7 +265,7 @@ TileData_1cc98: ; 0xcc98
 	db $00 ; terminator
 
 TileData_1cca2: ; 0xcca2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1A60
@@ -273,7 +273,7 @@ TileData_1cca2: ; 0xcca2
 	db $00 ; terminator
 
 TileData_1ccac: ; 0xccac
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1A80
@@ -281,7 +281,7 @@ TileData_1ccac: ; 0xccac
 	db $00 ; terminator
 
 TileData_1ccb6: ; 0xccb6
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1AA0
@@ -289,7 +289,7 @@ TileData_1ccb6: ; 0xccb6
 	db $00 ; terminator
 
 TileData_1ccc0: ; 0xccc0
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1AC0
@@ -297,7 +297,7 @@ TileData_1ccc0: ; 0xccc0
 	db $00 ; terminator
 
 TileData_1ccca: ; 0xccca
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1AE0
@@ -305,7 +305,7 @@ TileData_1ccca: ; 0xccca
 	db $00 ; terminator
 
 TileData_1ccd4: ; 0xccd4
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1B00
@@ -313,7 +313,7 @@ TileData_1ccd4: ; 0xccd4
 	db $00 ; terminator
 
 TileData_1ccde: ; 0xccde
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1B20
@@ -321,7 +321,7 @@ TileData_1ccde: ; 0xccde
 	db $00 ; terminator
 
 TileData_1cce8: ; 0xcce8
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1B40
@@ -329,7 +329,7 @@ TileData_1cce8: ; 0xcce8
 	db $00 ; terminator
 
 TileData_1ccf2: ; 0xccf2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1B60
@@ -337,7 +337,7 @@ TileData_1ccf2: ; 0xccf2
 	db $00 ; terminator
 
 TileData_1ccfc: ; 0xccfc
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1B80
@@ -345,7 +345,7 @@ TileData_1ccfc: ; 0xccfc
 	db $00 ; terminator
 
 TileData_1cd06: ; 0xcd06
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $6E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1BA0

--- a/data/queued_tiledata/red_field/arrow_indicators.asm
+++ b/data/queued_tiledata/red_field/arrow_indicators.asm
@@ -118,7 +118,7 @@ TileData_16a6e: ; 0x16a6e
 	dw TileData_16be5
 
 TileData_16a73: ; 0x16a73
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3A
 	dw StageRedFieldBottomBaseGameBoyGfx + $ba0
@@ -126,7 +126,7 @@ TileData_16a73: ; 0x16a73
 	db $00
 
 TileData_16a7d: ; 0x16a7d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3D
 	dw StageRedFieldBottomBaseGameBoyGfx + $bd0
@@ -134,7 +134,7 @@ TileData_16a7d: ; 0x16a7d
 	db $00
 
 TileData_16a87: ; 0x16a87
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $40
 	dw StageRedFieldBottomBaseGameBoyGfx + $c00
@@ -142,7 +142,7 @@ TileData_16a87: ; 0x16a87
 	db $00
 
 TileData_16a91: ; 0x16a91
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $380
@@ -150,7 +150,7 @@ TileData_16a91: ; 0x16a91
 	db $00
 
 TileData_16a9b: ; 0x16a9b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $3B0
@@ -158,7 +158,7 @@ TileData_16a9b: ; 0x16a9b
 	db $00
 
 TileData_16aa5: ; 0x16aa5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $40
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $3E0
@@ -166,7 +166,7 @@ TileData_16aa5: ; 0x16aa5
 	db $00
 
 TileData_16aaf: ; 0x16aaf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $3F0
@@ -174,7 +174,7 @@ TileData_16aaf: ; 0x16aaf
 	db $00
 
 TileData_16ab9: ; 0x16ab9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $420
@@ -182,7 +182,7 @@ TileData_16ab9: ; 0x16ab9
 	db $00
 
 TileData_16ac3: ; 0x16ac3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $40
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $450
@@ -190,7 +190,7 @@ TileData_16ac3: ; 0x16ac3
 	db $00
 
 TileData_16acd: ; 0x16acd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $460
@@ -198,7 +198,7 @@ TileData_16acd: ; 0x16acd
 	db $00
 
 TileData_16ad7: ; 0x16ad7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $490
@@ -206,7 +206,7 @@ TileData_16ad7: ; 0x16ad7
 	db $00
 
 TileData_16ae1: ; 0x16ae1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $40
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $4C0
@@ -214,7 +214,7 @@ TileData_16ae1: ; 0x16ae1
 	db $00
 
 TileData_16aeb: ; 0x16aeb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $F30
@@ -222,7 +222,7 @@ TileData_16aeb: ; 0x16aeb
 	db $00
 
 TileData_16af5: ; 0x16af5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $3D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $F60
@@ -230,7 +230,7 @@ TileData_16af5: ; 0x16af5
 	db $00
 
 TileData_16aff: ; 0x16aff
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $40
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $F90
@@ -238,7 +238,7 @@ TileData_16aff: ; 0x16aff
 	db $00
 
 TileData_16b09: ; 0x16b09
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageRedFieldBottomBaseGameBoyGfx + $c10
@@ -246,7 +246,7 @@ TileData_16b09: ; 0x16b09
 	db $00
 
 TileData_16b13: ; 0x16b13
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomBaseGameBoyGfx + $c40
@@ -254,7 +254,7 @@ TileData_16b13: ; 0x16b13
 	db $00
 
 TileData_16b1d: ; 0x16b1d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomBaseGameBoyGfx + $c70
@@ -262,7 +262,7 @@ TileData_16b1d: ; 0x16b1d
 	db $00
 
 TileData_16b27: ; 0x16b27
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $4D0
@@ -270,7 +270,7 @@ TileData_16b27: ; 0x16b27
 	db $00
 
 TileData_16b31: ; 0x16b31
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $500
@@ -278,7 +278,7 @@ TileData_16b31: ; 0x16b31
 	db $00
 
 TileData_16b3b: ; 0x16b3b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $530
@@ -286,7 +286,7 @@ TileData_16b3b: ; 0x16b3b
 	db $00
 
 TileData_16b45: ; 0x16b45
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $540
@@ -294,7 +294,7 @@ TileData_16b45: ; 0x16b45
 	db $00
 
 TileData_16b4f: ; 0x16b4f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $570
@@ -302,7 +302,7 @@ TileData_16b4f: ; 0x16b4f
 	db $00
 
 TileData_16b59: ; 0x16b59
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $5A0
@@ -310,7 +310,7 @@ TileData_16b59: ; 0x16b59
 	db $00
 
 TileData_16b63: ; 0x16b63
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $5B0
@@ -318,7 +318,7 @@ TileData_16b63: ; 0x16b63
 	db $00
 
 TileData_16b6d: ; 0x16b6d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $5E0
@@ -326,7 +326,7 @@ TileData_16b6d: ; 0x16b6d
 	db $00
 
 TileData_16b77: ; 0x16b77
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $610
@@ -334,7 +334,7 @@ TileData_16b77: ; 0x16b77
 	db $00
 
 TileData_16b81: ; 0x16b81
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $41
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1010
@@ -342,7 +342,7 @@ TileData_16b81: ; 0x16b81
 	db $00
 
 TileData_16b8b: ; 0x16b8b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1040
@@ -350,7 +350,7 @@ TileData_16b8b: ; 0x16b8b
 	db $00
 
 TileData_16b95: ; 0x16b95
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1070
@@ -358,7 +358,7 @@ TileData_16b95: ; 0x16b95
 	db $00
 
 TileData_16b9f: ; 0x16b9f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $20
 	dw StageRedFieldBottomBaseGameBoyGfx + $a00
@@ -366,7 +366,7 @@ TileData_16b9f: ; 0x16b9f
 	db $00
 
 TileData_16ba9: ; 0x16ba9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $20
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1080
@@ -374,7 +374,7 @@ TileData_16ba9: ; 0x16ba9
 	db $00
 
 TileData_16bb3: ; 0x16bb3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $23
 	dw StageRedFieldBottomBaseGameBoyGfx + $a30
@@ -382,7 +382,7 @@ TileData_16bb3: ; 0x16bb3
 	db $00
 
 TileData_16bbd: ; 0x16bbd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $23
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $10B0
@@ -390,7 +390,7 @@ TileData_16bbd: ; 0x16bbd
 	db $00
 
 TileData_16bc7: ; 0x16bc7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1C
 	dw StageRedFieldBottomBaseGameBoyGfx + $9c0
@@ -398,7 +398,7 @@ TileData_16bc7: ; 0x16bc7
 	db $00
 
 TileData_16bd1: ; 0x16bd1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1E
 	dw StageRedFieldBottomBaseGameBoyGfx + $9e0
@@ -406,7 +406,7 @@ TileData_16bd1: ; 0x16bd1
 	db $00
 
 TileData_16bdb: ; 0x16bdb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $6E0
@@ -414,7 +414,7 @@ TileData_16bdb: ; 0x16bdb
 	db $00
 
 TileData_16be5: ; 0x16be5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $1E
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $700

--- a/data/queued_tiledata/red_field/bonus_multiplier_railings.asm
+++ b/data/queued_tiledata/red_field/bonus_multiplier_railings.asm
@@ -121,7 +121,7 @@ BonusMultiplierRailingTileData_1704f: ; 0x1704f
 	dw BonusMultiplierRailingTileData_171da
 
 BonusMultiplierRailingTileData_17054: ; 0x17054
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1280
@@ -129,7 +129,7 @@ BonusMultiplierRailingTileData_17054: ; 0x17054
 	db $00
 
 BonusMultiplierRailingTileData_1705e: ; 0x1705e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1140
@@ -137,7 +137,7 @@ BonusMultiplierRailingTileData_1705e: ; 0x1705e
 	db $00
 
 BonusMultiplierRailingTileData_17068: ; 0x17068
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $12A0
@@ -145,7 +145,7 @@ BonusMultiplierRailingTileData_17068: ; 0x17068
 	db $00
 
 BonusMultiplierRailingTileData_17072: ; 0x17072
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1160
@@ -153,7 +153,7 @@ BonusMultiplierRailingTileData_17072: ; 0x17072
 	db $00
 
 BonusMultiplierRailingTileData_1707c: ; 0x1707c
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $12C0
@@ -161,7 +161,7 @@ BonusMultiplierRailingTileData_1707c: ; 0x1707c
 	db $00
 
 BonusMultiplierRailingTileData_17086: ; 0x17086
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1180
@@ -169,7 +169,7 @@ BonusMultiplierRailingTileData_17086: ; 0x17086
 	db $00
 
 BonusMultiplierRailingTileData_17090: ; 0x17090
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $12E0
@@ -177,7 +177,7 @@ BonusMultiplierRailingTileData_17090: ; 0x17090
 	db $00
 
 BonusMultiplierRailingTileData_1709a: ; 0x1709a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $11A0
@@ -185,7 +185,7 @@ BonusMultiplierRailingTileData_1709a: ; 0x1709a
 	db $00
 
 BonusMultiplierRailingTileData_170a4: ; 0x170a4
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1300
@@ -193,7 +193,7 @@ BonusMultiplierRailingTileData_170a4: ; 0x170a4
 	db $00
 
 BonusMultiplierRailingTileData_170ae: ; 0x170ae
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $11C0
@@ -201,7 +201,7 @@ BonusMultiplierRailingTileData_170ae: ; 0x170ae
 	db $00
 
 BonusMultiplierRailingTileData_170b8: ; 0x170b8
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1320
@@ -209,7 +209,7 @@ BonusMultiplierRailingTileData_170b8: ; 0x170b8
 	db $00
 
 BonusMultiplierRailingTileData_170c2: ; 0x170c2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $11E0
@@ -217,7 +217,7 @@ BonusMultiplierRailingTileData_170c2: ; 0x170c2
 	db $00
 
 BonusMultiplierRailingTileData_170cc: ; 0x170cc
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1340
@@ -225,7 +225,7 @@ BonusMultiplierRailingTileData_170cc: ; 0x170cc
 	db $00
 
 BonusMultiplierRailingTileData_170d6: ; 0x170d6
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1200
@@ -233,7 +233,7 @@ BonusMultiplierRailingTileData_170d6: ; 0x170d6
 	db $00
 
 BonusMultiplierRailingTileData_170e0: ; 0x170e0
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1360
@@ -241,7 +241,7 @@ BonusMultiplierRailingTileData_170e0: ; 0x170e0
 	db $00
 
 BonusMultiplierRailingTileData_170ea: ; 0x170ea
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1220
@@ -249,7 +249,7 @@ BonusMultiplierRailingTileData_170ea: ; 0x170ea
 	db $00
 
 BonusMultiplierRailingTileData_170f4: ; 0x170f4
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1380
@@ -257,7 +257,7 @@ BonusMultiplierRailingTileData_170f4: ; 0x170f4
 	db $00
 
 BonusMultiplierRailingTileData_170fe: ; 0x170fe
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1240
@@ -265,7 +265,7 @@ BonusMultiplierRailingTileData_170fe: ; 0x170fe
 	db $00
 
 BonusMultiplierRailingTileData_17108: ; 0x17108
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $13A0
@@ -273,7 +273,7 @@ BonusMultiplierRailingTileData_17108: ; 0x17108
 	db $00
 
 BonusMultiplierRailingTileData_17112: ; 0x17112
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1260
@@ -281,7 +281,7 @@ BonusMultiplierRailingTileData_17112: ; 0x17112
 	db $00
 
 BonusMultiplierRailingTileData_1711c: ; 0x1711c
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1500
@@ -289,7 +289,7 @@ BonusMultiplierRailingTileData_1711c: ; 0x1711c
 	db $00
 
 BonusMultiplierRailingTileData_17126: ; 0x17126
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $13C0
@@ -297,7 +297,7 @@ BonusMultiplierRailingTileData_17126: ; 0x17126
 	db $00
 
 BonusMultiplierRailingTileData_17130: ; 0x17130
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1520
@@ -305,7 +305,7 @@ BonusMultiplierRailingTileData_17130: ; 0x17130
 	db $00
 
 BonusMultiplierRailingTileData_1713a: ; 0x1713a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $13E0
@@ -313,7 +313,7 @@ BonusMultiplierRailingTileData_1713a: ; 0x1713a
 	db $00
 
 BonusMultiplierRailingTileData_17144: ; 0x17144
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1540
@@ -321,7 +321,7 @@ BonusMultiplierRailingTileData_17144: ; 0x17144
 	db $00
 
 BonusMultiplierRailingTileData_1714e: ; 0x1714e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1400
@@ -329,7 +329,7 @@ BonusMultiplierRailingTileData_1714e: ; 0x1714e
 	db $00
 
 BonusMultiplierRailingTileData_17158: ; 0x17158
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1560
@@ -337,7 +337,7 @@ BonusMultiplierRailingTileData_17158: ; 0x17158
 	db $00
 
 BonusMultiplierRailingTileData_17162: ; 0x17162
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1420
@@ -345,7 +345,7 @@ BonusMultiplierRailingTileData_17162: ; 0x17162
 	db $00
 
 BonusMultiplierRailingTileData_1716c: ; 0x1716c
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1580
@@ -353,7 +353,7 @@ BonusMultiplierRailingTileData_1716c: ; 0x1716c
 	db $00
 
 BonusMultiplierRailingTileData_17176: ; 0x17176
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1440
@@ -361,7 +361,7 @@ BonusMultiplierRailingTileData_17176: ; 0x17176
 	db $00
 
 BonusMultiplierRailingTileData_17180: ; 0x17180
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $15A0
@@ -369,7 +369,7 @@ BonusMultiplierRailingTileData_17180: ; 0x17180
 	db $00
 
 BonusMultiplierRailingTileData_1718a: ; 0x1718a
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1460
@@ -377,7 +377,7 @@ BonusMultiplierRailingTileData_1718a: ; 0x1718a
 	db $00
 
 BonusMultiplierRailingTileData_17194: ; 0x17194
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $15C0
@@ -385,7 +385,7 @@ BonusMultiplierRailingTileData_17194: ; 0x17194
 	db $00
 
 BonusMultiplierRailingTileData_1719e: ; 0x1719e
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1480
@@ -393,7 +393,7 @@ BonusMultiplierRailingTileData_1719e: ; 0x1719e
 	db $00
 
 BonusMultiplierRailingTileData_171a8: ; 0x171a8
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $15E0
@@ -401,7 +401,7 @@ BonusMultiplierRailingTileData_171a8: ; 0x171a8
 	db $00
 
 BonusMultiplierRailingTileData_171b2: ; 0x171b2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $14A0
@@ -409,7 +409,7 @@ BonusMultiplierRailingTileData_171b2: ; 0x171b2
 	db $00
 
 BonusMultiplierRailingTileData_171bc: ; 0x171bc
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1600
@@ -417,7 +417,7 @@ BonusMultiplierRailingTileData_171bc: ; 0x171bc
 	db $00
 
 BonusMultiplierRailingTileData_171c6: ; 0x171c6
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $14C0
@@ -425,7 +425,7 @@ BonusMultiplierRailingTileData_171c6: ; 0x171c6
 	db $00
 
 BonusMultiplierRailingTileData_171d0: ; 0x171d0
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4a
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1620
@@ -433,7 +433,7 @@ BonusMultiplierRailingTileData_171d0: ; 0x171d0
 	db $00
 
 BonusMultiplierRailingTileData_171da: ; 0x171da
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $4c
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $14E0

--- a/data/queued_tiledata/red_field/diglett.asm
+++ b/data/queued_tiledata/red_field/diglett.asm
@@ -297,7 +297,7 @@ Data_14b44: ; 0x14b44
 	dw Data_14c83
 
 Data_14b4d: ; 0x14b4d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $26
 	dw StageRedFieldBottomBaseGameBoyGfx + $a60
@@ -305,7 +305,7 @@ Data_14b4d: ; 0x14b4d
 	db $00 ; terminator
 
 Data_14b57: ; 0x14b57
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $29
 	dw StageRedFieldBottomBaseGameBoyGfx + $a90
@@ -313,7 +313,7 @@ Data_14b57: ; 0x14b57
 	db $00 ; terminator
 
 Data_14b61: ; 0x14b61
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $2C
 	dw StageRedFieldBottomBaseGameBoyGfx + $ac0
@@ -321,7 +321,7 @@ Data_14b61: ; 0x14b61
 	db $00 ; terminator
 
 Data_14b6b: ; 0x14b6b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $2F
 	dw StageRedFieldBottomBaseGameBoyGfx + $af0
@@ -329,7 +329,7 @@ Data_14b6b: ; 0x14b6b
 	db $00 ; terminator
 
 Data_14b75: ; 0x14b75
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $26
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $720
@@ -337,7 +337,7 @@ Data_14b75: ; 0x14b75
 	db $00 ; terminator
 
 Data_14b7f: ; 0x14b7f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $29
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $750
@@ -345,7 +345,7 @@ Data_14b7f: ; 0x14b7f
 	db $00 ; terminator
 
 Data_14b89: ; 0x14b89
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $2C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $780
@@ -353,7 +353,7 @@ Data_14b89: ; 0x14b89
 	db $00 ; terminator
 
 Data_14b93: ; 0x14b93
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $2F
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $7B0
@@ -361,7 +361,7 @@ Data_14b93: ; 0x14b93
 	db $00 ; terminator
 
 Data_14b9d: ; 0x14b9d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $26
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $7C0
@@ -369,7 +369,7 @@ Data_14b9d: ; 0x14b9d
 	db $00 ; terminator
 
 Data_14ba7: ; 0x14ba7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $29
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $7F0
@@ -377,7 +377,7 @@ Data_14ba7: ; 0x14ba7
 	db $00 ; terminator
 
 Data_14bb1: ; 0x14bb1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $2C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $820
@@ -385,7 +385,7 @@ Data_14bb1: ; 0x14bb1
 	db $00 ; terminator
 
 Data_14bbb: ; 0x14bbb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $2F
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $850
@@ -393,7 +393,7 @@ Data_14bbb: ; 0x14bbb
 	db $00 ; terminator
 
 Data_14bc5: ; 0x14bc5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $26
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $860
@@ -401,7 +401,7 @@ Data_14bc5: ; 0x14bc5
 	db $00 ; terminator
 
 Data_14bcf: ; 0x14bcf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $29
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $890
@@ -409,7 +409,7 @@ Data_14bcf: ; 0x14bcf
 	db $00 ; terminator
 
 Data_14bd9: ; 0x14bd9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $2C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $8C0
@@ -417,7 +417,7 @@ Data_14bd9: ; 0x14bd9
 	db $00 ; terminator
 
 Data_14be3: ; 0x14be3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $2F
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $8F0
@@ -425,7 +425,7 @@ Data_14be3: ; 0x14be3
 	db $00 ; terminator
 
 Data_14bed: ; 0x14bed
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $30
 	dw StageRedFieldBottomBaseGameBoyGfx + $B00
@@ -433,7 +433,7 @@ Data_14bed: ; 0x14bed
 	db $00 ; terminator
 
 Data_14bf7: ; 0x14bf7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $33
 	dw StageRedFieldBottomBaseGameBoyGfx + $B30
@@ -441,7 +441,7 @@ Data_14bf7: ; 0x14bf7
 	db $00 ; terminator
 
 Data_14c01: ; 0x14c01
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $36
 	dw StageRedFieldBottomBaseGameBoyGfx + $B60
@@ -449,7 +449,7 @@ Data_14c01: ; 0x14c01
 	db $00 ; terminator
 
 Data_14c0b: ; 0x14c0b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $39
 	dw StageRedFieldBottomBaseGameBoyGfx + $B90
@@ -457,7 +457,7 @@ Data_14c0b: ; 0x14c0b
 	db $00 ; terminator
 
 Data_14c15: ; 0x14c15
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $30
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $900
@@ -465,7 +465,7 @@ Data_14c15: ; 0x14c15
 	db $00 ; terminator
 
 Data_14c1f: ; 0x14c1f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $33
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $930
@@ -473,7 +473,7 @@ Data_14c1f: ; 0x14c1f
 	db $00 ; terminator
 
 Data_14c29: ; 0x14c29
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $36
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $960
@@ -481,7 +481,7 @@ Data_14c29: ; 0x14c29
 	db $00 ; terminator
 
 Data_14c33: ; 0x14c33
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $39
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $990
@@ -489,7 +489,7 @@ Data_14c33: ; 0x14c33
 	db $00 ; terminator
 
 Data_14c3d: ; 0x14c3d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $30
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $9A0
@@ -497,7 +497,7 @@ Data_14c3d: ; 0x14c3d
 	db $00 ; terminator
 
 Data_14c47: ; 0x14c47
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $33
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $9D0
@@ -505,7 +505,7 @@ Data_14c47: ; 0x14c47
 	db $00 ; terminator
 
 Data_14c51: ; 0x14c51
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $36
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $A00
@@ -513,7 +513,7 @@ Data_14c51: ; 0x14c51
 	db $00 ; terminator
 
 Data_14c5b: ; 0x14c5b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $39
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $A30
@@ -521,7 +521,7 @@ Data_14c5b: ; 0x14c5b
 	db $00 ; terminator
 
 Data_14c65: ; 0x14c65
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $30
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $A40
@@ -529,7 +529,7 @@ Data_14c65: ; 0x14c65
 	db $00 ; terminator
 
 Data_14c6f: ; 0x14c6f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $33
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $A70
@@ -537,7 +537,7 @@ Data_14c6f: ; 0x14c6f
 	db $00 ; terminator
 
 Data_14c79: ; 0x14c79
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $36
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $AA0
@@ -545,7 +545,7 @@ Data_14c79: ; 0x14c79
 	db $00 ; terminator
 
 Data_14c83: ; 0x14c83
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $39
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $AD0

--- a/data/queued_tiledata/red_field/slot_cave.asm
+++ b/data/queued_tiledata/red_field/slot_cave.asm
@@ -23,7 +23,7 @@ TileData_16460: ; 0x16460
 	dw TileData_16497
 
 TileData_16465: ; 0x16465
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldTopBaseGameBoyGfx + $1c0
@@ -31,7 +31,7 @@ TileData_16465: ; 0x16465
 	db $00
 
 TileData_1646f: ; 0x1646f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $46
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $340
@@ -39,7 +39,7 @@ TileData_1646f: ; 0x1646f
 	db $00
 
 TileData_16479: ; 0x16479
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $48
 	dw StageRedFieldBottomBaseGameBoyGfx + $c80
@@ -47,7 +47,7 @@ TileData_16479: ; 0x16479
 	db $00
 
 TileData_16483: ; 0x16483
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $4A
 	dw StageRedFieldBottomBaseGameBoyGfx + $CA0
@@ -55,7 +55,7 @@ TileData_16483: ; 0x16483
 	db $00
 
 TileData_1648D: ; 0x1648D
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $48
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $340
@@ -63,7 +63,7 @@ TileData_1648D: ; 0x1648D
 	db $00
 
 TileData_16497: ; 0x16497
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $4A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $360

--- a/data/queued_tiledata/red_field/spinner.asm
+++ b/data/queued_tiledata/red_field/spinner.asm
@@ -97,7 +97,7 @@ TileData_14f56: ; 0x14f56
 	dw TileData_15091
 
 TileData_14f5b: ; 0x14f5b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldTopBaseGameBoyGfx + $cb0
@@ -105,7 +105,7 @@ TileData_14f5b: ; 0x14f5b
 	db $00 ; terminator
 
 TileData_14f65: ; 0x14f65
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldTopBaseGameBoyGfx + $cd0
@@ -113,7 +113,7 @@ TileData_14f65: ; 0x14f65
 	db $00 ; terminator
 
 TileData_14f6f: ; 0x14f6f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $AE0
@@ -121,7 +121,7 @@ TileData_14f6f: ; 0x14f6f
 	db $00 ; terminator
 
 TileData_14f79: ; 0x14f79
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $B00
@@ -129,7 +129,7 @@ TileData_14f79: ; 0x14f79
 	db $00 ; terminator
 
 TileData_14f83: ; 0x14f83
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $B20
@@ -137,7 +137,7 @@ TileData_14f83: ; 0x14f83
 	db $00 ; terminator
 
 TileData_14f8d: ; 0x14f8d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $B40
@@ -145,7 +145,7 @@ TileData_14f8d: ; 0x14f8d
 	db $00 ; terminator
 
 TileData_14f97: ; 0x14f97
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $B60
@@ -153,7 +153,7 @@ TileData_14f97: ; 0x14f97
 	db $00 ; terminator
 
 TileData_14fa1: ; 0x14fa1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $B80
@@ -161,7 +161,7 @@ TileData_14fa1: ; 0x14fa1
 	db $00 ; terminator
 
 TileData_14fab: ; 0x14fab
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $BA0
@@ -169,7 +169,7 @@ TileData_14fab: ; 0x14fab
 	db $00 ; terminator
 
 TileData_14fb5: ; 0x14fb5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $BC0
@@ -177,7 +177,7 @@ TileData_14fb5: ; 0x14fb5
 	db $00 ; terminator
 
 TileData_14fbf: ; 0x14fbf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $BE0
@@ -185,7 +185,7 @@ TileData_14fbf: ; 0x14fbf
 	db $00 ; terminator
 
 TileData_14fc9: ; 0x14fc9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $C00
@@ -193,7 +193,7 @@ TileData_14fc9: ; 0x14fc9
 	db $00 ; terminator
 
 TileData_14fd3: ; 0x14fd3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $C20
@@ -201,7 +201,7 @@ TileData_14fd3: ; 0x14fd3
 	db $00 ; terminator
 
 TileData_14fdd: ; 0x14fdd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $C40
@@ -209,7 +209,7 @@ TileData_14fdd: ; 0x14fdd
 	db $00 ; terminator
 
 TileData_14fe7: ; 0x14fe7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $C60
@@ -217,7 +217,7 @@ TileData_14fe7: ; 0x14fe7
 	db $00 ; terminator
 
 TileData_14ff1: ; 0x14ff1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $C80
@@ -225,7 +225,7 @@ TileData_14ff1: ; 0x14ff1
 	db $00 ; terminator
 
 TileData_14ffb: ; 0x14ffb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $CA0
@@ -233,7 +233,7 @@ TileData_14ffb: ; 0x14ffb
 	db $00 ; terminator
 
 TileData_15005: ; 0x15005
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $CC0
@@ -241,7 +241,7 @@ TileData_15005: ; 0x15005
 	db $00 ; terminator
 
 TileData_1500f: ; 0x1500f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $CE0
@@ -249,7 +249,7 @@ TileData_1500f: ; 0x1500f
 	db $00 ; terminator
 
 TileData_15019: ; 0x15019
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $D00
@@ -257,7 +257,7 @@ TileData_15019: ; 0x15019
 	db $00 ; terminator
 
 TileData_15023: ; 0x15023
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $D20
@@ -265,7 +265,7 @@ TileData_15023: ; 0x15023
 	db $00 ; terminator
 
 TileData_1502d: ; 0x1502d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $D40
@@ -273,7 +273,7 @@ TileData_1502d: ; 0x1502d
 	db $00 ; terminator
 
 TileData_15037: ; 0x15037
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $D60
@@ -281,7 +281,7 @@ TileData_15037: ; 0x15037
 	db $00 ; terminator
 
 TileData_15041: ; 0x15041
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $D80
@@ -289,7 +289,7 @@ TileData_15041: ; 0x15041
 	db $00 ; terminator
 
 TileData_1504b: ; 0x1504b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $DA0
@@ -297,7 +297,7 @@ TileData_1504b: ; 0x1504b
 	db $00 ; terminator
 
 TileData_15055: ; 0x15055
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $DC0
@@ -305,7 +305,7 @@ TileData_15055: ; 0x15055
 	db $00 ; terminator
 
 TileData_1505f: ; 0x1505f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $DE0
@@ -313,7 +313,7 @@ TileData_1505f: ; 0x1505f
 	db $00 ; terminator
 
 TileData_15069: ; 0x15069
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $E00
@@ -321,7 +321,7 @@ TileData_15069: ; 0x15069
 	db $00 ; terminator
 
 TileData_15073: ; 0x15073
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $E20
@@ -329,7 +329,7 @@ TileData_15073: ; 0x15073
 	db $00 ; terminator
 
 TileData_1507d: ; 0x1507d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $E40
@@ -337,7 +337,7 @@ TileData_1507d: ; 0x1507d
 	db $00 ; terminator
 
 TileData_15087: ; 0x15087
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $75
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $E60
@@ -345,7 +345,7 @@ TileData_15087: ; 0x15087
 	db $00 ; terminator
 
 TileData_15091: ; 0x15091
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesBG tile $77
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $E80

--- a/data/queued_tiledata/red_field/staryu_bumper.asm
+++ b/data/queued_tiledata/red_field/staryu_bumper.asm
@@ -23,7 +23,7 @@ TileData_168af: ; 0x168af
 	dw TileData_16906
 
 TileData_168b6: ; 0x168b6
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $50
 	dw StageRedFieldTopBaseGameBoyGfx + $260
@@ -31,7 +31,7 @@ TileData_168b6: ; 0x168b6
 	db $00
 
 TileData_168c0: ; 0x168c0
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $53
 	dw StageRedFieldTopBaseGameBoyGfx + $290
@@ -39,7 +39,7 @@ TileData_168c0: ; 0x168c0
 	db $00
 
 TileData_168ca: ; 0x168ca
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesSH tile $56
 	dw StageRedFieldTopBaseGameBoyGfx + $2c0
@@ -47,7 +47,7 @@ TileData_168ca: ; 0x168ca
 	db $00
 
 TileData_168d4: ; 0x168d4
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $52
 	dw StageRedFieldTopBaseGameBoyGfx + $280
@@ -55,7 +55,7 @@ TileData_168d4: ; 0x168d4
 	db $00
 
 TileData_168de: ; 0x168de
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $55
 	dw StageRedFieldTopBaseGameBoyGfx + $2b0
@@ -63,7 +63,7 @@ TileData_168de: ; 0x168de
 	db $00
 
 TileData_168e8: ; 0x168e8
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $50
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $EA0
@@ -71,7 +71,7 @@ TileData_168e8: ; 0x168e8
 	db $00
 
 TileData_168f2: ; 0x168f2
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $51
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $10E0
@@ -79,7 +79,7 @@ TileData_168f2: ; 0x168f2
 	db $00
 
 TileData_168fc: ; 0x168fc
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesSH tile $54
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1110
@@ -87,7 +87,7 @@ TileData_168fc: ; 0x168fc
 	db $00
 
 TileData_16906: ; 0x16906
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesSH tile $50
 	dw StageRedFieldTopBaseGameBoyGfx + $260

--- a/data/queued_tiledata/red_field/structures.asm
+++ b/data/queued_tiledata/red_field/structures.asm
@@ -201,7 +201,7 @@ TileData_15b82: ; 0x15b82
 	dw TileData_15ca1
 
 TileData_15b93: ; 0x15b93
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy
@@ -209,7 +209,7 @@ TileData_15b93: ; 0x15b93
 	db $00
 
 TileData_15b9d: ; 0x15b9d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $47
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $30
@@ -217,7 +217,7 @@ TileData_15b9d: ; 0x15b9d
 	db $00
 
 TileData_15ba7: ; 0x15ba7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4A
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $60
@@ -225,7 +225,7 @@ TileData_15ba7: ; 0x15ba7
 	db $00
 
 TileData_15bb1: ; 0x15bb1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4D
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $90
@@ -233,7 +233,7 @@ TileData_15bb1: ; 0x15bb1
 	db $00
 
 TileData_15bbb: ; 0x15bbb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $50
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $C0
@@ -241,7 +241,7 @@ TileData_15bbb: ; 0x15bbb
 	db $00
 
 TileData_15bc5: ; 0x15bc5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $53
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $F0
@@ -249,7 +249,7 @@ TileData_15bc5: ; 0x15bc5
 	db $00
 
 TileData_15bcf: ; 0x15bcf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $44
 	dw StageRedFieldTopBaseGameBoyGfx + $9a0
@@ -257,7 +257,7 @@ TileData_15bcf: ; 0x15bcf
 	db $00
 
 TileData_15bd9: ; 0x15bd9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $47
 	dw StageRedFieldTopBaseGameBoyGfx + $9d0
@@ -265,7 +265,7 @@ TileData_15bd9: ; 0x15bd9
 	db $00
 
 TileData_15be3: ; 0x15be3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4A
 	dw StageRedFieldTopBaseGameBoyGfx + $a00
@@ -273,7 +273,7 @@ TileData_15be3: ; 0x15be3
 	db $00
 
 TileData_15bed: ; 0x15bed
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $4D
 	dw StageRedFieldTopBaseGameBoyGfx + $a30
@@ -281,7 +281,7 @@ TileData_15bed: ; 0x15bed
 	db $00
 
 TileData_15bf7: ; 0x15bf7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $50
 	dw StageRedFieldTopBaseGameBoyGfx + $a60
@@ -289,7 +289,7 @@ TileData_15bf7: ; 0x15bf7
 	db $00
 
 TileData_15c01: ; 0x15c01
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $53
 	dw StageRedFieldTopBaseGameBoyGfx + $a90
@@ -297,7 +297,7 @@ TileData_15c01: ; 0x15c01
 	db $00
 
 TileData_15c0b: ; 0x15c0b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $56
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $120
@@ -305,7 +305,7 @@ TileData_15c0b: ; 0x15c0b
 	db $00
 
 TileData_15c15: ; 0x15c15
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $59
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $150
@@ -313,7 +313,7 @@ TileData_15c15: ; 0x15c15
 	db $00
 
 TileData_15c1f: ; 0x15c1f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $5C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $180
@@ -321,7 +321,7 @@ TileData_15c1f: ; 0x15c1f
 	db $00
 
 TileData_15c29: ; 0x15c29
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $5F
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1B0
@@ -329,7 +329,7 @@ TileData_15c29: ; 0x15c29
 	db $00
 
 TileData_15c33: ; 0x15c33
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $62
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $1E0
@@ -337,7 +337,7 @@ TileData_15c33: ; 0x15c33
 	db $00
 
 TileData_15c3d: ; 0x15c3d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $65
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $210
@@ -345,7 +345,7 @@ TileData_15c3d: ; 0x15c3d
 	db $00
 
 TileData_15c47: ; 0x15c47
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $66
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $620
@@ -353,7 +353,7 @@ TileData_15c47: ; 0x15c47
 	db $00
 
 TileData_15c51: ; 0x15c51
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $69
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $650
@@ -361,7 +361,7 @@ TileData_15c51: ; 0x15c51
 	db $00
 
 TileData_15c5b: ; 0x15c5b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $56
 	dw StageRedFieldTopBaseGameBoyGfx + $ac0
@@ -369,7 +369,7 @@ TileData_15c5b: ; 0x15c5b
 	db $00
 
 TileData_15c65: ; 0x15c65
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $59
 	dw StageRedFieldTopBaseGameBoyGfx + $af0
@@ -377,7 +377,7 @@ TileData_15c65: ; 0x15c65
 	db $00
 
 TileData_15c6f: ; 0x15c6f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $5C
 	dw StageRedFieldTopBaseGameBoyGfx + $b20
@@ -385,7 +385,7 @@ TileData_15c6f: ; 0x15c6f
 	db $00
 
 TileData_15c79: ; 0x15c79
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $5F
 	dw StageRedFieldTopBaseGameBoyGfx + $b50
@@ -393,7 +393,7 @@ TileData_15c79: ; 0x15c79
 	db $00
 
 TileData_15c83: ; 0x15c83
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $62
 	dw StageRedFieldTopBaseGameBoyGfx + $b80
@@ -401,7 +401,7 @@ TileData_15c83: ; 0x15c83
 	db $00
 
 TileData_15c8d: ; 0x15c8d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $65
 	dw StageRedFieldTopBaseGameBoyGfx + $bb0
@@ -409,7 +409,7 @@ TileData_15c8d: ; 0x15c8d
 	db $00
 
 TileData_15c97: ; 0x15c97
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $66
 	dw StageRedFieldTopBaseGameBoyGfx + $bc0
@@ -417,7 +417,7 @@ TileData_15c97: ; 0x15c97
 	db $00
 
 TileData_15ca1: ; 0x15ca1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $69
 	dw StageRedFieldTopBaseGameBoyGfx + $bf0
@@ -425,7 +425,7 @@ TileData_15ca1: ; 0x15ca1
 	db $00
 
 TileData_15cab: ; 0x15cab
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2B0
@@ -433,7 +433,7 @@ TileData_15cab: ; 0x15cab
 	db $00
 
 TileData_15cb5: ; 0x15cb5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6F
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $2E0
@@ -441,7 +441,7 @@ TileData_15cb5: ; 0x15cb5
 	db $00
 
 TileData_15cbf: ; 0x15cbf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $72
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $310
@@ -449,7 +449,7 @@ TileData_15cbf: ; 0x15cbf
 	db $00
 
 TileData_15cc9: ; 0x15cc9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6C
 	dw StageRedFieldTopBaseGameBoyGfx + $c20
@@ -457,7 +457,7 @@ TileData_15cc9: ; 0x15cc9
 	db $00
 
 TileData_15cd3: ; 0x15cd3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6F
 	dw StageRedFieldTopBaseGameBoyGfx + $c50
@@ -465,7 +465,7 @@ TileData_15cd3: ; 0x15cd3
 	db $00
 
 TileData_15cdd: ; 0x15cdd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $72
 	dw StageRedFieldTopBaseGameBoyGfx + $c80
@@ -473,7 +473,7 @@ TileData_15cdd: ; 0x15cdd
 	db $00
 
 TileData_15ce7: ; 0x15ce7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6C
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $220
@@ -481,7 +481,7 @@ TileData_15ce7: ; 0x15ce7
 	db $00
 
 TileData_15cf1: ; 0x15cf1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6F
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $250
@@ -489,7 +489,7 @@ TileData_15cf1: ; 0x15cf1
 	db $00
 
 TileData_15cfb: ; 0x15cfb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $72
 	dw StageRedFieldBottomIndicatorsGfx_Gameboy + $280
@@ -618,7 +618,7 @@ TileData_15db4: ; 0x15db4
 	dw TileData_15e21
 
 TileData_15db7: ; 0x15db7
-	dw Func_1198
+	dw LoadSequentialTileLists
 
 	db ($a << 1)
 	db $03
@@ -650,7 +650,7 @@ TileData_15db7: ; 0x15db7
 	db $00 ; terminator
 
 TileData_15dd5: ; 0x15dd5
-	dw Func_1198
+	dw LoadSequentialTileLists
 
 	db ($a << 1)
 	db $03
@@ -785,7 +785,7 @@ TileData_15e69: ; 0x15e69
 	db $00 ; terminator
 
 TileData_15e82: ; 0x15e82
-	dw Func_1198
+	dw LoadSequentialTileLists
 
 	db ((4 << 1) | 1)
 	db $07

--- a/data/timer_digits_tiledata.asm
+++ b/data/timer_digits_tiledata.asm
@@ -525,7 +525,7 @@ TileDataPointer_TimerDigit_Bonus_Colon_GameBoy: ; 0x178b8
 	dw TileData_TimerDigit_Bonus_Colon_GameBoy
 
 TileData_TimerDigit_Top_Minutes_0_GameBoy: ; 0x178bb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2
@@ -533,7 +533,7 @@ TileData_TimerDigit_Top_Minutes_0_GameBoy: ; 0x178bb
 	db $00
 
 TileData_TimerDigit_Top_Minutes_1_GameBoy: ; 0x178c5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $20
@@ -541,7 +541,7 @@ TileData_TimerDigit_Top_Minutes_1_GameBoy: ; 0x178c5
 	db $00
 
 TileData_TimerDigit_Top_Minutes_2_GameBoy: ; 0x178cf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $40
@@ -549,7 +549,7 @@ TileData_TimerDigit_Top_Minutes_2_GameBoy: ; 0x178cf
 	db $00
 
 TileData_TimerDigit_Top_Minutes_3_GameBoy: ; 0x178d9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $60
@@ -557,7 +557,7 @@ TileData_TimerDigit_Top_Minutes_3_GameBoy: ; 0x178d9
 	db $00
 
 TileData_TimerDigit_Top_Minutes_4_GameBoy: ; 0x178e3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $80
@@ -565,7 +565,7 @@ TileData_TimerDigit_Top_Minutes_4_GameBoy: ; 0x178e3
 	db $00
 
 TileData_TimerDigit_Top_Minutes_5_GameBoy: ; 0x178ed
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $A0
@@ -573,7 +573,7 @@ TileData_TimerDigit_Top_Minutes_5_GameBoy: ; 0x178ed
 	db $00
 
 TileData_TimerDigit_Top_Minutes_6_GameBoy: ; 0x178f7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $C0
@@ -581,7 +581,7 @@ TileData_TimerDigit_Top_Minutes_6_GameBoy: ; 0x178f7
 	db $00
 
 TileData_TimerDigit_Top_Minutes_7_GameBoy: ; 0x17901
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $E0
@@ -589,7 +589,7 @@ TileData_TimerDigit_Top_Minutes_7_GameBoy: ; 0x17901
 	db $00
 
 TileData_TimerDigit_Top_Minutes_8_GameBoy: ; 0x1790b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $100
@@ -597,7 +597,7 @@ TileData_TimerDigit_Top_Minutes_8_GameBoy: ; 0x1790b
 	db $00
 
 TileData_TimerDigit_Top_Minutes_9_GameBoy: ; 0x17915
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw TimerDigitsGfx2 + $120
@@ -605,7 +605,7 @@ TileData_TimerDigit_Top_Minutes_9_GameBoy: ; 0x17915
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_0_GameBoy: ; 0x1791f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $00
@@ -613,7 +613,7 @@ TileData_TimerDigit_Top_TenSeconds_0_GameBoy: ; 0x1791f
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_1_GameBoy: ; 0x17929
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $20
@@ -621,7 +621,7 @@ TileData_TimerDigit_Top_TenSeconds_1_GameBoy: ; 0x17929
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_2_GameBoy: ; 0x17933
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $40
@@ -629,7 +629,7 @@ TileData_TimerDigit_Top_TenSeconds_2_GameBoy: ; 0x17933
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_3_GameBoy: ; 0x1793d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $60
@@ -637,7 +637,7 @@ TileData_TimerDigit_Top_TenSeconds_3_GameBoy: ; 0x1793d
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_4_GameBoy: ; 0x17947
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $80
@@ -645,7 +645,7 @@ TileData_TimerDigit_Top_TenSeconds_4_GameBoy: ; 0x17947
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_5_GameBoy: ; 0x17951
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $A0
@@ -653,7 +653,7 @@ TileData_TimerDigit_Top_TenSeconds_5_GameBoy: ; 0x17951
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_6_GameBoy: ; 0x1795b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $C0
@@ -661,7 +661,7 @@ TileData_TimerDigit_Top_TenSeconds_6_GameBoy: ; 0x1795b
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_7_GameBoy: ; 0x17965
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $E0
@@ -669,7 +669,7 @@ TileData_TimerDigit_Top_TenSeconds_7_GameBoy: ; 0x17965
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_8_GameBoy: ; 0x1796f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $100
@@ -677,7 +677,7 @@ TileData_TimerDigit_Top_TenSeconds_8_GameBoy: ; 0x1796f
 	db $00
 
 TileData_TimerDigit_Top_TenSeconds_9_GameBoy: ; 0x17979
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw TimerDigitsGfx2 + $120
@@ -685,7 +685,7 @@ TileData_TimerDigit_Top_TenSeconds_9_GameBoy: ; 0x17979
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_0_GameBoy: ; 0x17983
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $00
@@ -693,7 +693,7 @@ TileData_TimerDigit_Top_OnesSecond_0_GameBoy: ; 0x17983
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_1_GameBoy: ; 0x1798d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $20
@@ -701,7 +701,7 @@ TileData_TimerDigit_Top_OnesSecond_1_GameBoy: ; 0x1798d
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_2_GameBoy: ; 0x17997
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $40
@@ -709,7 +709,7 @@ TileData_TimerDigit_Top_OnesSecond_2_GameBoy: ; 0x17997
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_3_GameBoy: ; 0x179a1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $60
@@ -717,7 +717,7 @@ TileData_TimerDigit_Top_OnesSecond_3_GameBoy: ; 0x179a1
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_4_GameBoy: ; 0x179ab
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $80
@@ -725,7 +725,7 @@ TileData_TimerDigit_Top_OnesSecond_4_GameBoy: ; 0x179ab
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_5_GameBoy: ; 0x179b5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $A0
@@ -733,7 +733,7 @@ TileData_TimerDigit_Top_OnesSecond_5_GameBoy: ; 0x179b5
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_6_GameBoy: ; 0x179bf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $C0
@@ -741,7 +741,7 @@ TileData_TimerDigit_Top_OnesSecond_6_GameBoy: ; 0x179bf
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_7_GameBoy: ; 0x179c9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $E0
@@ -749,7 +749,7 @@ TileData_TimerDigit_Top_OnesSecond_7_GameBoy: ; 0x179c9
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_8_GameBoy: ; 0x179d3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $100
@@ -757,7 +757,7 @@ TileData_TimerDigit_Top_OnesSecond_8_GameBoy: ; 0x179d3
 	db $00
 
 TileData_TimerDigit_Top_OnesSecond_9_GameBoy: ; 0x179dd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $34
 	dw TimerDigitsGfx2 + $120
@@ -765,7 +765,7 @@ TileData_TimerDigit_Top_OnesSecond_9_GameBoy: ; 0x179dd
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_0_GameBoy: ; 0x179e7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $00
@@ -773,7 +773,7 @@ TileData_TimerDigit_Bottom_Minute_0_GameBoy: ; 0x179e7
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_1_GameBoy: ; 0x179f1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $20
@@ -781,7 +781,7 @@ TileData_TimerDigit_Bottom_Minute_1_GameBoy: ; 0x179f1
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_2_GameBoy: ; 0x179fb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $40
@@ -789,7 +789,7 @@ TileData_TimerDigit_Bottom_Minute_2_GameBoy: ; 0x179fb
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_3_GameBoy: ; 0x17a05
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $60
@@ -797,7 +797,7 @@ TileData_TimerDigit_Bottom_Minute_3_GameBoy: ; 0x17a05
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_4_GameBoy: ; 0x17a0f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $80
@@ -805,7 +805,7 @@ TileData_TimerDigit_Bottom_Minute_4_GameBoy: ; 0x17a0f
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_5_GameBoy: ; 0x17a19
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $A0
@@ -813,7 +813,7 @@ TileData_TimerDigit_Bottom_Minute_5_GameBoy: ; 0x17a19
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_6_GameBoy: ; 0x17a23
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $C0
@@ -821,7 +821,7 @@ TileData_TimerDigit_Bottom_Minute_6_GameBoy: ; 0x17a23
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_7_GameBoy: ; 0x17a2d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $E0
@@ -829,7 +829,7 @@ TileData_TimerDigit_Bottom_Minute_7_GameBoy: ; 0x17a2d
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_8_GameBoy: ; 0x17a37
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $100
@@ -837,7 +837,7 @@ TileData_TimerDigit_Bottom_Minute_8_GameBoy: ; 0x17a37
 	db $00
 
 TileData_TimerDigit_Bottom_Minute_9_GameBoy: ; 0x17a41
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $3A
 	dw TimerDigitsGfx2 + $120
@@ -845,7 +845,7 @@ TileData_TimerDigit_Bottom_Minute_9_GameBoy: ; 0x17a41
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_0_GameBoy: ; 0x17a4b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $00
@@ -853,7 +853,7 @@ TileData_TimerDigit_Bottom_TenSeconds_0_GameBoy: ; 0x17a4b
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_1_GameBoy: ; 0x17a55
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $20
@@ -861,7 +861,7 @@ TileData_TimerDigit_Bottom_TenSeconds_1_GameBoy: ; 0x17a55
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_2_GameBoy: ; 0x17a5f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $40
@@ -869,7 +869,7 @@ TileData_TimerDigit_Bottom_TenSeconds_2_GameBoy: ; 0x17a5f
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_3_GameBoy: ; 0x17a69
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $60
@@ -877,7 +877,7 @@ TileData_TimerDigit_Bottom_TenSeconds_3_GameBoy: ; 0x17a69
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_4_GameBoy: ; 0x17a73
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $80
@@ -885,7 +885,7 @@ TileData_TimerDigit_Bottom_TenSeconds_4_GameBoy: ; 0x17a73
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_5_GameBoy: ; 0x17a7d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $A0
@@ -893,7 +893,7 @@ TileData_TimerDigit_Bottom_TenSeconds_5_GameBoy: ; 0x17a7d
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_6_GameBoy: ; 0x17a87
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $C0
@@ -901,7 +901,7 @@ TileData_TimerDigit_Bottom_TenSeconds_6_GameBoy: ; 0x17a87
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_7_GameBoy: ; 0x17a91
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $E0
@@ -909,7 +909,7 @@ TileData_TimerDigit_Bottom_TenSeconds_7_GameBoy: ; 0x17a91
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_8_GameBoy: ; 0x17a9b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $100
@@ -917,7 +917,7 @@ TileData_TimerDigit_Bottom_TenSeconds_8_GameBoy: ; 0x17a9b
 	db $00
 
 TileData_TimerDigit_Bottom_TenSeconds_9_GameBoy: ; 0x17aa5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $7E
 	dw TimerDigitsGfx2 + $120
@@ -925,7 +925,7 @@ TileData_TimerDigit_Bottom_TenSeconds_9_GameBoy: ; 0x17aa5
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_0_GameBoy: ; 0x17aaf
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $00
@@ -933,7 +933,7 @@ TileData_TimerDigit_Bottom_OneSeconds_0_GameBoy: ; 0x17aaf
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_1_GameBoy: ; 0x17ab9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $20
@@ -941,7 +941,7 @@ TileData_TimerDigit_Bottom_OneSeconds_1_GameBoy: ; 0x17ab9
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_2_GameBoy: ; 0x17ac3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $40
@@ -949,7 +949,7 @@ TileData_TimerDigit_Bottom_OneSeconds_2_GameBoy: ; 0x17ac3
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_3_GameBoy: ; 0x17acd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $60
@@ -957,7 +957,7 @@ TileData_TimerDigit_Bottom_OneSeconds_3_GameBoy: ; 0x17acd
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_4_GameBoy: ; 0x17ad7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $80
@@ -965,7 +965,7 @@ TileData_TimerDigit_Bottom_OneSeconds_4_GameBoy: ; 0x17ad7
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_5_GameBoy: ; 0x17ae1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $A0
@@ -973,7 +973,7 @@ TileData_TimerDigit_Bottom_OneSeconds_5_GameBoy: ; 0x17ae1
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_6_GameBoy: ; 0x17aeb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $C0
@@ -981,7 +981,7 @@ TileData_TimerDigit_Bottom_OneSeconds_6_GameBoy: ; 0x17aeb
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_7_GameBoy: ; 0x17af5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $E0
@@ -989,7 +989,7 @@ TileData_TimerDigit_Bottom_OneSeconds_7_GameBoy: ; 0x17af5
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_8_GameBoy: ; 0x17aff
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $100
@@ -997,7 +997,7 @@ TileData_TimerDigit_Bottom_OneSeconds_8_GameBoy: ; 0x17aff
 	db $00
 
 TileData_TimerDigit_Bottom_OneSeconds_9_GameBoy: ; 0x17b09
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3C
 	dw TimerDigitsGfx2 + $120
@@ -1005,7 +1005,7 @@ TileData_TimerDigit_Bottom_OneSeconds_9_GameBoy: ; 0x17b09
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_0_GameBoy: ; 0x17b13
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $00
@@ -1013,7 +1013,7 @@ TileData_TimerDigit_Bonus_Minute_0_GameBoy: ; 0x17b13
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_1_GameBoy: ; 0x17b1d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $20
@@ -1021,7 +1021,7 @@ TileData_TimerDigit_Bonus_Minute_1_GameBoy: ; 0x17b1d
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_2_GameBoy: ; 0x17b27
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $40
@@ -1029,7 +1029,7 @@ TileData_TimerDigit_Bonus_Minute_2_GameBoy: ; 0x17b27
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_3_GameBoy: ; 0x17b31
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $60
@@ -1037,7 +1037,7 @@ TileData_TimerDigit_Bonus_Minute_3_GameBoy: ; 0x17b31
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_4_GameBoy: ; 0x17b3b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $80
@@ -1045,7 +1045,7 @@ TileData_TimerDigit_Bonus_Minute_4_GameBoy: ; 0x17b3b
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_5_GameBoy: ; 0x17b45
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $A0
@@ -1053,7 +1053,7 @@ TileData_TimerDigit_Bonus_Minute_5_GameBoy: ; 0x17b45
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_6_GameBoy: ; 0x17b4f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $C0
@@ -1061,7 +1061,7 @@ TileData_TimerDigit_Bonus_Minute_6_GameBoy: ; 0x17b4f
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_7_GameBoy: ; 0x17b59
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $E0
@@ -1069,7 +1069,7 @@ TileData_TimerDigit_Bonus_Minute_7_GameBoy: ; 0x17b59
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_8_GameBoy: ; 0x17b63
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $100
@@ -1077,7 +1077,7 @@ TileData_TimerDigit_Bonus_Minute_8_GameBoy: ; 0x17b63
 	db $00
 
 TileData_TimerDigit_Bonus_Minute_9_GameBoy: ; 0x17b6d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $72
 	dw TimerDigitsGfx2 + $120
@@ -1085,7 +1085,7 @@ TileData_TimerDigit_Bonus_Minute_9_GameBoy: ; 0x17b6d
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_0_GameBoy: ; 0x17b77
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $00
@@ -1093,7 +1093,7 @@ TileData_TimerDigit_Bonus_TenSeconds_0_GameBoy: ; 0x17b77
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_1_GameBoy: ; 0x17b81
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $20
@@ -1101,7 +1101,7 @@ TileData_TimerDigit_Bonus_TenSeconds_1_GameBoy: ; 0x17b81
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_2_GameBoy: ; 0x17b8b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $40
@@ -1109,7 +1109,7 @@ TileData_TimerDigit_Bonus_TenSeconds_2_GameBoy: ; 0x17b8b
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_3_GameBoy: ; 0x17b95
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $60
@@ -1117,7 +1117,7 @@ TileData_TimerDigit_Bonus_TenSeconds_3_GameBoy: ; 0x17b95
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_4_GameBoy: ; 0x17b9f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $80
@@ -1125,7 +1125,7 @@ TileData_TimerDigit_Bonus_TenSeconds_4_GameBoy: ; 0x17b9f
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_5_GameBoy: ; 0x17ba9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $A0
@@ -1133,7 +1133,7 @@ TileData_TimerDigit_Bonus_TenSeconds_5_GameBoy: ; 0x17ba9
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_6_GameBoy: ; 0x17bb3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $C0
@@ -1141,7 +1141,7 @@ TileData_TimerDigit_Bonus_TenSeconds_6_GameBoy: ; 0x17bb3
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_7_GameBoy: ; 0x17bbd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $E0
@@ -1149,7 +1149,7 @@ TileData_TimerDigit_Bonus_TenSeconds_7_GameBoy: ; 0x17bbd
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_8_GameBoy: ; 0x17bc7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $100
@@ -1157,7 +1157,7 @@ TileData_TimerDigit_Bonus_TenSeconds_8_GameBoy: ; 0x17bc7
 	db $00
 
 TileData_TimerDigit_Bonus_TenSeconds_9_GameBoy: ; 0x17bd1
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $74
 	dw TimerDigitsGfx2 + $120
@@ -1165,7 +1165,7 @@ TileData_TimerDigit_Bonus_TenSeconds_9_GameBoy: ; 0x17bd1
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_0_GameBoy: ; 0x17bdb
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $00
@@ -1173,7 +1173,7 @@ TileData_TimerDigit_Bonus_OneSeconds_0_GameBoy: ; 0x17bdb
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_1_GameBoy: ; 0x17be5
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $20
@@ -1181,7 +1181,7 @@ TileData_TimerDigit_Bonus_OneSeconds_1_GameBoy: ; 0x17be5
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_2_GameBoy: ; 0x17bef
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $40
@@ -1189,7 +1189,7 @@ TileData_TimerDigit_Bonus_OneSeconds_2_GameBoy: ; 0x17bef
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_3_GameBoy: ; 0x17bf9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $60
@@ -1197,7 +1197,7 @@ TileData_TimerDigit_Bonus_OneSeconds_3_GameBoy: ; 0x17bf9
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_4_GameBoy: ; 0x17c03
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $80
@@ -1205,7 +1205,7 @@ TileData_TimerDigit_Bonus_OneSeconds_4_GameBoy: ; 0x17c03
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_5_GameBoy: ; 0x17c0d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $A0
@@ -1213,7 +1213,7 @@ TileData_TimerDigit_Bonus_OneSeconds_5_GameBoy: ; 0x17c0d
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_6_GameBoy: ; 0x17c17
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $C0
@@ -1221,7 +1221,7 @@ TileData_TimerDigit_Bonus_OneSeconds_6_GameBoy: ; 0x17c17
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_7_GameBoy: ; 0x17c21
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $E0
@@ -1229,7 +1229,7 @@ TileData_TimerDigit_Bonus_OneSeconds_7_GameBoy: ; 0x17c21
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_8_GameBoy: ; 0x17c2b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $100
@@ -1237,7 +1237,7 @@ TileData_TimerDigit_Bonus_OneSeconds_8_GameBoy: ; 0x17c2b
 	db $00
 
 TileData_TimerDigit_Bonus_OneSeconds_9_GameBoy: ; 0x17c35
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $76
 	dw TimerDigitsGfx2 + $120
@@ -1245,7 +1245,7 @@ TileData_TimerDigit_Bonus_OneSeconds_9_GameBoy: ; 0x17c35
 	db $00
 
 TileData_TimerDigit_Top_Colon_GameBoy: ; 0x17c3f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $36
 	dw TimerDigitsGfx2 + $140
@@ -1253,7 +1253,7 @@ TileData_TimerDigit_Top_Colon_GameBoy: ; 0x17c3f
 	db $00
 
 TileData_TimerDigit_Bottom_Colon_GameBoy: ; 0x17c49
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $28
 	dw TimerDigitsGfx2 + $140
@@ -1261,7 +1261,7 @@ TileData_TimerDigit_Bottom_Colon_GameBoy: ; 0x17c49
 	db $00
 
 TileData_TimerDigit_BottomCatchem_Colon_GameBoy: ; 0x17c53
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $38
 	dw TimerDigitsGfx2 + $140
@@ -1269,7 +1269,7 @@ TileData_TimerDigit_BottomCatchem_Colon_GameBoy: ; 0x17c53
 	db $00
 
 TileData_TimerDigit_Bonus_Colon_GameBoy: ; 0x17c5d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesOB tile $78
 	dw TimerDigitsGfx2 + $140

--- a/engine/high_scores_screen.asm
+++ b/engine/high_scores_screen.asm
@@ -2,14 +2,14 @@ HandleHighScoresScreen: ; 0xca7f
 	ld a, [wScreenState]
 	rst JumpTable  ; calls JumpToFuncInTable
 HighScoresScreenFunctions: ; 0xca83
-	dw Func_ca8f
-	dw Func_cb14
-	dw Func_ccac
-	dw Func_ccb6
-	dw Func_cd6c
+	dw InitializeHighScoreEntry
+	dw LoadHighScoresScreen
+	dw UpdateHighScoreNameEntry
+	dw HandleHighScoresScreenInput
+	dw HandleHighScorePrintingSending
 	dw ExitHighScoresScreen
 
-Func_ca8f: ; 0xca8f
+InitializeHighScoreEntry: ; 0xca8f
 	ld hl, wHighScoreId
 	call GenRandom
 	ld [hli], a
@@ -96,7 +96,7 @@ Func_ca8f: ; 0xca8f
 	inc [hl]
 	ret
 
-Func_cb14: ; 0xcb14
+LoadHighScoresScreen: ; 0xcb14
 	ld a, $43
 	ldh [hLCDC], a
 	ld a, $e0
@@ -132,13 +132,13 @@ Func_cb14: ; 0xcb14
 	call ClearSpriteBuffer
 	ld a, $20
 	ld [wHighScoreNameEntryAsteriskBlinkCounter], a
-	call Func_d211
+	call UpdateHighScoreNameEntryAsterisks
 	hlCoord 0, 14, vBGMap
 	ld de, wRedHighScore5Id + $3
-	call Func_d2cb
+	call RenderHighScoreEntry
 	hlCoord 0, 14, vBGWin
 	ld de, wBlueHighScore5Id + $3
-	call Func_d2cb
+	call RenderHighScoreEntry
 	ld a, [wHighScoresStage]
 	and a
 	jr z, .asm_cb7f
@@ -166,9 +166,9 @@ Func_cb14: ; 0xcb14
 .asm_cba6
 	call EnableLCD
 	ld bc, $0009
-	call Func_d68a
+	call CheckDexCompletionAndShowCrown
 	ld bc, $03c9
-	call Func_d68a
+	call CheckDexCompletionAndShowCrown
 	call FadeIn
 	ld hl, wScreenState
 	inc [hl]
@@ -181,9 +181,9 @@ Func_cb14: ; 0xcb14
 	call PlaySong
 	call EnableLCD
 	ld bc, $0009
-	call Func_d68a
+	call CheckDexCompletionAndShowCrown
 	ld bc, $03c9
-	call Func_d68a
+	call CheckDexCompletionAndShowCrown
 	call FadeIn
 	ld hl, wScreenState
 	inc [hl]
@@ -268,14 +268,14 @@ HighScoresBlueStageVideoData_GameBoyColor: ; 0xcc64
 	VIDEO_DATA_PALETTES HighScoresBlueStagePalettes, $80
 	db $FF, $FF  ; terminators
 
-Func_ccac: ; 0xccac
-	call Func_d18b
-	call Func_d1d2
-	call Func_d211
+UpdateHighScoreNameEntry: ; 0xccac
+	call HandleHighScoreNameCharacterInput
+	call HandleHighScoreNamePositionInput
+	call UpdateHighScoreNameEntryAsterisks
 	ret
 
-Func_ccb6: ; 0xccb6
-	call Func_d4cf
+HandleHighScoresScreenInput: ; 0xccb6
+	call HandleHighScoresStageTransition
 	call AnimateHighScoresArrow
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
@@ -302,7 +302,7 @@ Func_ccb6: ; 0xccb6
 .asm_cce4
 	bit 3, a
 	jr z, .asm_ccfb
-	call Func_1a43
+	call InitiateHighScoreTransferWithFlag
 	ldh a, [hGameBoyColorFlag]
 	ld [wd8f0], a
 	lb de, $00, $01
@@ -351,22 +351,22 @@ Func_ccb6: ; 0xccb6
 	call LoadVRAMData
 	hlCoord 0, 14, vBGMap
 	ld de, wRedHighScore5Id + $3
-	call Func_d361
+	call RenderHighScoreEntryToVRAM
 	hlCoord 0, 14, vBGWin
 	ld de, wBlueHighScore5Id + $3
-	call Func_d361
+	call RenderHighScoreEntryToVRAM
 	ld hl, wRedHighScore1Points
 	ld de, sHighScores
 	ld bc, $0082
 	call SaveData
 	ret
 
-Func_cd6c: ; 0xcd6c
+HandleHighScorePrintingSending: ; 0xcd6c
 	ldh a, [hFrameCounter]
 	and $1f
-	call z, Func_1a43
-	call Func_cf7d
-	call Func_cfa6
+	call z, InitiateHighScoreTransferWithFlag
+	call HandleHighScoresPrintSendSelection
+	call DrawHighScoresPrintSendDialog
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	jr z, .asm_cdbb
@@ -382,7 +382,7 @@ Func_cd6c: ; 0xcd6c
 	ld bc, $473b
 	ld a, SPRITE_HIGH_SCORES_PRINTING
 	call LoadSpriteData
-	call Func_d042
+	call PrintHighScoresToIR
 	jr .asm_cdc6
 
 .asm_cda1
@@ -392,7 +392,7 @@ Func_cd6c: ; 0xcd6c
 	ld de, MUSIC_NOTHING
 	call PlaySong
 	rst AdvanceFrame
-	call Func_cdce
+	call TransmitReceiveHighScores
 	push af
 	ld de, MUSIC_HI_SCORE
 	call PlaySong
@@ -411,13 +411,13 @@ Func_cd6c: ; 0xcd6c
 	dec [hl]
 	ret
 
-Func_cdce: ; 0xcdce
+TransmitReceiveHighScores: ; 0xcdce
 	push af
 	ld a, $0
 	ld [$abf6], a
 	pop af
 	call ClearSpriteBuffer
-	call Func_1be3
+	call InitializeIRTimingData
 	call SendHighScores
 	push af
 	ld a, $1
@@ -436,7 +436,7 @@ Func_cdce: ; 0xcdce
 	pop af
 	ld b, $82
 	ld hl, wRedHighScore1Points
-	call Func_1cf8
+	call TransmitIRData
 	ld a, [wd8ea]
 	cp $0
 	jp nz, .asm_ceb6
@@ -445,7 +445,7 @@ Func_cdce: ; 0xcdce
 	ld [$abf6], a
 	pop af
 	ld hl, wc4c0
-	call Func_1dda
+	call ReceiveIRData
 	ld a, [wd8ea]
 	cp $0
 	jp nz, .asm_ceb6
@@ -457,7 +457,7 @@ Func_cdce: ; 0xcdce
 	ld [$abf6], a
 	pop af
 	ld hl, wc4c0
-	call Func_1dda
+	call ReceiveIRData
 	ld a, [wd8ea]
 	cp $0
 	jr nz, .asm_ceb6
@@ -467,7 +467,7 @@ Func_cdce: ; 0xcdce
 	pop af
 	ld b, $82
 	ld hl, wRedHighScore1Points
-	call Func_1cf8
+	call TransmitIRData
 	ld a, [wd8ea]
 	cp $0
 	jr nz, .asm_ceb6
@@ -476,7 +476,7 @@ Func_cdce: ; 0xcdce
 	ld a, $6
 	ld [$abf6], a
 	pop af
-	call Func_ceca
+	call WaitForVBlankLine0
 	rst AdvanceFrame
 	ld hl, wc4cc
 	ld b, $5
@@ -486,7 +486,7 @@ Func_cdce: ; 0xcdce
 	ld d, h
 	ld e, l
 	ld hl, wRedHighScore5Id + $3
-	call Func_cfcb
+	call InsertReceivedHighScore
 	pop hl
 	pop bc
 	ld de, $000d
@@ -505,7 +505,7 @@ Func_cdce: ; 0xcdce
 	ld d, h
 	ld e, l
 	ld hl, wBlueHighScore5Id + $3
-	call Func_cfcb
+	call InsertReceivedHighScore
 	pop hl
 	pop bc
 	ld de, $000d
@@ -518,10 +518,10 @@ Func_cdce: ; 0xcdce
 	pop af
 	hlCoord 0, 14, vBGMap
 	ld de, wRedHighScore5Id + $3
-	call Func_d361
+	call RenderHighScoreEntryToVRAM
 	hlCoord 0, 14, vBGWin
 	ld de, wBlueHighScore5Id + $3
-	call Func_d361
+	call RenderHighScoreEntryToVRAM
 	ld hl, wRedHighScore1Points
 	ld de, sHighScores
 	ld bc, $0082
@@ -534,7 +534,7 @@ Func_cdce: ; 0xcdce
 	ld a, $9
 	ld [$abf6], a
 	pop af
-	call Func_ceca
+	call WaitForVBlankLine0
 	rst AdvanceFrame
 	push af
 	ld a, $a
@@ -543,10 +543,10 @@ Func_cdce: ; 0xcdce
 	scf
 	ret
 
-Func_ceca: ; 0xceca
+WaitForVBlankLine0: ; 0xceca
 	ldh a, [rLY]
 	and a
-	jr nz, Func_ceca
+	jr nz, WaitForVBlankLine0
 	ei
 	ret
 
@@ -582,7 +582,7 @@ SendHighScores: ; 0xced1
 	jr .asm_cf0e
 
 .asm_cf09
-	call Func_1c50
+	call HandleIRReceiveHandshake
 	jr .continueAttempts
 
 .asm_cf0e
@@ -597,7 +597,7 @@ SendHighScores: ; 0xced1
 	ld a, SPRITE_SENDING_HIGH_SCORES_TEXT
 	call LoadSpriteData
 	call CleanSpriteBuffer
-	call Func_1ca1
+	call HandleIRSendHandshake
 	ld a, [wSendHighScoresAnimationIndex]
 	cp $6
 	jr nz, .continueAttempts
@@ -623,7 +623,7 @@ SendHighScoresAnimationData: ; 0xcf4b
 	db $06, SPRITE_SEND_HIGH_SCORES_5
 	db $00  ; terminator
 
-Func_cf58: ; 0xcf58
+DisplayHighScoresErrorDialog: ; 0xcf58
 	cp SPRITE_HIGH_SCORES_ERROR_DIALOGS_COUNT + 1
 	ret z
 	push af
@@ -644,7 +644,7 @@ Func_cf58: ; 0xcf58
 	call PlaySoundEffect
 	ret
 
-Func_cf7d: ; 0xcf7d
+HandleHighScoresPrintSendSelection: ; 0xcf7d
 	ld a, [wNewlyPressedButtonsPersistent]
 	ld b, a
 	ld a, [wHighScoresPrintSendSelection]
@@ -669,7 +669,7 @@ Func_cf7d: ; 0xcf7d
 	call PlaySoundEffect
 	ret
 
-Func_cfa6: ; 0xcfa6
+DrawHighScoresPrintSendDialog: ; 0xcfa6
 	ld bc, $473b
 	ld a, SPRITE_HIGH_SCORES_PRINT_SEND_DIALOG_TEXT
 	call LoadSpriteData
@@ -689,7 +689,7 @@ Func_cfa6: ; 0xcfa6
 	call LoadSpriteData
 	ret
 
-Func_cfcb: ; 0xcfcb
+InsertReceivedHighScore: ; 0xcfcb
 	ld a, e
 	ldh [hHighscoresFF8C], a
 	ld a, d
@@ -747,7 +747,7 @@ Func_d005: ; 0xd005
 .asm_d010
 	ld a, c
 	ldh [hHighscoresFF8E], a
-	call Func_d035
+	call AdvanceHighScoreComparisonPointers
 	ret
 
 Func_d017: ; 0xd017
@@ -766,16 +766,16 @@ Func_d017: ; 0xd017
 	jr nz, .asm_d02b
 	ld b, $5
 .asm_d02b
-	call Func_d035
+	call AdvanceHighScoreComparisonPointers
 	scf
 	ret
 
 .asm_d030
-	call Func_d035
+	call AdvanceHighScoreComparisonPointers
 	and a
 	ret
 
-Func_d035: ; 0xd035
+AdvanceHighScoreComparisonPointers: ; 0xd035
 	ld a, e
 	sub c
 	ld e, a
@@ -790,7 +790,7 @@ Func_d035: ; 0xd035
 .asm_d041
 	ret
 
-Func_d042: ; 0xd042
+PrintHighScoresToIR: ; 0xd042
 	ldh a, [hJoypadState]
 	ld [wda86], a
 	ld b, a
@@ -823,15 +823,15 @@ Func_d042: ; 0xd042
 	ld de, wSendHighScoresTopBarTilemap + $200
 	ld bc, $0040
 	call FarCopyData
-	call Func_d6b6
-	call Func_d0e3
+	call MarkDexCompletionInHighScoresBar
+	call TransferHighScoreGraphicsToIR
 	ret c
 	ld a, [wda86]
 	bit 2, a
 	jr z, .asm_d0a2
 	ld de, wRedHighScore1Id
-	call Func_d107
-	call Func_d0f5
+	call FormatHighScoresToHexDisplay
+	call TransferHighScoreHexCharsToIR
 	ret c
 .asm_d0a2
 	ld a, BANK(HighScoresTilemap2)
@@ -849,40 +849,40 @@ Func_d042: ; 0xd042
 	ld de, wSendHighScoresTopBarTilemap + $200
 	ld bc, $0040
 	call FarCopyData
-	call Func_d6b6
-	call Func_d0e3
+	call MarkDexCompletionInHighScoresBar
+	call TransferHighScoreGraphicsToIR
 	ret c
 	ld a, [wda86]
 	bit 2, a
 	ret z
 	ld de, wBlueHighScore1Id
-	call Func_d107
-	call Func_d0f5
+	call FormatHighScoresToHexDisplay
+	call TransferHighScoreHexCharsToIR
 	ret
 
-Func_d0e3: ; 0xd0e3
+TransferHighScoreGraphicsToIR: ; 0xd0e3
 	ld a, BANK(HighScoresBaseGameBoyGfx)
 	ld hl, HighScoresBaseGameBoyGfx + $800
-	call Func_1a21
+	call InitiateHighScoreTransfer
 	ld a, [wd86d]
 	and a
 	ret z
-	call Func_cf58
+	call DisplayHighScoresErrorDialog
 	scf
 	ret
 
-Func_d0f5: ; 0xd0f5
+TransferHighScoreHexCharsToIR: ; 0xd0f5
 	ld a, BANK(HighScoresHexadecimalCharsGfx)
 	ld hl, HighScoresHexadecimalCharsGfx
-	call Func_1a21
+	call InitiateHighScoreTransfer
 	ld a, [wd86d]
 	and a
 	ret z
-	call Func_cf58
+	call DisplayHighScoresErrorDialog
 	scf
 	ret
 
-Func_d107: ; 0xd107
+FormatHighScoresToHexDisplay: ; 0xd107
 	ld hl, wSendHighScoresTopBarTilemap
 	ld a, $c0
 	ld b, $20
@@ -899,9 +899,9 @@ endr
 .inner
 	ld a, [de]
 	swap a
-	call Func_d159
+	call ConvertNibbleToHexTile
 	ld a, [de]
-	call Func_d159
+	call ConvertNibbleToHexTile
 	inc de
 	inc hl
 	dec c
@@ -922,7 +922,7 @@ endr
 	jr nz, .loop
 	ret
 
-Func_d159: ; 0xd159
+ConvertNibbleToHexTile: ; 0xd159
 	and $f
 	sla a
 	sla a
@@ -955,7 +955,7 @@ ExitHighScoresScreen: ; 0xd171
 	ld [wScreenState], a
 	ret
 
-Func_d18b: ; 0xd18b
+HandleHighScoreNameCharacterInput: ; 0xd18b
 	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [wHighScoreNameRow]
@@ -995,12 +995,12 @@ Func_d18b: ; 0xd18b
 	ld a, $37
 .asm_d1c7
 	ld [hl], a
-	call Func_d46f
+	call UpdateHighScoreNameTile
 	lb de, $00, $03
 	call PlaySoundEffect
 	ret
 
-Func_d1d2: ; 0xd1d2
+HandleHighScoreNamePositionInput: ; 0xd1d2
 	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wHighScoreNameColumn]
@@ -1035,7 +1035,7 @@ Func_d1d2: ; 0xd1d2
 	call PlaySoundEffect
 	ret
 
-Func_d211: ; 0xd211
+UpdateHighScoreNameEntryAsterisks: ; 0xd211
 ; related to high scores name entry?
 	ld a, [wHighScoreIsEnteringName]
 	and a
@@ -1121,7 +1121,7 @@ HighScoresLeftArrowSpritePixelXOffsets: ; 0xd2a3
 	db $01, $01, $01, $01, $01, $01, $01, $01
 	db $01, $01, $01, $01, $01, $01, $01, $01
 
-Func_d2cb: ; 0xd2cb
+RenderHighScoreEntry: ; 0xd2cb
 	ld b, $5
 .asm_d2cd
 	push bc
@@ -1136,7 +1136,7 @@ Func_d2cb: ; 0xd2cb
 	ld b, $3
 .asm_d2d9
 	ld a, [de]
-	call Func_d348
+	call PlaceHighScoreTileBufNoVRAM
 	dec de
 	dec hl
 	dec b
@@ -1162,7 +1162,7 @@ Func_d2cb: ; 0xd2cb
 	dec b
 	jr nz, .asm_d2eb
 	xor a
-	call Func_d317
+	call PlaceHighScoreTileWithPalette
 	pop hl
 	ld bc, -3 * $20
 	add hl, bc
@@ -1172,18 +1172,18 @@ Func_d2cb: ; 0xd2cb
 	ret
 
 Func_d30e: ; 0xd30e
-	jr nz, Func_d317
+	jr nz, PlaceHighScoreTileWithPalette
 	ld a, b
 	dec a
-	jr z, Func_d317
+	jr z, PlaceHighScoreTileWithPalette
 	ld a, c
 	and a
 	ret nz
 	; fall through
-Func_d317: ; 0xd317
+PlaceHighScoreTileWithPalette: ; 0xd317
 	push de
 	push af
-	call Func_d336
+	call DeterminePaletteOffsetForHex
 	pop af
 	ld c, $0
 	sla a
@@ -1207,7 +1207,7 @@ Func_d317: ; 0xd317
 	pop de
 	ret
 
-Func_d336: ; 0xd336
+DeterminePaletteOffsetForHex: ; 0xd336
 	ld e, $6c
 	ld a, b
 	cp $3
@@ -1221,7 +1221,7 @@ Func_d336: ; 0xd336
 	ld e, $58
 	ret
 
-Func_d348: ; 0xd348
+PlaceHighScoreTileBufNoVRAM: ; 0xd348
 	ld c, $0
 	sla a
 	add $90
@@ -1243,7 +1243,7 @@ Func_d348: ; 0xd348
 	pop hl
 	ret
 
-Func_d361: ; 0xd361
+RenderHighScoreEntryToVRAM: ; 0xd361
 	ld b, $5
 .asm_d363
 	push bc
@@ -1258,7 +1258,7 @@ Func_d361: ; 0xd361
 	ld b, $3
 .asm_d36f
 	ld a, [de]
-	call Func_d3e2
+	call PlaceHighScoreTileVRAMDirect
 	dec de
 	dec hl
 	dec b
@@ -1284,7 +1284,7 @@ Func_d361: ; 0xd361
 	dec b
 	jr nz, .asm_d381
 	xor a
-	call Func_d3ad
+	call PlaceHighScoreTileVRAM
 	pop hl
 	ld bc, -3 * $20
 	add hl, bc
@@ -1294,18 +1294,18 @@ Func_d361: ; 0xd361
 	ret
 
 Func_d3a4: ; 0xd3a4
-	jr nz, Func_d3ad
+	jr nz, PlaceHighScoreTileVRAM
 	ld a, b
 	dec a
-	jr z, Func_d3ad
+	jr z, PlaceHighScoreTileVRAM
 	ld a, c
 	and a
 	ret nz
 	; fall through
-Func_d3ad: ; 0xd3ad
+PlaceHighScoreTileVRAM: ; 0xd3ad
 	push de
 	push af
-	call Func_d3d0
+	call DeterminePaletteOffsetForHexVRAM
 	pop af
 	ld c, $0
 	sla a
@@ -1329,7 +1329,7 @@ Func_d3ad: ; 0xd3ad
 	pop de
 	ret
 
-Func_d3d0: ; 0xd3d0
+DeterminePaletteOffsetForHexVRAM: ; 0xd3d0
 	ld e, $6c
 	ld a, b
 	cp $3
@@ -1343,7 +1343,7 @@ Func_d3d0: ; 0xd3d0
 	ld e, $58
 	ret
 
-Func_d3e2: ; 0xd3e2
+PlaceHighScoreTileVRAMDirect: ; 0xd3e2
 	ld c, $0
 	sla a
 	add $90
@@ -1405,7 +1405,7 @@ CopyInitialHighScoresForStage: ; 0xd40e
 
 INCLUDE "data/initial_high_scores.asm" ; 0xd42e
 
-Func_d46f: ; 0xd46f
+UpdateHighScoreNameTile: ; 0xd46f
 	ld a, [wHighScoreNameRow]
 	ld d, a
 	sla a
@@ -1462,7 +1462,7 @@ Func_d46f: ; 0xd46f
 	call PutTileInVRAM
 	ret
 
-Func_d4cf: ; 0xd4cf
+HandleHighScoresStageTransition: ; 0xd4cf
 	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wHighScoresStage]
@@ -1485,7 +1485,7 @@ Func_d4cf: ; 0xd4cf
 
 .asm_d4f0
 	call ClearSpriteBuffer
-	call Func_d57b
+	call PrepareHighScoresTransition
 	ld a, $a5
 	ldh [hWX], a
 	xor a
@@ -1522,12 +1522,12 @@ Func_d4cf: ; 0xd4cf
 	set 3, [hl]
 	ld a, $1
 	ld [wHighScoresStage], a
-	call Func_d5d0
+	call CompleteHighScoresStageTransition
 	ret
 
 .asm_d537
 	call ClearSpriteBuffer
-	call Func_d57b
+	call PrepareHighScoresTransition
 	ld a, $7
 	ldh [hWX], a
 	xor a
@@ -1563,10 +1563,10 @@ Func_d4cf: ; 0xd4cf
 	res 5, [hl]
 	xor a
 	ld [wHighScoresStage], a
-	call Func_d5d0
+	call CompleteHighScoresStageTransition
 	ret
 
-Func_d57b: ; 0xd57b
+PrepareHighScoresTransition: ; 0xd57b
 	ld a, $f0
 	ldh [hSCY], a
 	xor a
@@ -1607,7 +1607,7 @@ Func_d57b: ; 0xd57b
 	jr nz, .asm_d5c1
 	ret
 
-Func_d5d0: ; 0xd5d0
+CompleteHighScoresStageTransition: ; 0xd5d0
 	ld b, $10
 .asm_d5d2
 	push bc
@@ -1640,7 +1640,7 @@ Func_d5d0: ; 0xd5d0
 	ld bc, $0040
 	call LoadVRAMData
 	ld bc, $0009
-	call Func_d68a
+	call CheckDexCompletionAndShowCrown
 	xor a
 	ldh [hSCY], a
 	ldh [hNextFrameHBlankSCX], a
@@ -1676,11 +1676,11 @@ TransitionHighScoresPalettes: ; 0xd626
 	ld de, $0008
 	ld bc, $0038
 	push af
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 	pop af
 	ld de, $0040
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 	ret
 
 HighScoresPalettesTransition: ; 0xd65a
@@ -1704,7 +1704,7 @@ HighScoresPalettesTransition: ; 0xd65a
 	dwb HighScoresTransitionPalettes15, Bank(HighScoresTransitionPalettes15)
 	dwb HighScoresTransitionPalettes16, Bank(HighScoresTransitionPalettes16)
 
-Func_d68a: ; 0xd68a
+CheckDexCompletionAndShowCrown: ; 0xd68a
 	push bc
 	ld hl, wPokedexFlags
 	ld bc, (NUM_POKEMON << 8)
@@ -1734,7 +1734,7 @@ ShowDexCompletionCrown: ; 0xd6aa
 	call PutTileInVRAM
 	ret
 
-Func_d6b6: ; 0xd6b6
+MarkDexCompletionInHighScoresBar: ; 0xd6b6
 	ld hl, wPokedexFlags
 	ld bc, (NUM_POKEMON << 8)
 .asm_d6bc

--- a/engine/options_screen.asm
+++ b/engine/options_screen.asm
@@ -2,14 +2,14 @@ HandleOptionsScreen: ; 0xc34a
 	ld a, [wScreenState]
 	rst JumpTable  ; calls JumpToFuncInTable
 OptionsScreenFunctions: ; 0xc34e
-	dw Func_c35a
-	dw Func_c400
-	dw Func_c483
-	dw Func_c493
-	dw Func_c506
-	dw Func_c691
+	dw InitializeOptionsScreen
+	dw HandleOptionsScreenMainLoop
+	dw ExitToTitleScreen
+	dw HandleGameSettingsScreen
+	dw HandleKeyConfigScreen
+	dw HandleSoundTestScreen
 
-Func_c35a: ; 0xc35a
+InitializeOptionsScreen: ; 0xc35a
 	ld a, $47
 	ldh [hLCDC], a
 	ld a, $e4
@@ -29,8 +29,8 @@ Func_c35a: ; 0xc35a
 	ld [wOptionsPsyduckAnimationTimer], a
 	ld a, $9
 	ld [wOptionsPikachuAnimationTimer], a
-	call Func_c43a
-	call Func_c948
+	call UpdateOptionsScreenAnimations
+	call RenderAllKeyConfigDigits
 	call SetAllPalettesWhite
 	ld a, Bank(Music_Options)
 	call SetSongBank
@@ -67,10 +67,10 @@ OptionsScreenVideoData_GameBoyColor: ; 0xc3d4
 	VIDEO_DATA_PALETTES      OptionMenuPalettes, $80
 	db $FF, $FF ; terminators
 
-Func_c400: ; 0xc400
-	call Func_c41a
-	call Func_c43a
-	call Func_c447
+HandleOptionsScreenMainLoop: ; 0xc400
+	call HandleOptionsMenuNavigation
+	call UpdateOptionsScreenAnimations
+	call HandleOptionsMenuSelection
 	ldh a, [hNewlyPressedButtons]
 	bit 1, a
 	ret z
@@ -80,7 +80,7 @@ Func_c400: ; 0xc400
 	ld [wScreenState], a
 	ret
 
-Func_c41a: ; 0xc41a
+HandleOptionsMenuNavigation: ; 0xc41a
 	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [wd916]
@@ -103,14 +103,14 @@ Func_c41a: ; 0xc41a
 	call PlaySoundEffect
 	ret
 
-Func_c43a: ; 0xc43a
+UpdateOptionsScreenAnimations: ; 0xc43a
 	call HandleOptionsPsyduckAnimation
 	call HandleOptionsPikachuAnimation
 	call HandleOptionsPokeballAnimation
-	call Func_c92e
+	call UpdateFadedArrowSprite
 	ret
 
-Func_c447: ; 0xc447
+HandleOptionsMenuSelection: ; 0xc447
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a
 	ret z
@@ -122,7 +122,7 @@ Func_c447: ; 0xc447
 	ldh a, [hSGBFlag]
 	and a
 	ret nz
-	call Func_c4f4
+	call ResetAnimationFrames
 	ld a, $3
 	ld [wScreenState], a
 	ret
@@ -144,7 +144,7 @@ Func_c447: ; 0xc447
 	ld [wScreenState], a
 	ret
 
-Func_c483: ; 0xc483
+ExitToTitleScreen: ; 0xc483
 	call FadeOut
 	call DisableLCD
 	ld a, SCREEN_TITLESCREEN
@@ -153,10 +153,10 @@ Func_c483: ; 0xc483
 	ld [wScreenState], a
 	ret
 
-Func_c493: ; 0xc493
-	call Func_c4b4
-	call Func_c4e6
-	call Func_c869
+HandleGameSettingsScreen: ; 0xc493
+	call HandleRumbleToggleInput
+	call UpdateGameSettingsScreenAnimations
+	call TriggerRumbleAtPikachuPeakFrame
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	ret z
@@ -169,17 +169,17 @@ Func_c493: ; 0xc493
 	ld [wScreenState], a
 	ret
 
-Func_c4b4: ; 0xc4b4
+HandleRumbleToggleInput: ; 0xc4b4
 	ldh a, [hNewlyPressedButtons]
 	ld b, a
-	ld a, [wd917]
+	ld a, [wDisableRumble]
 	bit BIT_D_LEFT, b
 	jr z, .asm_c4ce
 	and a
 	ret z
 	dec a
-	ld [wd917], a
-	call Func_c4f4
+	ld [wDisableRumble], a
+	call ResetAnimationFrames
 	lb de, $00, $03
 	call PlaySoundEffect
 	ret
@@ -190,7 +190,7 @@ Func_c4b4: ; 0xc4b4
 	cp $1
 	ret z
 	inc a
-	ld [wd917], a
+	ld [wDisableRumble], a
 	xor a
 	ld [wRumblePattern], a
 	ld [wRumbleDuration], a
@@ -198,15 +198,15 @@ Func_c4b4: ; 0xc4b4
 	call PlaySoundEffect
 	ret
 
-Func_c4e6: ; 0xc4e6
+UpdateGameSettingsScreenAnimations: ; 0xc4e6
 	call HandleOptionsPsyduckAnimation
 	call HandleOptionsPikachuAnimation
 	call HandleOptionsPokeballAnimation
 	xor a
-	call Func_c8f1
+	call UpdateArrowCursorSprite
 	ret
 
-Func_c4f4: ; 0xc4f4
+ResetAnimationFrames: ; 0xc4f4
 	xor a
 	ld [wOptionsPsyduckAnimationFrame], a
 	ld [wOptionsPikachuAnimationFrame], a
@@ -216,10 +216,10 @@ Func_c4f4: ; 0xc4f4
 	ld [wOptionsPikachuAnimationTimer], a
 	ret
 
-Func_c506: ; 0xc506
-	call Func_c534
-	call Func_c554
-	call Func_c55a
+HandleKeyConfigScreen: ; 0xc506
+	call HandleKeyConfigNavigation
+	call UpdateKeyConfigArrowSprite
+	call HandleKeyConfigSelection
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	ret z
@@ -236,7 +236,7 @@ Func_c506: ; 0xc506
 	ld [wScreenState], a
 	ret
 
-Func_c534: ; 0xc534
+HandleKeyConfigNavigation: ; 0xc534
 	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wd918]
@@ -259,12 +259,12 @@ Func_c534: ; 0xc534
 	call PlaySoundEffect
 	ret
 
-Func_c554: ; 0xc554
+UpdateKeyConfigArrowSprite: ; 0xc554
 	ld a, $1
-	call Func_c8f1
+	call UpdateArrowCursorSprite
 	ret
 
-Func_c55a: ; 0xc55a
+HandleKeyConfigSelection: ; 0xc55a
 	ld a, [wd918]
 	and a
 	jr nz, .asm_c572
@@ -274,7 +274,7 @@ Func_c55a: ; 0xc55a
 	lb de, $00, $01
 	call PlaySoundEffect
 	call SaveDefaultKeyConfigs
-	call Func_c948
+	call RenderAllKeyConfigDigits
 	ret
 
 .asm_c572
@@ -298,7 +298,7 @@ Func_c55a: ; 0xc55a
 	ld a, [wd918]
 	dec a
 	sla a
-	call Func_c644
+	call ClearKeyConfigOption
 	ld bc, $00ff
 .asm_c59f
 	push bc
@@ -306,8 +306,8 @@ Func_c55a: ; 0xc55a
 	ld a, [wd918]
 	dec a
 	sla a
-	call Func_c621
-	call Func_c554
+	call RenderKeyInputCursorFrame
+	call UpdateKeyConfigArrowSprite
 	call CleanSpriteBuffer
 	rst AdvanceFrame
 	pop hl
@@ -316,8 +316,8 @@ Func_c55a: ; 0xc55a
 	and a
 	jr z, .asm_c5c2
 	ld c, $0
-	call Func_c9be
-	call Func_c95f
+	call UpdateKeyInputDisplayBuffer
+	call ConvertKeyButtonToTileDigit
 	jr .asm_c59f
 
 .asm_c5c2
@@ -326,7 +326,7 @@ Func_c55a: ; 0xc55a
 	ld a, [wd918]
 	dec a
 	sla a
-	call Func_c639
+	call SaveKeyInputResult
 	push hl
 	ld bc, $001e
 	call AdvanceFrames
@@ -337,7 +337,7 @@ Func_c55a: ; 0xc55a
 	dec a
 	sla a
 	inc a
-	call Func_c644
+	call ClearKeyConfigOption
 	ld bc, $00ff
 	ld d, $5a
 .asm_c5e9
@@ -348,8 +348,8 @@ Func_c55a: ; 0xc55a
 	dec a
 	sla a
 	inc a
-	call Func_c621
-	call Func_c554
+	call RenderKeyInputCursorFrame
+	call UpdateKeyConfigArrowSprite
 	call CleanSpriteBuffer
 	rst AdvanceFrame
 	pop hl
@@ -362,8 +362,8 @@ Func_c55a: ; 0xc55a
 	jr z, .asm_c613
 	ld d, $ff
 	ld c, $0
-	call Func_c9be
-	call Func_c95f
+	call UpdateKeyInputDisplayBuffer
+	call ConvertKeyButtonToTileDigit
 	jr .asm_c5e9
 
 .asm_c613
@@ -373,10 +373,10 @@ Func_c55a: ; 0xc55a
 	dec a
 	sla a
 	inc a
-	call Func_c639
+	call SaveKeyInputResult
 	ret
 
-Func_c621: ; 0xc621
+RenderKeyInputCursorFrame: ; 0xc621
 	sla a
 	ld c, a
 	ld b, $0
@@ -393,7 +393,7 @@ Func_c621: ; 0xc621
 	call LoadSpriteData
 	ret
 
-Func_c639: ; 0xc639
+SaveKeyInputResult: ; 0xc639
 	push hl
 	ld e, a
 	ld d, $0
@@ -403,7 +403,7 @@ Func_c639: ; 0xc639
 	pop hl
 	ret
 
-Func_c644: ; 0xc644
+ClearKeyConfigOption: ; 0xc644
 	push hl
 	ld c, a
 	ld b, $0
@@ -449,10 +449,10 @@ SpritePixelOffsetData_c66d: ; 0xc66d
 Data_c689: ; 0xc689
 	db $81, $81, $81, $81, $81, $81, $81, $81
 
-Func_c691: ; 0xc91
-	call Func_c6bf
-	call Func_c6d9
-	call Func_c6e8
+HandleSoundTestScreen: ; 0xc91
+	call HandleSoundTestModeToggle
+	call UpdateSoundTestScreenAnimations
+	call HandleSoundTestSelection
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
 	ret z
@@ -471,7 +471,7 @@ Func_c691: ; 0xc91
 	ld [wScreenState], a
 	ret
 
-Func_c6bf: ; 0xc6bf
+HandleSoundTestModeToggle: ; 0xc6bf
 	ldh a, [hNewlyPressedButtons]
 	ld b, a
 	ld a, [wd919]
@@ -492,15 +492,15 @@ Func_c6bf: ; 0xc6bf
 	ld [wd919], a
 	ret
 
-Func_c6d9: ; 0xc6d9
+UpdateSoundTestScreenAnimations: ; 0xc6d9
 	call HandleOptionsPsyduckAnimation
 	call HandleOptionsPikachuAnimation
 	call HandleOptionsPokeballAnimation
 	ld a, $2
-	call Func_c8f1
+	call UpdateArrowCursorSprite
 	ret
 
-Func_c6e8: ; 0xc6e8
+HandleSoundTestSelection: ; 0xc6e8
 	ld a, [wd919]
 	and a
 	jr nz, UpdateSoundTestSoundEffectSelection
@@ -633,7 +633,7 @@ HandleOptionsPsyduckAnimation: ; 0xc7ac
 	ld a, [wd916]
 	and a
 	jr nz, .asm_c7cc
-	ld a, [wd917]
+	ld a, [wDisableRumble]
 	and a
 	jr nz, .asm_c7cc
 	ld a, [wOptionsPikachuAnimationFrame]
@@ -689,7 +689,7 @@ HandleOptionsPikachuAnimation: ; 0xc80b
 	ld a, [wd916]
 	and a
 	jr nz, .asm_c824
-	ld a, [wd917]
+	ld a, [wDisableRumble]
 	and a
 	jr nz, .asm_c824
 	ld a, [wOptionsPikachuAnimationFrame]
@@ -736,11 +736,11 @@ AnimationData_OptionsPikachu: ; 0xc85e
 	db SPRITE_OPTIONS_PIKACHU_3, $01
 	db $00 ; terminator
 
-Func_c869: ; 0xc869
+TriggerRumbleAtPikachuPeakFrame: ; 0xc869
 	ld a, [wd916]
 	and a
 	ret nz
-	ld a, [wd917]
+	ld a, [wDisableRumble]
 	and a
 	ret nz
 	ld a, [wOptionsPikachuAnimationFrame]
@@ -821,10 +821,10 @@ SpritePixelOffsets_OptionsPokeball: ; 0xc8eb
 	db $30, $08
 	db $48, $08
 
-Func_c8f1: ; 0xc8f1
+UpdateArrowCursorSprite: ; 0xc8f1
 	ld c, a
 	ld b, $0
-	ld hl, wd917
+	ld hl, wDisableRumble
 	add hl, bc
 	ld e, [hl]
 	sla c
@@ -867,8 +867,8 @@ SpritePixelOffsets_OptionsArrowBgm: ; 0xc92a
 	dw $1058
 	dw $1068
 
-Func_c92e: ; 0xc92e
-	ld a, [wd917]
+UpdateFadedArrowSprite: ; 0xc92e
+	ld a, [wDisableRumble]
 	sla a
 	ld c, a
 	ld b, $0
@@ -886,14 +886,14 @@ SpritePixelOffsets_OptionsArrowFadedRumble: ; 0xc944
 	dw $5018
 	dw $7018
 
-Func_c948: ; 0xc948
+RenderAllKeyConfigDigits: ; 0xc948
 	hlCoord 13, 3, vBGWin
 	ld de, wKeyConfigBallStart
 	ld b, $e
 .asm_c950
 	push bc
 	ld a, [de]
-	call Func_c95f
+	call ConvertKeyButtonToTileDigit
 	inc de
 	ld bc, $0020
 	add hl, bc
@@ -902,7 +902,7 @@ Func_c948: ; 0xc948
 	jr nz, .asm_c950
 	ret
 
-Func_c95f: ; 0xc95f
+ConvertKeyButtonToTileDigit: ; 0xc95f
 	push bc
 	push de
 	push hl
@@ -927,16 +927,16 @@ Func_c95f: ; 0xc95f
 	jr nc, .asm_c994
 	ld a, [de]
 	inc de
-	call Func_c9aa
+	call WriteNonzeroTileToBuffer
 	ld a, [de]
 	inc de
-	call Func_c9aa
+	call WriteNonzeroTileToBuffer
 	pop af
 	push af
 	and a
 	jr z, .asm_c996
 	ld a, $1a
-	call Func_c9aa
+	call WriteNonzeroTileToBuffer
 	jr .asm_c996
 
 .asm_c994
@@ -956,7 +956,7 @@ Func_c95f: ; 0xc95f
 	pop bc
 	ret
 
-Func_c9aa: ; 0xc9aa
+WriteNonzeroTileToBuffer: ; 0xc9aa
 	and a
 	ret z
 	ld [hli], a
@@ -965,7 +965,7 @@ Func_c9aa: ; 0xc9aa
 Data_c9ae: ; 0xc9ae
 	db $14, $00, $15, $00, $18, $19, $16, $17, $13, $00, $12, $00, $10, $00, $11, $00
 
-Func_c9be: ; 0xc9be
+UpdateKeyInputDisplayBuffer: ; 0xc9be
 	push af
 	push bc
 	push hl
@@ -973,10 +973,10 @@ Func_c9be: ; 0xc9be
 	xor b
 	and c
 	ld hl, wd936
-	call Func_c9ff
+	call ConvertButtonBitToTileArray
 	ld a, b
 	ld hl, wd93f
-	call Func_c9ff
+	call ConvertButtonBitToTileArray
 	ld a, [wd947]
 	cp $3
 	jr nc, .asm_c9f3
@@ -984,7 +984,7 @@ Func_c9be: ; 0xc9be
 	add [hl]
 	sub $4
 	ld hl, wd936
-	call nc, Func_ca15
+	call nc, ClearBufferTiles
 	ld de, wd936
 	ld hl, wd93f
 	ld b, $8
@@ -997,7 +997,7 @@ Func_c9be: ; 0xc9be
 	jr nz, .asm_c9ec
 .asm_c9f3
 	ld hl, wd93f
-	call Func_ca29
+	call ConvertTileArrayToButtonBits
 	pop hl
 	pop bc
 	ld b, a
@@ -1005,7 +1005,7 @@ Func_c9be: ; 0xc9be
 	ld a, b
 	ret
 
-Func_c9ff: ; 0xc9ff
+ConvertButtonBitToTileArray: ; 0xc9ff
 	push bc
 	ld bc, $0800
 .asm_ca03
@@ -1025,7 +1025,7 @@ Func_c9ff: ; 0xc9ff
 	pop bc
 	ret
 
-Func_ca15: ; 0xca15
+ClearBufferTiles: ; 0xca15
 	push bc
 	inc a
 	ld c, a
@@ -1045,7 +1045,7 @@ Func_ca15: ; 0xca15
 	pop bc
 	ret
 
-Func_ca29: ; 0ca29
+ConvertTileArrayToButtonBits: ; 0ca29
 	push bc
 	ld bc, $0800
 .asm_ca2d

--- a/engine/pinball_game.asm
+++ b/engine/pinball_game.asm
@@ -154,10 +154,10 @@ GameScreenFunction_HandleBallPhysics: ; 0xd909
 	ld a, [wDisableDrawScoreboardInfo]
 	and a
 	jr nz, .skipDrawingScoreboard
-	callba Func_85c7
+	callba ProcessScoreQueue
 	callba HideScoreIfBallLow
-	callba Func_8645
-	call Func_dba9
+	callba DrawScoreToBottomBar
+	call DrawBallLifeIndicator
 	call DrawNumPartyMonsIcon
 	call DrawPikachuSaverLightningBoltIcon
 .skipDrawingScoreboard
@@ -192,7 +192,7 @@ GameScreenFunction_HandleBallLoss: ; 0xda36
 	callba nz, HandleFlippers
 	callba DrawSpritesForStage
 	call UpdateBottomText
-	callba Func_85c7
+	callba ProcessScoreQueue
 	ld a, [wBottomTextEnabled]
 	and a
 	ret nz
@@ -346,7 +346,7 @@ HighScoresStageMapping: ; 0xdb99
 	db $00  ; STAGE_SEEL_BONUS
 	db $00  ; STAGE_SEEL_BONUS
 
-Func_dba9: ; 0xdba9
+DrawBallLifeIndicator: ; 0xdba9
 	ld a, $85
 	ld [wBottomMessageBuffer + $44], a
 	ld a, [wCurBallLife]

--- a/engine/pinball_game/ball_init/ball_init.asm
+++ b/engine/pinball_game/ball_init/ball_init.asm
@@ -32,8 +32,8 @@ InitBallForStage: ; 0x83ba
 InitBall_CallTable: ; 0x8404
 	padded_dab InitBallRedField          ; STAGE_RED_FIELD_TOP
 	padded_dab InitBallRedField          ; STAGE_RED_FIELD_BOTTOM
-	padded_dab Func_1804a
-	padded_dab Func_1804a
+	padded_dab InitBallPosition_UnusedStage
+	padded_dab InitBallPosition_UnusedStage
 	padded_dab InitBallBlueField         ; STAGE_BLUE_FIELD_TOP
 	padded_dab InitBallBlueField         ; STAGE_BLUE_FIELD_BOTTOM
 	padded_dab InitBallGengarBonusStage  ; STAGE_GENGAR_BONUS

--- a/engine/pinball_game/ball_init/ball_init_blue_field.asm
+++ b/engine/pinball_game/ball_init/ball_init_blue_field.asm
@@ -12,7 +12,7 @@ InitBallBlueField: ; 0x1c08d
 	ld [wBallYPos + 1], a
 	xor a
 	ld [wEnableBallGravityAndTilt], a
-	ld [wd580], a
+	ld [wTimerGraphicsNeedsLoading], a
 	call InitBlueFieldCollisionAttributes
 	ld a, [wLostBall]
 	and a
@@ -23,7 +23,7 @@ InitBallBlueField: ; 0x1c08d
 	ld [wSpinnerVelocity], a
 	ld [wSpinnerVelocity + 1], a
 	ld [wPikachuSaverSlotRewardActive], a
-	ld [wd51e], a
+	ld [wSpinnerChargeSoundCooldown], a
 	ld [wPikachuSaverCharge], a
 	ld hl, wCAVELightStates
 	ld [hli], a

--- a/engine/pinball_game/ball_init/ball_init_gengar_bonus.asm
+++ b/engine/pinball_game/ball_init/ball_init_gengar_bonus.asm
@@ -12,7 +12,7 @@ InitBallGengarBonusStage: ; 0x18157
 	ld [wStageCollisionState], a
 	ld [wGengarBonusClosedGate], a
 	xor a
-	ld [wd674], a
+	ld [wGengarPhaseTimer], a
 	ld a, $8
 	ld [wd690], a
 	ld [wd6a1], a

--- a/engine/pinball_game/ball_init/ball_init_red_field.asm
+++ b/engine/pinball_game/ball_init/ball_init_red_field.asm
@@ -12,7 +12,7 @@ InitBallRedField: ; 0x3007d
 	ld [wBallYPos + 1], a
 	xor a
 	ld [wEnableBallGravityAndTilt], a
-	ld [wd580], a
+	ld [wTimerGraphicsNeedsLoading], a
 	ld a, [wRedStageStructureBackup]
 	bit 7, a
 	jr z, .asm_300ae
@@ -33,7 +33,7 @@ InitBallRedField: ; 0x3007d
 	ld [wSpinnerVelocity + 1], a
 	ld [wPikachuSaverSlotRewardActive], a
 	ld [wPikachuSaverCharge], a
-	ld [wd51e], a
+	ld [wSpinnerChargeSoundCooldown], a
 	ld hl, wCAVELightStates
 	ld [hli], a
 	ld [hli], a

--- a/engine/pinball_game/ball_init/ball_init_seel_bonus.asm
+++ b/engine/pinball_game/ball_init/ball_init_seel_bonus.asm
@@ -50,13 +50,13 @@ InitBallSeelBonusStage: ; 0x25af1
 	ld [wd79a], a
 	ld de, wd76b
 	ld a, [wd76c]
-	call Func_26137
+	call InitializeSeelAnimationState
 	ld de, wd775
 	ld a, [wd776]
-	call Func_26137
+	call InitializeSeelAnimationState
 	ld de, wd77f
 	ld a, [wd780]
-	call Func_26137
+	call InitializeSeelAnimationState
 	ld a, [wLostBall]
 	and a
 	ret z

--- a/engine/pinball_game/ball_init/ball_init_unused_stage.asm
+++ b/engine/pinball_game/ball_init/ball_init_unused_stage.asm
@@ -1,4 +1,4 @@
-Func_1804a: ; 0x1804a
+InitBallPosition_UnusedStage: ; 0x1804a
 ; Unused -- Init ball routine for unused stage.
 	ld a, $0
 	ld [wBallXPos], a

--- a/engine/pinball_game/ball_loss/ball_loss.asm
+++ b/engine/pinball_game/ball_loss/ball_loss.asm
@@ -6,8 +6,8 @@ CallTable_dc4d: ; 0xdc4d
 	dw HandleBallLossRedField
 	; STAGE_RED_FIELD_BOTTOM
 	dw HandleBallLossRedField
-	dw Func_de4e
-	dw Func_de4e
+	dw DoNothing_BallLoss_Unused
+	dw DoNothing_BallLoss_Unused
 	; STAGE_BLUE_FIELD_TOP
 	dw HandleBallLossBlueField
 	; STAGE_BLUE_FIELD_TOP

--- a/engine/pinball_game/ball_loss/ball_loss_meowth_bonus.asm
+++ b/engine/pinball_game/ball_loss/ball_loss_meowth_bonus.asm
@@ -20,7 +20,7 @@ HandleBallLossMeowthBonus: ; 0xdfe2
 	xor a
 .asm_e002
 	ld [wMeowthStageScore], a
-	callba Func_24fa3
+	callba UpdateMeowthMultiplierAnimation
 .asm_e00f
 	ld a, [wCurrentStageBackup]
 	ld hl, wCurrentStage

--- a/engine/pinball_game/ball_loss/ball_loss_red_field.asm
+++ b/engine/pinball_game/ball_loss/ball_loss_red_field.asm
@@ -99,6 +99,6 @@ ConcludeSpecialMode_RedField: ; 0xddfd
 	ld [wStageCollisionState], a
 	ret
 
-Func_de4e: ; 0xde4e
+DoNothing_BallLoss_Unused: ; 0xde4e
 ; unused
 	ret

--- a/engine/pinball_game/ball_loss/ball_loss_seel_bonus.asm
+++ b/engine/pinball_game/ball_loss/ball_loss_seel_bonus.asm
@@ -20,7 +20,7 @@ HandleBallLossSeelBonus: ; 0xe08b
 	xor a
 .asm_e0ab
 	ld [wSeelStageScore], a
-	callba Func_262f4
+	callba UpdateSeelStageScoreDisplay
 .asm_e0b8
 	ld a, [wCurrentStageBackup]
 	ld hl, wCurrentStage

--- a/engine/pinball_game/billboard.asm
+++ b/engine/pinball_game/billboard.asm
@@ -58,7 +58,7 @@ LoadGreyBillboardPaletteData: ; 0xf269
 	ld hl, StageRedFieldBottomBGPalette5
 	ld de, $0030
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .loadPaletteMap
 	ld a, BANK(GreyBillboardPaletteMap)
 	ld de, GreyBillboardPaletteMap

--- a/engine/pinball_game/catchem_mode.asm
+++ b/engine/pinball_game/catchem_mode.asm
@@ -128,8 +128,8 @@ StartCatchEmMode: ; 0x1003f
 	ld b, a ;bc = timer legnth. b = secons c = minutes
 	callba StartTimer
 	callba InitBallSaverForCatchEmMode
-	call Func_10696
-	call Func_3579
+	call DisplayLetsGetPokemonText
+	call ClearJackpot
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_1011d
@@ -148,12 +148,12 @@ StartCatchEmMode: ; 0x1003f
 	ld a, [wCurrentStage]
 	rst JumpTable  ; calls JumpToFuncInTable
 CallTable_10124: ; 0x10124
-	dw Func_10871      ; STAGE_RED_FIELD_TOP
-	dw Func_10871      ; STAGE_RED_FIELD_BOTTOM
+	dw InitializeCatchModeRedField      ; STAGE_RED_FIELD_TOP
+	dw InitializeCatchModeRedField      ; STAGE_RED_FIELD_BOTTOM
 	dw DoNothing_1098a
 	dw DoNothing_1098a
-	dw Func_1098c      ; STAGE_BLUE_FIELD_TOP
-	dw Func_1098c      ; STAGE_BLUE_FIELD_BOTTOM
+	dw InitializeCatchModeBlueField      ; STAGE_BLUE_FIELD_TOP
+	dw InitializeCatchModeBlueField      ; STAGE_BLUE_FIELD_BOTTOM
 
 CheckForMew:
 ; Sets the encountered mon to Mew if the following conditions are met:
@@ -190,7 +190,7 @@ ConcludeCatchEmMode: ; 0x10157
 	xor a
 	ld [wInSpecialMode], a
 	ld [wWildMonIsHittable], a
-	ld [wd5c6], a
+	ld [wCatchModeTransitionFlag], a
 	ld [wNumberOfCatchModeTilesFlipped], a
 	ld [wNumMonHits], a
 	call ClearWildMonCollisionMask
@@ -198,14 +198,14 @@ ConcludeCatchEmMode: ; 0x10157
 	ld a, [wCurrentStage]
 	rst JumpTable  ; calls JumpToFuncInTable
 CallTable_10178: ; 0x10178
-	dw Func_108f5      ; STAGE_RED_FIELD_TOP
-	dw Func_108f5      ; STAGE_RED_FIELD_BOTTOM
+	dw ConcludeCatchModeRedField      ; STAGE_RED_FIELD_TOP
+	dw ConcludeCatchModeRedField      ; STAGE_RED_FIELD_BOTTOM
 	dw DoNothing_1098b
 	dw DoNothing_1098b
-	dw Func_109fc      ; STAGE_BLUE_FIELD_TOP
-	dw Func_109fc      ; STAGE_BLUE_FIELD_BOTTOM
+	dw ConcludeCatchModeBlueField      ; STAGE_BLUE_FIELD_TOP
+	dw ConcludeCatchModeBlueField      ; STAGE_BLUE_FIELD_BOTTOM
 
-Func_10184: ; 0x10184 called by what looks like the "hit voltorb and shellder" handllers and after all tiles are flipped, as well as some evo mode stuff
+UpdateBillboardTileGraphics: ; 0x10184 called by what looks like the "hit voltorb and shellder" handllers and after all tiles are flipped, as well as some evo mode stuff
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z  ;skip if stage has no flippers
@@ -244,14 +244,14 @@ Func_10184: ; 0x10184 called by what looks like the "hit voltorb and shellder" h
 	ld [hli], a ;load first byte into next and test it gainst the second byte, if it's the same skip
 	jr z, .NextLoop
 	ld b, a ;else store in b
-	call nz, Func_101d9
+	call nz, QueueBillboardTileDMGGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .NextLoop ;skip if DMG
 	ld a, [wCurrentStage]
 	bit 0, a
 	ld a, b
-	call nz, Func_10230 ;if lower stage, run ???
+	call nz, QueueBillboardTileCGBPalette ;if lower stage, run ???
 .NextLoop
 	inc c
 	ld a, c
@@ -259,7 +259,7 @@ Func_10184: ; 0x10184 called by what looks like the "hit voltorb and shellder" h
 	jr nz, .Loop24Times
 	ret
 
-Func_101d9: ; 0x101d9
+QueueBillboardTileDMGGraphics: ; 0x101d9
 	push bc
 	push hl
 	push de
@@ -316,14 +316,14 @@ Func_101d9: ; 0x101d9
 	pop bc
 	push de
 	xor a
-	ld de, Func_11d2 ; queue graphics load from the adjusted pointer bank 0 using this func
+	ld de, LoadBankedTileData ; queue graphics load from the adjusted pointer bank 0 using this func
 	call QueueGraphicsToLoadWithFunc
 	pop de
 	pop hl
 	pop bc
 	ret
 
-Func_10230: ; 0x10230
+QueueBillboardTileCGBPalette: ; 0x10230
 	push bc
 	push hl
 	push de
@@ -403,7 +403,7 @@ PointerTable_10274: ; 0x10274 4x6 area? the billboard's position?
 Data_102a4: ; 0x102a4
 	db $00, $07, $06, $01, $0E, $15, $14, $0F, $04, $0B, $0A, $05, $0C, $13, $12, $0D, $02, $09, $08, $03, $10, $17, $16, $11
 
-Func_102bc: ; 0x102bc
+LoadBillboardStaticPalette: ; 0x102bc
 	ld a, [wCurrentCatchEmMon]
 	ld c, a
 	ld b, $0
@@ -449,7 +449,7 @@ Func_102bc: ; 0x102bc
 	call QueueGraphicsToLoadWithFunc
 	ret
 
-Func_10301: ; 0x10301
+LoadBillboardAnimatedPalettes: ; 0x10301
 	ld a, [wCurrentCatchEmMon]
 	ld c, a
 	ld b, $0
@@ -516,7 +516,7 @@ Func_10301: ; 0x10301
 	call QueueGraphicsToLoadWithFunc
 	ret
 
-Func_10362: ; 0x10362
+QueueBillboardAnimatedGraphics: ; 0x10362
 	ld a, [wCurrentCatchEmMon]
 	ld c, a
 	ld b, $0
@@ -538,14 +538,14 @@ Func_10362: ; 0x10362
 	ld de, wc150
 	ld bc, 0
 .loop
-	call Func_1038e
+	call QueueBillboardAnimatedTileEntry
 	inc c
 	ld a, c
 	cp $d
 	jr nz, .loop
 	ret
 
-Func_1038e: ; 0x1038e
+QueueBillboardAnimatedTileEntry: ; 0x1038e
 	push bc
 	push de
 	ld a, c
@@ -585,7 +585,7 @@ Func_1038e: ; 0x1038e
 	pop bc
 	push de
 	xor a
-	ld de, Func_11d2
+	ld de, LoadBankedTileData
 	call QueueGraphicsToLoadWithFunc
 	pop de
 	pop bc
@@ -693,7 +693,7 @@ ClearWildMonCollisionMask: ; 0x10488
 
 BallCaptureInit: ; 0x10496
 	xor a
-	ld [wd5c6], a
+	ld [wCatchModeTransitionFlag], a
 	ld a, BANK(BallCaptureSmoke2Gfx)
 	ld hl, BallCaptureSmoke2Gfx
 	ld de, vTilesOB tile $7e
@@ -802,7 +802,7 @@ CapturePokemonAnimation: ; 0x1052d
 	call MainLoopUntilTextIsClear
 	ld a, [wNumPartyMons]
 	and a
-	call z, Func_10848
+	call z, AwardFirstPokemonCaughtBonus
 	ld a, $50
 	ld [wBallXPos + 1], a
 	ld a, $40
@@ -863,7 +863,7 @@ BallCaptureAnimationData: ; 0x105e4
 	db $01, BALLCAPTURESPRITE_10
 	db $00  ; terminator
 
-Func_10611: ; 0x10611
+LoadCatchTextGraphics: ; 0x10611
 	and a ;if a NZ
 	ret z
 	dec a ;dec a
@@ -877,7 +877,7 @@ Func_10611: ; 0x10611
 	ld a, [hl]
 	ld b, a
 	ld a, BANK(Data_1062a)
-	ld de, Func_11d2
+	ld de, LoadBankedTileData
 	call QueueGraphicsToLoadWithFunc
 	ret
 
@@ -910,27 +910,27 @@ Data_10640:
 	db BANK(CatchTextGfx)
 	db $00
 
-Func_10648: ; 0x10648
-	call Func_10184
-	ld a, [wd54e]
+UpdateBillboardTileFlashAnimation: ; 0x10648
+	call UpdateBillboardTileGraphics
+	ld a, [wCatchModeFlashFrameCounter]
 	dec a
-	ld [wd54e], a
+	ld [wCatchModeFlashFrameCounter], a
 	jr nz, .asm_10677
 	ld a, $14
-	ld [wd54e], a
+	ld [wCatchModeFlashFrameCounter], a
 	ld hl, wBillboardTilesIlluminationStates
 	ld b, $18
 .asm_1065e
-	ld a, [wd54f]
+	ld a, [wCatchModeFlashPhaseCounter]
 	and $1
 	ld [hli], a
 	xor $1
 	ld [hli], a
 	dec b
 	jr nz, .asm_1065e
-	ld a, [wd54f]
+	ld a, [wCatchModeFlashPhaseCounter]
 	dec a
-	ld [wd54f], a
+	ld [wCatchModeFlashPhaseCounter], a
 	jr nz, .asm_10677
 	ld hl, wSpecialModeState
 	inc [hl]
@@ -953,7 +953,7 @@ ShowAnimatedWildMon: ; 0x10678
 	ld [wNumMonHits], a
 	ret
 
-Func_10696: ; 0x10696
+DisplayLetsGetPokemonText: ; 0x10696
 	call FillBottomMessageBufferWithBlackTile
 	call EnableBottomText
 	ld hl, wScrollingText1
@@ -961,7 +961,7 @@ Func_10696: ; 0x10696
 	call LoadScrollingText
 	ret
 
-Func_106a6: ; 0x106a6
+DisplayPokemonRanAwayText: ; 0x106a6
 	call FillBottomMessageBufferWithBlackTile
 	call EnableBottomText
 	ld hl, wScrollingText1
@@ -1144,7 +1144,7 @@ SetLeftAndRightAlleyArrowIndicatorStates_RedField: ; 0x107c8
 	ld [wIndicatorStates], a
 	ret
 
-Func_107e9: ; 0x107e9
+SetRedStageStructureBackup: ; 0x107e9
 	ld a, [wLeftAlleyCount]
 	cp $3
 	ld a, $4
@@ -1199,7 +1199,7 @@ ShowJackpotText: ; 0x10825
 	call LoadStationaryTextAndHeader
 	ret
 
-Func_10848: ; 0x10848
+AwardFirstPokemonCaughtBonus: ; 0x10848
 	ld bc, OneHundredMillionPoints
 	callba AddBigBCD6FromQueue
 	call FillBottomMessageBufferWithBlackTile
@@ -1213,7 +1213,7 @@ Func_10848: ; 0x10848
 	call MainLoopUntilTextIsClear
 	ret
 
-Func_10871: ; 0x10871
+InitializeCatchModeRedField: ; 0x10871
 	ld a, [wCurrentCatchEmMon]
 	ld c, a
 	ld b, $0
@@ -1263,17 +1263,17 @@ Func_10871: ; 0x10871
 
 .asm_108d3
 	callba ClearAllRedIndicators
-	callba Func_10184
+	callba UpdateBillboardTileGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_102bc
+	callba nz, LoadBillboardStaticPalette
 	ret
 
-Func_108f5: ; 0x108f5
+ConcludeCatchModeRedField: ; 0x108f5
 	call ResetIndicatorStates
 	call OpenSlotCave
 	call SetLeftAndRightAlleyArrowIndicatorStates_RedField
-	call Func_107e9
+	call SetRedStageStructureBackup
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
@@ -1307,7 +1307,7 @@ BlankSaverSpaceTileDataRedField:
 	dw BlankSaverSpaceTileDataRedField3
 
 BlankSaverSpaceTileDataRedField1:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $2e
 	dw StageRedFieldBottomBaseGameBoyColorGfx + $2e0
@@ -1315,7 +1315,7 @@ BlankSaverSpaceTileDataRedField1:
 	db $00
 
 BlankSaverSpaceTileDataRedField2:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw StageRedFieldBottomBaseGameBoyColorGfx + $300
@@ -1323,7 +1323,7 @@ BlankSaverSpaceTileDataRedField2:
 	db $00
 
 BlankSaverSpaceTileDataRedField3:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw StageRedFieldBottomBaseGameBoyColorGfx + $320
@@ -1335,7 +1335,7 @@ CaughtPokeballTileDataPointers:
 	dw CaughtPokeballTileData
 
 CaughtPokeballTileData:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $2e
 	dw CaughtPokeballGfx
@@ -1348,7 +1348,7 @@ DoNothing_1098a: ; 0x1098a
 DoNothing_1098b: ; 0x1098b
 	ret
 
-Func_1098c: ; 0x1098c
+InitializeCatchModeBlueField: ; 0x1098c
 	ld a, [wCurrentCatchEmMon]
 	ld c, a
 	ld b, $0
@@ -1390,21 +1390,21 @@ Func_1098c: ; 0x1098c
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
-	callba Func_1c2cb
-	callba Func_10184
+	callba LoadArrowIndicators_BlueField
+	callba UpdateBillboardTileGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_102bc
+	callba nz, LoadBillboardStaticPalette
 	ret
 
-Func_109fc: ; 0x109fc
+ConcludeCatchModeBlueField: ; 0x109fc
 	call ResetIndicatorStates
 	call OpenSlotCave
 	callba SetLeftAndRightAlleyArrowIndicatorStates_BlueField
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
-	callba Func_1c2cb
+	callba LoadArrowIndicators_BlueField
 	call LoadBillboardTilemap
 	callba LoadMapBillboardTileData
 	ld a, BANK(StageSharedBonusSlotGlowGfx)
@@ -1434,7 +1434,7 @@ BlankSaverSpaceTileDataBlueField:
 	dw BlankSaverSpaceTileDataBlueField3
 
 BlankSaverSpaceTileDataBlueField1:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $2e
 	dw StageBlueFieldBottomBaseGameBoyColorGfx + $2e0
@@ -1442,7 +1442,7 @@ BlankSaverSpaceTileDataBlueField1:
 	db $00
 
 BlankSaverSpaceTileDataBlueField2:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $30
 	dw StageBlueFieldBottomBaseGameBoyColorGfx + $300
@@ -1450,7 +1450,7 @@ BlankSaverSpaceTileDataBlueField2:
 	db $00
 
 BlankSaverSpaceTileDataBlueField3:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $32
 	dw StageBlueFieldBottomBaseGameBoyColorGfx + $320
@@ -1462,7 +1462,7 @@ Data_10a88:
 	dw Data_10a8b
 
 Data_10a8b:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $2e
 	dw CaughtPokeballGfx

--- a/engine/pinball_game/catchem_mode/catchem_mode_blue_field.asm
+++ b/engine/pinball_game/catchem_mode/catchem_mode_blue_field.asm
@@ -18,16 +18,16 @@ HandleBlueCatchEmCollision: ; 0x202bc
 	ld a, [wSpecialModeState]
 	call CallInFollowingTable
 CatchemModeCallTable_BlueField: ; 0x202e2
-	padded_dab Func_20302
-	padded_dab Func_20320
-	padded_dab Func_2032c
+	padded_dab CheckAllTilesFlipped_BlueField
+	padded_dab RunBillboardFlashAnimation_BlueField
+	padded_dab TransitionToAnimatedMon_BlueField
 	padded_dab ShowAnimatedCatchemPokemon_BlueField
 	padded_dab UpdateMonState_CatchemMode_BlueField
 	padded_dab CatchPokemon_BlueField
 	padded_dab CapturePokemonAnimation_BlueField
 	padded_dab ConcludeCatchemMode_BlueField
 
-Func_20302: ; 0x20302
+CheckAllTilesFlipped_BlueField: ; 0x20302
 	ld a, [wNumberOfCatchModeTilesFlipped]
 	cp $18
 	jr nz, .asm_2031e
@@ -37,32 +37,32 @@ Func_20302: ; 0x20302
 	ld hl, wSpecialModeState
 	inc [hl]
 	ld a, $14
-	ld [wd54e], a
+	ld [wCatchModeFlashFrameCounter], a
 	ld a, $5
-	ld [wd54f], a
+	ld [wCatchModeFlashPhaseCounter], a
 .asm_2031e
 	scf
 	ret
 
-Func_20320: ; 0x20320
-	callba Func_10648
+RunBillboardFlashAnimation_BlueField: ; 0x20320
+	callba UpdateBillboardTileFlashAnimation
 	scf
 	ret
 
-Func_2032c: ; 0x2032c
+TransitionToAnimatedMon_BlueField: ; 0x2032c
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_20333
-	call Func_1130
+	call CheckGraphicsQueueEmpty
 	jr nz, .asm_20362
 	callba LoadBillboardClearedTilemap
-	callba Func_10362
+	callba QueueBillboardAnimatedGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_10301
+	callba nz, LoadBillboardAnimatedPalettes
 .asm_20333
 	ld a, $1
-	ld [wd5c6], a
+	ld [wCatchModeTransitionFlag], a
 	ld hl, wSpecialModeState
 	inc [hl]
 .asm_20362
@@ -73,7 +73,7 @@ ShowAnimatedCatchemPokemon_BlueField: ; 0x20364
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_20370
-	call Func_1130
+	call CheckGraphicsQueueEmpty
 	jr nz, .asm_20392
 .asm_20370
 	callba ShowAnimatedWildMon
@@ -136,7 +136,7 @@ UpdateMonState_CatchemMode_BlueField: ; 0x20394
 	ld de, HitText
 	call LoadStationaryTextAndHeader
 	ld a, [wNumMonHits]
-	callba Func_10611
+	callba LoadCatchTextGraphics
 	ld c, $2
 	jr .asm_2044b
 
@@ -178,11 +178,11 @@ UpdateMonState_CatchemMode_BlueField: ; 0x20394
 	ret
 
 CatchPokemon_BlueField: ; 0x20454
-	ld a, [wd580]
+	ld a, [wTimerGraphicsNeedsLoading]
 	and a
 	jr z, .asm_2045f
 	xor a
-	ld [wd580], a
+	ld [wTimerGraphicsNeedsLoading], a
 	ret
 
 .asm_2045f
@@ -227,7 +227,7 @@ CheckIfCatchemModeTimerExpired_BlueField: ; 0x204b3
 	callba SetPokemonOwnedFlag
 .notMew
 	callba StopTimer
-	callba Func_106a6
+	callba DisplayPokemonRanAwayText
 	ret
 
 HandleShellderCollision_CatchemMode: ; 0x204f1
@@ -262,7 +262,7 @@ HandleShellderCollision_CatchemMode: ; 0x204f1
 	xor a
 	ld [wIndicatorStates + 9], a
 .asm_20525
-	callba Func_10184
+	callba UpdateBillboardTileGraphics
 	ld bc, OneHundredThousandPoints
 	callba AddBigBCD6FromQueue
 	ld bc, $0010

--- a/engine/pinball_game/catchem_mode/catchem_mode_red_field.asm
+++ b/engine/pinball_game/catchem_mode/catchem_mode_red_field.asm
@@ -16,16 +16,16 @@ HandleRedCatchEmCollision: ; 0x20000
 	ld a, [wSpecialModeState]
 	call CallInFollowingTable
 CatchemModeCallTable_RedField: ; 0x20021
-	padded_dab Func_20041
-	padded_dab Func_2005f
-	padded_dab Func_2006b
+	padded_dab CheckAllTilesFlipped_RedField
+	padded_dab RunBillboardFlashAnimation_RedField
+	padded_dab TransitionToAnimatedMon_RedField
 	padded_dab ShowAnimatedCatchemPokemon_RedField
 	padded_dab UpdateMonState_CatchemMode_RedField
 	padded_dab CatchPokemon_RedField
 	padded_dab CapturePokemonAnimation_RedField
 	padded_dab ConcludeCatchemMode_RedField
 
-Func_20041: ; 0x20041
+CheckAllTilesFlipped_RedField: ; 0x20041
 	ld a, [wNumberOfCatchModeTilesFlipped]
 	cp $18
 	jr nz, .NotDone
@@ -35,32 +35,32 @@ Func_20041: ; 0x20041
 	ld hl, wSpecialModeState
 	inc [hl]
 	ld a, $14
-	ld [wd54e], a
+	ld [wCatchModeFlashFrameCounter], a
 	ld a, $5
-	ld [wd54f], a
+	ld [wCatchModeFlashPhaseCounter], a
 .NotDone
 	scf
 	ret
 
-Func_2005f: ; 0x2005f
-	callba Func_10648
+RunBillboardFlashAnimation_RedField: ; 0x2005f
+	callba UpdateBillboardTileFlashAnimation
 	scf
 	ret
 
-Func_2006b: ; 0x2006b
+TransitionToAnimatedMon_RedField: ; 0x2006b
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_20098
-	call Func_1130
+	call CheckGraphicsQueueEmpty
 	jr nz, .asm_200a1
 	callba LoadBillboardClearedTilemap
-	callba Func_10362
+	callba QueueBillboardAnimatedGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_10301
+	callba nz, LoadBillboardAnimatedPalettes
 .asm_20098
 	ld a, $1
-	ld [wd5c6], a
+	ld [wCatchModeTransitionFlag], a
 	ld hl, wSpecialModeState
 	inc [hl]
 .asm_200a1
@@ -71,7 +71,7 @@ ShowAnimatedCatchemPokemon_RedField: ; 0x200a3
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_200af
-	call Func_1130
+	call CheckGraphicsQueueEmpty
 	jr nz, .asm_200d1
 .asm_200af
 	callba ShowAnimatedWildMon
@@ -134,7 +134,7 @@ UpdateMonState_CatchemMode_RedField: ; 0x200d3
 	ld de, HitText
 	call LoadStationaryTextAndHeader
 	ld a, [wNumMonHits]
-	callba Func_10611 ;queue up a graphic based on number of mon hits
+	callba LoadCatchTextGraphics ;queue up a graphic based on number of mon hits
 	ld c, $2
 	jr .UpdateMonAnimation
 
@@ -176,11 +176,11 @@ UpdateMonState_CatchemMode_RedField: ; 0x200d3
 	ret
 
 CatchPokemon_RedField: ; 0x20193
-	ld a, [wd580]
+	ld a, [wTimerGraphicsNeedsLoading]
 	and a
 	jr z, .asm_2019e
 	xor a
-	ld [wd580], a
+	ld [wTimerGraphicsNeedsLoading], a
 	ret
 
 .asm_2019e
@@ -225,7 +225,7 @@ CheckIfCatchemModeTimerExpired_RedField: ; 0x201f2
 	callba SetPokemonOwnedFlag
 .asm_2021b
 	callba StopTimer
-	callba Func_106a6
+	callba DisplayPokemonRanAwayText
 	ret
 
 HandleVoltorbCollision_CatchemMode: ; 0x20230 resolve hitting a voltorb in catch mode?
@@ -260,7 +260,7 @@ HandleVoltorbCollision_CatchemMode: ; 0x20230 resolve hitting a voltorb in catch
 	xor a
 	ld [wIndicatorStates + 9], a ;if 24, unmark voltorb arrow indicator
 .NotDoneFlipping
-	callba Func_10184 ;load billboard graphics?
+	callba UpdateBillboardTileGraphics ;load billboard graphics?
 	ld bc, OneHundredThousandPoints
 	callba AddBigBCD6FromQueue
 	ld bc, $0010

--- a/engine/pinball_game/draw_sprites/draw_blue_field_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_blue_field_sprites.asm
@@ -160,7 +160,7 @@ DrawPikachuSavers_BlueStage: ; 0x1f448
 	and a
 	ld a, [wWhichPikachuSaverSide]
 	jr z, .asm_1f473
-	ld a, [wd51c]
+	ld a, [wPikachuSaverAnimationState]
 	and a
 	jr nz, .asm_1f469
 	ldh a, [hFrameCounter]

--- a/engine/pinball_game/draw_sprites/draw_gengar_bonus_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_gengar_bonus_sprites.asm
@@ -1,9 +1,9 @@
 DrawSpritesGengarBonus: ; 0x18faf
 	ld bc, $7f00
 	callba DrawTimer
-	call Func_19020
-	call Func_190b9
-	call Func_19185
+	call DrawAllGastlySprites
+	call DrawAllHaunterSprites
+	call DrawAllGengarSprites
 	callba DrawFlippers
 	callba DrawPinball
 	ret
@@ -50,21 +50,21 @@ Debug_CycleGengarBonusPhase:
 	ld [wd698], a
 	ret
 
-Func_19020: ; 0x19020
+DrawAllGastlySprites: ; 0x19020
 	ld de, wGastly1Enabled
-	call Func_19033
+	call DrawGastlySprite
 	ld de, wGastly2Enabled
-	call Func_19033
+	call DrawGastlySprite
 	ld de, wGastly3Enabled
-	call Func_19033
+	call DrawGastlySprite
 	ret
 
-Func_19033: ; 0x19033
+DrawGastlySprite: ; 0x19033
 	ld a, [de]
 	and a
 	ret z
 .asm_19036
-	call Func_19070
+	call LoadGastlyGraphics
 	jr nc, .asm_19042
 	ldh a, [rLCDC]
 	bit 7, a
@@ -111,13 +111,13 @@ SpriteIds_Gastly:
 	db SPRITE2_GASTLY_HIT
 	db $FF
 
-Func_19070: ; 0x19070
-	ld a, [wd674]
+LoadGastlyGraphics: ; 0x19070
+	ld a, [wGengarPhaseTimer]
 	and a
 	ret z
 	push de
 	dec a
-	ld [wd674], a
+	ld [wGengarPhaseTimer], a
 	sla a
 	sla a
 	ld c, a
@@ -151,19 +151,19 @@ GastlyVideoData_190a9:
 	dw vTilesSH tile $1c, GengarBonusGastlyGfx + $c0
 	dw vTilesSH tile $22, GengarBonusGastlyGfx + $120
 
-Func_190b9: ; 0x190b9
+DrawAllHaunterSprites: ; 0x190b9
 	ld de, wd67e
-	call Func_190c6
+	call DrawHaunterSprite
 	ld de, wd687
-	call Func_190c6
+	call DrawHaunterSprite
 	ret
 
-Func_190c6: ; 0x190c6
+DrawHaunterSprite: ; 0x190c6
 	ld a, [de]
 	and a
 	ret z
 .asm_190c9
-	call Func_19104
+	call LoadHaunterGraphics
 	jr nc, .asm_190d5
 	ldh a, [rLCDC]
 	bit 7, a
@@ -211,7 +211,7 @@ SpriteIds_Haunter:
 	db SPRITE2_HAUNTER_HIT
 	db $FF
 
-Func_19104: ; 0x19104
+LoadHaunterGraphics: ; 0x19104
 	ld a, [wd690]
 	and a
 	ret z
@@ -239,7 +239,7 @@ Func_19104: ; 0x19104
 	ld a, Bank(GengarBonusHaunterGfx)
 	call LoadOrCopyVRAMData
 	ld a, $4
-	ld [wd674], a
+	ld [wGengarPhaseTimer], a
 	ld a, $8
 	ld [wd6a1], a
 	xor a
@@ -266,17 +266,17 @@ GengarBonusStageHaunterGfxTable: ; 0x19145
 	dw $60, vTilesOB tile $1e, GengarBonusHaunterGfx + $1e0, $0000
 	dw $60, vTilesOB tile $24, GengarBonusHaunterGfx + $240, $0000
 
-Func_19185: ; 0x19185
+DrawAllGengarSprites: ; 0x19185
 	ld de, wd698
-	call Func_1918c
+	call DrawGengarSprite
 	ret
 
-Func_1918c: ; 0x1918c
+DrawGengarSprite: ; 0x1918c
 	ld a, [de]
 	and a
 	ret z
 .asm_1918f
-	call Func_191cb
+	call LoadGengarGraphics
 	jr nc, .asm_1919b
 	ldh a, [rLCDC]
 	bit 7, a
@@ -325,7 +325,7 @@ SpriteIds_Gengar:
 	db SPRITE2_GENGAR_HIT
 	db $FF
 
-Func_191cb: ; 0x191cb
+LoadGengarGraphics: ; 0x191cb
 	ld a, [wd6a1]
 	and a
 	ret z
@@ -353,7 +353,7 @@ Func_191cb: ; 0x191cb
 	ld a, $26
 	call LoadOrCopyVRAMData
 	ld a, $4
-	ld [wd674], a
+	ld [wGengarPhaseTimer], a
 	ld a, $8
 	ld [wd690], a
 	xor a

--- a/engine/pinball_game/draw_sprites/draw_meowth_bonus_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_meowth_bonus_sprites.asm
@@ -2,15 +2,15 @@ DrawSpritesMeowthBonus: ; 0x2583b
 	ld bc, $7f65
 	callba DrawTimer
 	callba DrawFlippers
-	call Func_259fe
-	call Func_25895
-	call Func_2595e
-	call Func_2586c
+	call DrawMeowthMultiplierSprite
+	call DrawMeowthBottomCoinSprites
+	call DrawMeowthTopCoinSprites
+	call DrawMeowthSprite
 	callba DrawPinball
-	call Func_25a39
+	call DrawMeowthProgressSparkle
 	ret
 
-Func_2586c: ; 0x2586c
+DrawMeowthSprite: ; 0x2586c
 	ld a, [wMeowthXPosition]
 	ld hl, hSCX
 	sub [hl]
@@ -46,7 +46,7 @@ MeowthSpriteIds:
 	MeowthSpriteId SPRITE2_MEOWTH_TIMEOUT_0, MEOWTHSPRITE_TIMEOUT_0
 	MeowthSpriteId SPRITE2_MEOWTH_TIMEOUT_1, MEOWTHSPRITE_TIMEOUT_1
 
-Func_25895: ; 0x25895
+DrawMeowthBottomCoinSprites: ; 0x25895
 	ld a, [wMeowthJewel0AnimationIndex]
 	cp $b ; each entry of MeowthJewelSpriteIdsTable has 11 entries
 	jr nz, .asm_258a0
@@ -181,7 +181,7 @@ MeowthJewelCollectSpriteIds:
 	db SPRITE2_MEOWTHJEWEL_COLLECT_5
 	db SPRITE2_MEOWTHJEWEL_COLLECT_5
 
-Func_2595e: ; 0x2595e
+DrawMeowthTopCoinSprites: ; 0x2595e
 	ld a, [wMeowthJewel3AnimationIndex]
 	cp $b
 	jr nz, .asm_25969
@@ -271,7 +271,7 @@ Func_2595e: ; 0x2595e
 	call LoadSpriteData2
 	ret
 
-Func_259fe: ; 0x259fe
+DrawMeowthMultiplierSprite: ; 0x259fe
 	ld a, [wd795]
 	and a
 	ret z
@@ -326,7 +326,7 @@ MeowthMultiplierSpriteIds:
 	MeowthMultiplierSpriteId SPRITE2_MEOWTH_MULTIPLIER_6_FRAME_2, MEOWTHMULTIPLIERSPRITE_6_FRAME_2
 	MeowthMultiplierSpriteId $FF, MEOWTHMULTIPLIERSPRITE_INVISIBLE
 
-Func_25a39: ; 0x25a39
+DrawMeowthProgressSparkle: ; 0x25a39
 	ld a, [wd64e]
 	and a
 	ret z

--- a/engine/pinball_game/draw_sprites/draw_mewtwo_bonus_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_mewtwo_bonus_sprites.asm
@@ -4,10 +4,10 @@ DrawSpritesMewtwoBonus: ; 0x1994e
 	call DrawOrbitingBallSprites
 	callba DrawFlippers
 	callba DrawPinball
-	call Func_19976
+	call DrawMewtwoSprite
 	ret
 
-Func_19976: ; 0x19976
+DrawMewtwoSprite: ; 0x19976
 	ld a, $40
 	ld hl, hSCX
 	sub [hl]

--- a/engine/pinball_game/draw_sprites/draw_pinball.asm
+++ b/engine/pinball_game/draw_sprites/draw_pinball.asm
@@ -35,18 +35,18 @@ DrawPinball: ; 0x17e81
 	ldh a, [hSGBFlag]
 	and a
 	ret nz
-	ld a, [wd4c5]
+	ld a, [wBallPreviousXPosDMG]
 	inc a
 	ld hl, hSCX
 	sub [hl]
 	ld b, a
-	ld a, [wd4c6]
+	ld a, [wBallPreviousYPosDMG]
 	inc a
 	sub $10
 	ld hl, hSCY
 	sub [hl]
 	ld c, a
-	ld a, [wd4c7]
+	ld a, [wBallPreviousRotationDMG]
 	srl a
 	srl a
 	srl a
@@ -55,9 +55,9 @@ DrawPinball: ; 0x17e81
 	add SPRITE_BALL_SPIN
 	call LoadSpriteData
 	ld a, [wBallXPos + 1]
-	ld [wd4c5], a
+	ld [wBallPreviousXPosDMG], a
 	ld a, [wBallYPos + 1]
-	ld [wd4c6], a
+	ld [wBallPreviousYPosDMG], a
 	ld a, [wBallRotation]
-	ld [wd4c7], a
+	ld [wBallPreviousRotationDMG], a
 	ret

--- a/engine/pinball_game/draw_sprites/draw_red_field_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_red_field_sprites.asm
@@ -335,7 +335,7 @@ DrawPikachuSavers_RedStage: ; 0x17e08
 	and a
 	ld a, [wWhichPikachuSaverSide]
 	jr z, .asm_17e33
-	ld a, [wd51c]
+	ld a, [wPikachuSaverAnimationState]
 	and a
 	jr nz, .asm_17e29
 	ldh a, [hFrameCounter]
@@ -372,16 +372,16 @@ PikachuSaverSpriteOffsets_RedStage:
 	dw $7E0F
 	dw $7E92
 
-Func_17e4f: ; 0x17e4f
+LoadRedFieldExtraSprites_Unused: ; 0x17e4f
 ; unused
 	ld hl, UnusedData_7e55
-	jp Func_17e5e
+	jp ProcessSpriteDataList_Unused
 
 UnusedData_7e55: ; 0x17e55
 	db $00, $2B, $69, $CB, $00, $67, $54, $CC
 	db $FF
 
-Func_17e5e: ; 0x17e5e
+ProcessSpriteDataList_Unused: ; 0x17e5e
 ; unused
 	ldh a, [hGameBoyColorFlag]
 	ld e, a

--- a/engine/pinball_game/draw_sprites/draw_seel_bonus_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_seel_bonus_sprites.asm
@@ -1,23 +1,23 @@
 DrawSpritesSeelBonus: ; 0x26b7e
 	ld bc, $7f65
 	callba DrawTimer
-	call Func_26bf7
+	call DrawSeelMultiplierSprite
 	callba DrawFlippers
 	callba DrawPinball
-	call Func_26ba9
-	call Func_26c3c
+	call DrawAllSeelSprites
+	call DrawSeelProgressSparkle
 	ret
 
-Func_26ba9: ; 0x26ba9
+DrawAllSeelSprites: ; 0x26ba9
 	ld de, wd76e
-	call Func_26bbc
+	call DrawSeelSprite
 	ld de, wd778
-	call Func_26bbc
+	call DrawSeelSprite
 	ld de, wd782
-	call Func_26bbc
+	call DrawSeelSprite
 	ret
 
-Func_26bbc: ; 0x26bbc
+DrawSeelSprite: ; 0x26bbc
 	ld a, [de]
 	ld hl, hSCX
 	sub [hl]
@@ -76,7 +76,7 @@ SpriteIds_26bdf: ; 0x26bdf
 	SeelSpriteId SPRITE2_SEEL_TURN_RIGHT_TO_LEFT_3, SEELSPRITE_TURN_RIGHT_TO_LEFT_3
 	SeelSpriteId $FF, SEELSPRITE_INVISIBLE
 
-Func_26bf7: ; 0x26bf7
+DrawSeelMultiplierSprite: ; 0x26bf7
 	ld a, [wd795]
 	cp $0
 	ret z
@@ -140,7 +140,7 @@ SeelMultiplierSpriteIds: ; 0x26c23
 	SeelMultiplierSpriteId SPRITE2_SEEL_MULTIPLIER_256_FRAME_2, SEELMULTIPLIERSPRITE_256_FRAME_2
 	SeelMultiplierSpriteId $FF, SEELMULTIPLIERSPRITE_INVISIBLE
 
-Func_26c3c: ; 0x26c3c
+DrawSeelProgressSparkle: ; 0x26c3c
 	ld a, [wd64e]
 	and a
 	ret z

--- a/engine/pinball_game/draw_sprites/draw_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_sprites.asm
@@ -5,8 +5,8 @@ DrawSpritesForStage: ; 0x84b7
 CallTable_84bd: ; 0x84bd
 	padded_dab DrawSpritesRedFieldTop     ; STAGE_RED_FIELD_TOP
 	padded_dab DrawSpritesRedFieldBottom  ; STAGE_RED_FIELD_BOTTOM
-	padded_dab Func_18079
-	padded_dab Func_18084
+	padded_dab DrawSprites_UnusedStageNoFlippers
+	padded_dab DrawSprites_UnusedStageWithFlippers
 	padded_dab DrawSpritesBlueFieldTop    ; STAGE_BLUE_FIELD_TOP
 	padded_dab DrawSpritesBlueFieldBottom ; STAGE_BLUE_FIELD_BOTTOM
 	padded_dab DrawSpritesGengarBonus     ; STAGE_GENGAR_BONUS
@@ -35,7 +35,7 @@ UnusedFunc_84fd:
 	ld a, $81
 	call .FillAttrsOrBGMap
 	ld de, wBottomMessageBuffer + $47
-	call Func_8524
+	call DrawScoreDigits
 	ret
 
 .FillAttrsOrBGMap: ; 8519 (2:4519)

--- a/engine/pinball_game/draw_sprites/draw_timer.asm
+++ b/engine/pinball_game/draw_sprites/draw_timer.asm
@@ -5,7 +5,7 @@ DrawTimer: ; 0x175a4
 	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, DrawTimer_GameBoyColor
-	ld a, [wd580]
+	ld a, [wTimerGraphicsNeedsLoading]
 	and a
 	ret z
 	ld a, [wd581]
@@ -16,7 +16,7 @@ DrawTimer: ; 0x175a4
 	ret
 
 .DrawTimer_GameBoy
-	call Func_1762f
+	call GetTimerSpriteIndex
 	ld hl, wTimerDigits
 	ld a, [wTimerMinutes]
 	and $f
@@ -72,7 +72,7 @@ DrawTimerDigit: ; 0x17627
 	ld b, a
 	ret
 
-Func_1762f: ; 0x1762f
+GetTimerSpriteIndex: ; 0x1762f
 ; determines which set of timer sprites to use based on the current board and board state
 ; returns: d : an index into TimerDigitsTileData
 ;          e : an index into TimerSpriteIds
@@ -101,7 +101,7 @@ LoadTimerDigitTiles: ; 0x1764f
 	push af
 	push hl
 	add d
-	call Func_17665
+	call QueueTimerDigitGraphics
 	pop hl
 	pop af
 	ld [hl], a
@@ -114,7 +114,7 @@ LoadTimerDigitTiles: ; 0x1764f
 	pop bc
 	ret
 
-Func_17665: ; 0x17665
+QueueTimerDigitGraphics: ; 0x17665
 	ld c, a
 	ld b, $0
 	sla c

--- a/engine/pinball_game/draw_sprites/draw_unused_stage_sprites.asm
+++ b/engine/pinball_game/draw_sprites/draw_unused_stage_sprites.asm
@@ -1,8 +1,8 @@
-Func_18079: ; 0x18079
+DrawSprites_UnusedStageNoFlippers: ; 0x18079
 	callba DrawPinball
 	ret
 
-Func_18084: ; 0x18084
+DrawSprites_UnusedStageWithFlippers: ; 0x18084
 	callba DrawFlippers
 	callba DrawPinball
 	ret

--- a/engine/pinball_game/end_of_ball_bonus.asm
+++ b/engine/pinball_game/end_of_ball_bonus.asm
@@ -1,7 +1,7 @@
 EndOfBallBonus: ; 0xf533
 	call FillBottomMessageBufferWithBlackTile
 	call LoadEAcuteCharacterGfx
-	call Func_f57f
+	call ClearBottomMessageAndUpdateVRAM
 	ld a, $60
 	ldh [hWY], a
 	dec a
@@ -38,7 +38,7 @@ LoadEAcuteCharacterGfx: ; 0xf55c
 	call LoadVRAMData
 	ret
 
-Func_f57f: ; 0xf57f
+ClearBottomMessageAndUpdateVRAM: ; 0xf57f
 	xor a
 	ld [wDrawBottomMessageBox], a
 	ld hl, wBottomMessageText
@@ -74,10 +74,10 @@ ShowBallBonusSummary: ; 0xf5a0
 	call HandleNumPokemonCaughtBallBonus
 	call HandleNumPokemonEvolvedBallBonus
 	call HandleBallBonusForCurrentField
-	call Func_f676
+	call DisplayBonusMultiplierLoop
 	ld a, 1
 	ld [wBallBonusWaitForButtonPress], a
-	call Func_f70d
+	call DisplayFinalBonusScore
 	ld a, [wGameOver]
 	and a
 	ret z
@@ -87,13 +87,13 @@ ShowBallBonusSummary: ; 0xf5a0
 	call PlaySong
 	ld hl, wBottomMessageText
 	ld bc, $0040
-	call Func_f81b
+	call FillBufferWithSpaceTile
 	ld de, wBottomMessageText + $20
 	ld hl, GameOverText
 	call PlaceTextAlphanumericOnly
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 .waitForAPress
 	rst AdvanceFrame
 	ldh a, [hNewlyPressedButtons]
@@ -124,14 +124,14 @@ HandleNumPokemonCaughtBallBonus: ; 0xf626
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $01
 	ld a, [wNumPokemonCaughtInBallBonus]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumPokemonCaughtInBallBonus
 	ld de, PointsPerPokemonCaught
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandleNumPokemonEvolvedBallBonus: ; 0xf64e
@@ -140,17 +140,17 @@ HandleNumPokemonEvolvedBallBonus: ; 0xf64e
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText
 	ld a, [wNumPokemonEvolvedInBallBonus]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumPokemonEvolvedInBallBonus
 	ld de, PointsPerPokemonEvolved
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
-Func_f676: ; 0xf676
+DisplayBonusMultiplierLoop: ; 0xf676
 	ld b, $4
 .asm_f678
 	push bc
@@ -160,7 +160,7 @@ Func_f676: ; 0xf676
 	call LocalCopyData
 	ld bc, $00c0
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld a, [wBallBonusWaitForButtonPress]
 	and a
 	jr z, .asm_f69f
@@ -182,19 +182,19 @@ Func_f676: ; 0xf676
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $50
 	ld a, [wCurBonusMultiplier]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0040
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 .asm_f6c7
 	push de
 	push hl
 	ld hl, wEndOfBallBonusTotalScore + $5
 	ld de, wBottomMessageText + $86
-	call Func_f8bd
+	call ConvertBCD6ToDecimalString
 	ld bc, $0040
 	ld de, $0080
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	lb de, $00, $3e
 	call PlaySoundEffect
 	ld a, [wBallBonusWaitForButtonPress]
@@ -220,10 +220,10 @@ Func_f676: ; 0xf676
 	jr .asm_f6c7
 
 .asm_f709
-	call Func_f83a
+	call WaitForButtonPressOrTimeout
 	ret
 
-Func_f70d: ; 0xf70d
+DisplayFinalBonusScore: ; 0xf70d
 	ld b, $4
 .asm_f70f
 	push bc
@@ -233,7 +233,7 @@ Func_f70d: ; 0xf70d
 	call LocalCopyData
 	ld bc, $00c0
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld a, [wBallBonusWaitForButtonPress]
 	and a
 	jr z, .asm_f736
@@ -252,10 +252,10 @@ Func_f70d: ; 0xf70d
 	call PlaceTextAlphanumericOnly
 	ld hl, wScore + $5
 	ld de, wBottomMessageText + $66
-	call Func_f8bd
+	call ConvertBCD6ToDecimalString
 	ld bc, $0040
 	ld de, $0060
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	lb de, $00, $3e
 	call PlaySoundEffect
 	ld a, [wBallBonusWaitForButtonPress]
@@ -273,15 +273,15 @@ Func_f70d: ; 0xf70d
 	call AddBigBCD6
 	ld hl, wScore + $5
 	ld de, wBottomMessageText + $66
-	call Func_f8bd
+	call ConvertBCD6ToDecimalString
 	ld bc, $0040
 	ld de, $0060
-	call Func_f80d
-	call Func_f83a
-	call Func_f83a
+	call CopyMessageBufferToVRAM
+	call WaitForButtonPressOrTimeout
+	call WaitForButtonPressOrTimeout
 	ret
 
-Func_f78e: ; 0xf78e
+ConvertByteToDecimalDisplay: ; 0xf78e
 	push hl
 	call ConvertHexByteToDecWord
 	pop hl
@@ -378,7 +378,7 @@ PlaceTextAlphanumericOnly: ; 0xf7b1 seems to filter out punctuation and other mi
 	inc de
 	jr .UnusedBranch
 
-Func_f80d: ; 0xf80d
+CopyMessageBufferToVRAM: ; 0xf80d
 	hlCoord 0, 0, vBGWin
 	add hl, de
 	push hl
@@ -388,26 +388,26 @@ Func_f80d: ; 0xf80d
 	call LoadVRAMData
 	ret
 
-Func_f81b: ; 0xf81b
+FillBufferWithSpaceTile: ; 0xf81b
 	ld a, $81
 	ld [hli], a
 	dec bc
 	ld a, b
 	or c
-	jr nz, Func_f81b
+	jr nz, FillBufferWithSpaceTile
 	ret
 
-Func_f824: ; 0xf824
-	call Func_f83a
+ClearMessageAndWaitForInput: ; 0xf824
+	call WaitForButtonPressOrTimeout
 	ld hl, wBottomMessageText
 	ld bc, $0040
-	call Func_f81b
+	call FillBufferWithSpaceTile
 	ld hl, wBottomMessageText + $48
 	ld bc, $0038
-	call Func_f81b
+	call FillBufferWithSpaceTile
 	ret
 
-Func_f83a: ; 0xf83a
+WaitForButtonPressOrTimeout: ; 0xf83a
 	ld a, [wBallBonusWaitForButtonPress]
 	and a
 	ret z
@@ -428,7 +428,7 @@ Func_f83a: ; 0xf83a
 	ld [wBallBonusWaitForButtonPress], a
 	ret
 
-Func_f853: ; 0xf853
+AccumulateBonusPoints: ; 0xf853
 	push hl
 	ld hl, wEndOfBallBonusCategoryScore
 	call ClearBCD6Buffer
@@ -438,10 +438,10 @@ Func_f853: ; 0xf853
 	push hl
 	ld hl, wEndOfBallBonusCategoryScore + $5
 	ld de, wBottomMessageText + $46
-	call Func_f8bd
+	call ConvertBCD6ToDecimalString
 	ld bc, $0040
 	ld de, $0040
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	lb de, $00, $3e
 	call PlaySoundEffect
 	ld a, [wBallBonusWaitForButtonPress]
@@ -474,10 +474,10 @@ Func_f853: ; 0xf853
 	call AddBigBCD6
 	ld hl, wEndOfBallBonusSubTotal + $5
 	ld de, wBottomMessageText + $86
-	call Func_f8bd
+	call ConvertBCD6ToDecimalString
 	ld bc, $0040
 	ld de, $0080
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ret
 
 ClearBCD6Buffer: ; 0xf8b5
@@ -489,16 +489,16 @@ ClearBCD6Buffer: ; 0xf8b5
 	jr nz, .loop
 	ret
 
-Func_f8bd: ; 0xf8bd
+ConvertBCD6ToDecimalString: ; 0xf8bd
 	ld bc, $0c01
 .asm_f8c0
 	ld a, [hl]
 	swap a
-	call Func_f8d5
+	call ConvertBCDNibbleToChar
 	inc de
 	dec b
 	ld a, [hld]
-	call Func_f8d5
+	call ConvertBCDNibbleToChar
 	inc de
 	dec b
 	jr nz, .asm_f8c0
@@ -507,7 +507,7 @@ Func_f8bd: ; 0xf8bd
 	inc de
 	ret
 
-Func_f8d5: ; 0xf8d5
+ConvertBCDNibbleToChar: ; 0xf8d5
 	and $f
 	jr nz, .asm_f8e0
 	ld a, b
@@ -591,14 +591,14 @@ HandleBellsproutEntriesBallBonus: ; 0xf952
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $03
 	ld a, [wNumBellsproutEntries]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumBellsproutEntries
 	ld de, PointsPerBellsproutEntry
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandleDugtrioTriplesBallBonus: ; 0xf97a
@@ -607,14 +607,14 @@ HandleDugtrioTriplesBallBonus: ; 0xf97a
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $04
 	ld a, [wNumDugtrioTriples]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumDugtrioTriples
 	ld de, PointsPerDugtrioTriple
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandleCAVECompletionsBallBonus_RedField: ; 0xf9a2
@@ -623,14 +623,14 @@ HandleCAVECompletionsBallBonus_RedField: ; 0xf9a2
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $03
 	ld a, [wNumCAVECompletions]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumCAVECompletions
 	ld de, PointsPerCAVECompletion
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandleSpinnerTurnsBallBonus_RedField: ; 0xf9ca
@@ -639,14 +639,14 @@ HandleSpinnerTurnsBallBonus_RedField: ; 0xf9ca
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $01
 	ld a, [wNumSpinnerTurns]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumSpinnerTurns
 	ld de, PointsPerSpinnerTurn
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 DoNothing_f9f2: ; 0xf9f2
@@ -667,14 +667,14 @@ HandleCloysterEntriesBallBonus: ; 0xfa06
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $04
 	ld a, [wNumCloysterEntries]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumCloysterEntries
 	ld de, PointsPerCloysterEntry
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandleSlowpokeEntriesBallBonus: ; 0xfa2e
@@ -683,14 +683,14 @@ HandleSlowpokeEntriesBallBonus: ; 0xfa2e
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $04
 	ld a, [wNumSlowpokeEntries]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumSlowpokeEntries
 	ld de, PointsPerSlowpokeEntry
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandlePoliwagTriplesBallBonus: ; 0xfa56
@@ -699,14 +699,14 @@ HandlePoliwagTriplesBallBonus: ; 0xfa56
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $04
 	ld a, [wNumPoliwagTriples]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumPoliwagTriples
 	ld de, PointsPerPoliwagTriple
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandlePsyduckTriplesBallBonus: ; 0xfa7e
@@ -715,14 +715,14 @@ HandlePsyduckTriplesBallBonus: ; 0xfa7e
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $04
 	ld a, [wNumPsyduckTriples]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumPsyduckTriples
 	ld de, PointsPerPsyduckTriple
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandleCAVECompletionsBallBonus_BlueField: ; 0xfaa6
@@ -731,14 +731,14 @@ HandleCAVECompletionsBallBonus_BlueField: ; 0xfaa6
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $03
 	ld a, [wNumCAVECompletions]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumCAVECompletions
 	ld de, PointsPerCAVECompletion
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 HandleSpinnerTurnsBallBonus_BlueField: ; 0xface  :)
@@ -747,14 +747,14 @@ HandleSpinnerTurnsBallBonus_BlueField: ; 0xface  :)
 	call PlaceTextAlphanumericOnly
 	ld hl, wBottomMessageText + $01
 	ld a, [wNumSpinnerTurns]
-	call Func_f78e
+	call ConvertByteToDecimalDisplay
 	ld bc, $0040
 	ld de, $0000
-	call Func_f80d
+	call CopyMessageBufferToVRAM
 	ld hl, wNumSpinnerTurns
 	ld de, PointsPerSpinnerTurn
-	call Func_f853
-	call Func_f824
+	call AccumulateBonusPoints
+	call ClearMessageAndWaitForInput
 	ret
 
 DoNothing_faf6: ; 0xfaf6

--- a/engine/pinball_game/evolution_mode.asm
+++ b/engine/pinball_game/evolution_mode.asm
@@ -497,7 +497,7 @@ InitEvolutionModeForMon: ; 0x10d1d
 	jr nz, .shuffleLoop
 	callba InitBallSaverForCatchEmMode
 	call ShowStartEvolutionModeText
-	call Func_3579
+	call ClearJackpot
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_10e09
@@ -598,7 +598,7 @@ EvolutionSpecialBonus: ; 0x10e8b
 	call EnableBottomText
 	ld hl, wScrollingText2
 	ld de, Data_2b6b
-	call Func_32cc
+	call LoadScrollingScoreText
 	pop de
 	pop bc
 	ld hl, wScrollingText1
@@ -654,10 +654,10 @@ StartEvolutionMode_RedField: ; 0x10ebb
 	ld bc, $00e0
 	call LoadOrCopyVRAMData
 	callba ClearAllRedIndicators
-	callba Func_10184
+	callba UpdateBillboardTileGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_102bc
+	callba nz, LoadBillboardStaticPalette
 	ret
 
 InitialIndicatorStates_RedField: ; 0x10f3b
@@ -698,7 +698,7 @@ ConcludeEvolutionMode_RedField: ; 0x10fe3
 	call ResetIndicatorStates
 	call OpenSlotCave
 	call SetLeftAndRightAlleyArrowIndicatorStates_RedField
-	call Func_107e9
+	call SetRedStageStructureBackup
 	ld a, [wCurrentStage]
 	bit 0, a
 	jp z, LoadRedFieldTopGraphics
@@ -717,7 +717,7 @@ ConcludeEvolutionMode_RedField: ; 0x10fe3
 	ld hl, StageRedFieldBottomOBJPalette7
 	ld de, $0078
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_11036
 	ld hl, BlankSaverSpaceTileDataRedField
 	ld a, BANK(BlankSaverSpaceTileDataRedField)
@@ -789,11 +789,11 @@ StartEvolutionMode_BlueField: ; 0x11061
 	ld de, vTilesOB tile $20
 	ld bc, $00e0
 	call LoadOrCopyVRAMData
-	callba Func_1c2cb
-	callba Func_10184
+	callba LoadArrowIndicators_BlueField
+	callba UpdateBillboardTileGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_102bc
+	callba nz, LoadBillboardStaticPalette
 	ret
 
 InitialIndicatorStates_BlueField: ; 0x110ed
@@ -839,7 +839,7 @@ ConcludeEvolutionMode_BlueField: ; 0x11195
 	ld a, [wCurrentStage]
 	bit 0, a
 	jp z, LoadBlueFieldTopGraphics
-	callba Func_1c2cb
+	callba LoadArrowIndicators_BlueField
 	callba LoadSlotCaveCoverGraphics_BlueField
 	callba LoadMapBillboardTileData
 	ld a, Bank(StageSharedBonusSlotGlowGfx)
@@ -854,7 +854,7 @@ ConcludeEvolutionMode_BlueField: ; 0x11195
 	ld hl, StageBlueFieldBottomOBJPalette7
 	ld de, $0078
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_111f0
 	ld hl, BlankSaverSpaceTileDataBlueField
 	ld a, BANK(BlankSaverSpaceTileDataBlueField)

--- a/engine/pinball_game/evolution_mode/evolution_mode_blue_field.asm
+++ b/engine/pinball_game/evolution_mode/evolution_mode_blue_field.asm
@@ -60,13 +60,13 @@ HandleEvolutionMode_BlueField: ; 0x20c08
 	ld [hl], a
 	ld [wEvolutionObjectsDisabled], a
 	call ProgressEvolution
-	ld a, [wd558]
+	ld a, [wEvolutionIndicatorState2Backup]
 	ld [wIndicatorStates], a
-	ld a, [wd559]
+	ld a, [wEvolutionIndicatorState3Backup]
 	ld [wIndicatorStates + 3], a
 	ld a, [wCurrentStage]
 	bit 0, a
-	callba nz, Func_1c2cb
+	callba nz, LoadArrowIndicators_BlueField
 	ld bc, OneMillionPoints
 	callba AddBigBCD6FromQueue
 	call FillBottomMessageBufferWithBlackTile
@@ -81,7 +81,7 @@ HandleEvolutionMode_BlueField: ; 0x20c08
 	ld hl, StageBlueFieldBottomOBJPalette6
 	ld de, $0070
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_20c74
 	scf
 	ret
@@ -150,8 +150,8 @@ ProgressEvolution: ; 0x20c76
 	ld [wIndicatorStates + 10], a
 	ld [wIndicatorStates + 6], a
 	ld [wIndicatorStates + 7], a
-	ld [wd558], a
-	ld [wd559], a
+	ld [wEvolutionIndicatorState2Backup], a
+	ld [wEvolutionIndicatorState3Backup], a
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
@@ -167,7 +167,7 @@ ProgressEvolution: ; 0x20c76
 	ld hl, StageBlueFieldBottomOBJPalette7
 	ld de, $0078
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_20d25
 	callba LoadSlotCaveCoverGraphics_BlueField
 	ret
@@ -245,13 +245,13 @@ CheckIfEvolutionModeTimerExpired_BlueField: ; 0x20da0
 	ld [wIndicatorStates + 10], a
 	ld [wIndicatorStates + 6], a
 	ld [wIndicatorStates + 7], a
-	ld [wd558], a
-	ld [wd559], a
+	ld [wEvolutionIndicatorState2Backup], a
+	ld [wEvolutionIndicatorState3Backup], a
 	ld [wEvolutionObjectsDisabled], a
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_20e1a
-	callba Func_1c2cb
+	callba LoadArrowIndicators_BlueField
 	callba LoadSlotCaveCoverGraphics_BlueField
 .asm_20e1a
 	callba StopTimer
@@ -459,9 +459,9 @@ CreateEvolutionTrinket_BlueField: ; 0x20f75
 	ld [hl], a
 	ld [wEvolutionObjectsDisabled], a
 	ld a, [wIndicatorStates]
-	ld [wd558], a
+	ld [wEvolutionIndicatorState2Backup], a
 	ld a, [wIndicatorStates + 3]
-	ld [wd559], a
+	ld [wEvolutionIndicatorState3Backup], a
 	ld a, [wIndicatorStates + 2]
 	ld [wIndicatorState2Backup], a
 	xor a
@@ -470,7 +470,7 @@ CreateEvolutionTrinket_BlueField: ; 0x20f75
 	ld [wIndicatorStates + 3], a
 	ld a, [wCurrentStage]
 	bit 0, a
-	callba nz, Func_1c2cb
+	callba nz, LoadArrowIndicators_BlueField
 	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_20fc3
@@ -478,7 +478,7 @@ CreateEvolutionTrinket_BlueField: ; 0x20f75
 	ld hl, EvolutionTrinketPalettes
 	ld de, $0070
 	ld bc, $0010
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_20fc3
 	ld bc, ThreeHundredThousandPoints
 	callba AddBigBCD6FromQueue
@@ -508,12 +508,12 @@ EvolutionTrinketNotFound_BlueField: ; 0x20fef
 	ld a, $1
 	ld [wEvolutionObjectsDisabled], a
 	ld a, [wIndicatorStates]
-	ld [wd558], a
+	ld [wEvolutionIndicatorState2Backup], a
 	ld a, $80
 	ld [wIndicatorStates], a
 	ld [wIndicatorStates + 1], a
 	ld a, [wIndicatorStates + 3]
-	ld [wd559], a
+	ld [wEvolutionIndicatorState3Backup], a
 	ld a, [wIndicatorStates + 2]
 	ld [wIndicatorState2Backup], a
 	xor a
@@ -521,7 +521,7 @@ EvolutionTrinketNotFound_BlueField: ; 0x20fef
 	ld [wIndicatorStates + 3], a
 	ld a, [wCurrentStage]
 	bit 0, a
-	callba nz, Func_1c2cb
+	callba nz, LoadArrowIndicators_BlueField
 	ld a, $58
 	ld [wEvolutionTrinketCooldownFrames], a
 	ld a, $2
@@ -608,15 +608,15 @@ RecoverPokemon_BlueField:
 	xor a
 	ld [wIndicatorStates + 1], a
 	ld [wEvolutionObjectsDisabled], a
-	ld a, [wd558]
+	ld a, [wEvolutionIndicatorState2Backup]
 	ld [wIndicatorStates], a
-	ld a, [wd559]
+	ld a, [wEvolutionIndicatorState3Backup]
 	ld [wIndicatorStates + 3], a
 	ld a, [wIndicatorState2Backup]
 	ld [wIndicatorStates + 2], a
 	ld a, [wCurrentStage]
 	bit 0, a
-	callba nz, Func_1c2cb
+	callba nz, LoadArrowIndicators_BlueField
 	ldh a, [hGameBoyColorFlag]
 	and a
 	jr z, .asm_21102
@@ -624,7 +624,7 @@ RecoverPokemon_BlueField:
 	ld hl, StageBlueFieldBottomOBJPalette6
 	ld de, $0070
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_21102
 	call FillBottomMessageBufferWithBlackTile
 	call EnableBottomText
@@ -715,7 +715,7 @@ HandleSlotCaveCollision_EvolutionMode_BlueField: ; 0x2112a
 	call ReadByteFromBank
 	ld bc, $10b0
 	ld hl, rBGPI
-	call Func_8e1
+	call LoadTileDataWithBankSwitch
 .asm_211a8
 	callba ShowMonEvolvedText
 	call MainLoopUntilTextIsClear

--- a/engine/pinball_game/evolution_mode/evolution_mode_red_field.asm
+++ b/engine/pinball_game/evolution_mode/evolution_mode_red_field.asm
@@ -61,10 +61,10 @@ HandleEvolutionMode_RedField: ; 0x205e0
 	xor a
 	ld [hl], a
 	ld [wEvolutionObjectsDisabled], a
-	call Func_20651
-	ld a, [wd558]
+	call AwardEvolutionTrinket_RedField
+	ld a, [wEvolutionIndicatorState2Backup]
 	ld [wIndicatorStates + 2], a
-	ld a, [wd559]
+	ld a, [wEvolutionIndicatorState3Backup]
 	ld [wIndicatorStates + 3], a
 	ld [wIndicatorStates + 10], a
 	ld a, [wCurrentStage]
@@ -84,12 +84,12 @@ HandleEvolutionMode_RedField: ; 0x205e0
 	ld hl, StageRedFieldBottomOBJPalette6
 	ld de, $0070
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_2064f
 	scf
 	ret
 
-Func_20651: ; 0x20651
+AwardEvolutionTrinket_RedField: ; 0x20651
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_20681
@@ -153,8 +153,8 @@ Func_20651: ; 0x20651
 	ld [wIndicatorStates + 12], a
 	ld [wIndicatorStates + 6], a
 	ld [wIndicatorStates + 7], a
-	ld [wd558], a
-	ld [wd559], a
+	ld [wEvolutionIndicatorState2Backup], a
+	ld [wEvolutionIndicatorState3Backup], a
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
@@ -170,7 +170,7 @@ Func_20651: ; 0x20651
 	ld hl, StageRedFieldBottomOBJPalette7
 	ld de, $0078
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_20700
 	callba LoadSlotCaveCoverGraphics_RedField
 	ret
@@ -248,8 +248,8 @@ CheckIfEvolutionModeTimerExpired_RedField: ; 0x2077b
 	ld [wIndicatorStates + 12], a
 	ld [wIndicatorStates + 6], a
 	ld [wIndicatorStates + 7], a
-	ld [wd558], a
-	ld [wd559], a
+	ld [wEvolutionIndicatorState2Backup], a
+	ld [wEvolutionIndicatorState3Backup], a
 	ld [wEvolutionObjectsDisabled], a
 	ld a, [wCurrentStage]
 	bit 0, a
@@ -483,9 +483,9 @@ CreateEvolutionTrinket_RedField: ; 0x20977
 	ld [hl], a
 	ld [wEvolutionObjectsDisabled], a
 	ld a, [wIndicatorStates + 2]
-	ld [wd558], a
+	ld [wEvolutionIndicatorState2Backup], a
 	ld a, [wIndicatorStates + 3]
-	ld [wd559], a
+	ld [wEvolutionIndicatorState3Backup], a
 	xor a
 	ld [wIndicatorStates + 2], a
 	ld [wIndicatorStates + 3], a
@@ -500,7 +500,7 @@ CreateEvolutionTrinket_RedField: ; 0x20977
 	ld hl, EvolutionTrinketPalettes
 	ld de, $0070
 	ld bc, $0010
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_209bf
 	ld bc, ThreeHundredThousandPoints
 	callba AddBigBCD6FromQueue
@@ -531,9 +531,9 @@ EvolutionTrinketNotFound_RedField: ; 0x209eb
 	ld [wIndicatorStates], a
 	ld [wIndicatorStates + 1], a
 	ld a, [wIndicatorStates + 2]
-	ld [wd558], a
+	ld [wEvolutionIndicatorState2Backup], a
 	ld a, [wIndicatorStates + 3]
-	ld [wd559], a
+	ld [wEvolutionIndicatorState3Backup], a
 	xor a
 	ld [wIndicatorStates + 2], a
 	ld [wIndicatorStates + 3], a
@@ -608,9 +608,9 @@ RecoverPokemon_RedField:
 	ld [wIndicatorStates], a
 	ld [wIndicatorStates + 1], a
 	ld [wEvolutionObjectsDisabled], a
-	ld a, [wd558]
+	ld a, [wEvolutionIndicatorState2Backup]
 	ld [wIndicatorStates + 2], a
-	ld a, [wd559]
+	ld a, [wEvolutionIndicatorState3Backup]
 	ld [wIndicatorStates + 3], a
 	ld [wIndicatorStates + 10], a
 	ld a, [wCurrentStage]
@@ -623,7 +623,7 @@ RecoverPokemon_RedField:
 	ld hl, StageRedFieldBottomOBJPalette6
 	ld de, $0070
 	ld bc, $0008
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 .asm_20ada
 	call FillBottomMessageBufferWithBlackTile
 	call EnableBottomText
@@ -714,7 +714,7 @@ HandleSlotCaveCollision_EvolutionMode_RedField: ; 0x20b02
 	call ReadByteFromBank
 	ld bc, $10b0
 	ld hl, rBGPI
-	call Func_8e1
+	call LoadTileDataWithBankSwitch
 .asm_20b80
 	callba ShowMonEvolvedText
 	call MainLoopUntilTextIsClear

--- a/engine/pinball_game/extra_ball.asm
+++ b/engine/pinball_game/extra_ball.asm
@@ -41,7 +41,7 @@ ShowExtraBallMessage: ; 0x30188
 	call EnableBottomText
 	ld hl, wScrollingText2
 	ld de, DigitsText1to9
-	call Func_32cc
+	call LoadScrollingScoreText
 	pop de
 	pop bc
 	ld hl, wScrollingText1

--- a/engine/pinball_game/flippers.asm
+++ b/engine/pinball_game/flippers.asm
@@ -297,7 +297,7 @@ ReadFlipperCollisionAttributes: ; 0xe25a
 	ld [wFlipperCollision], a
 	ret
 
-Func_e2e4:
+FixedPointDivide:
 	ld a, c
 	or b
 	or l
@@ -525,7 +525,7 @@ CalculateFlipperYForce: ; 0xe379
 ; This function might be have been used as CalculateFlipperXForce, since
 ; there is use of FlipperXForce anywhere, and this appears very similar to
 ; CalculateFlipperYForce.
-Func_e3de:
+CalculateFlipperXForce:
 	push bc
 	push de
 	ld c, d

--- a/engine/pinball_game/load_stage_data/load_blue_field.asm
+++ b/engine/pinball_game/load_stage_data/load_blue_field.asm
@@ -8,16 +8,16 @@ _LoadStageDataBlueFieldTop: ; 0x1c165
 	ld [wBlueStageForceFieldGfxNeedsLoading], a
 	call UpdateForceFieldGraphics
 	callba LoadTimerGraphics
-	call Func_1c203
+	call SaveBallStateForDMG_BlueField
 	ret
 
 _LoadStageDataBlueFieldBottom: ; 0x1c191
-	call Func_1c1db
+	call ResetForceFieldState_BlueField
 	call LoadBillboardGraphics_BlueField
-	call Func_1c2cb
+	call LoadArrowIndicators_BlueField
 	call LoadCAVELightsGraphics_BlueField
 	call LoadBillboardStatusBarGraphics_BlueField
-	call Func_1c305
+	call HandleCatchAndEvolutionGraphics_BlueField
 	call LoadEvolutionTrinketGraphics_BlueField
 	callba LoadAgainTextGraphics
 	callba DrawBallSaverIcon
@@ -26,10 +26,10 @@ _LoadStageDataBlueFieldBottom: ; 0x1c191
 	call LoadSlotCaveCoverGraphics_BlueField
 	callba LoadBallGraphics
 	callba LoadTimerGraphics
-	call Func_1c203
+	call SaveBallStateForDMG_BlueField
 	ret
 
-Func_1c1db: ; 0x1c1db
+ResetForceFieldState_BlueField: ; 0x1c1db
 	ld a, [wBlueStageForceFieldFlippedDown]
 	cp $0
 	ret z
@@ -49,16 +49,16 @@ Func_1c1db: ; 0x1c1db
 	ld [wd648], a
 	ret
 
-Func_1c203: ; 0x1c203
+SaveBallStateForDMG_BlueField: ; 0x1c203
 	ld a, $ff
 	ld [wWhichAnimatedShellder], a
 	ld [wWhichBumperGfx], a
 	ld a, [wBallXPos + 1]
-	ld [wd4c5], a
+	ld [wBallPreviousXPosDMG], a
 	ld a, [wBallYPos + 1]
-	ld [wd4c6], a
+	ld [wBallPreviousYPosDMG], a
 	ld a, [wBallRotation]
-	ld [wd4c7], a
+	ld [wBallPreviousRotationDMG], a
 	ret
 
 LoadBonusMultiplierRailingGraphics_BlueField: ; 0x1c21e
@@ -166,7 +166,7 @@ LoadPsyduckOrPoliwagGraphics: ; 0x1c235
 	call LoadPsyduckOrPoliwagNumberGraphics
 	ret
 
-Func_1c2cb: ; 0x1c2cb
+LoadArrowIndicators_BlueField: ; 0x1c2cb
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
@@ -206,27 +206,27 @@ Func_1c2cb: ; 0x1c2cb
 	jr nz, .asm_1c2e9
 	ret
 
-Func_1c305: ; 0x1c305
+HandleCatchAndEvolutionGraphics_BlueField: ; 0x1c305
 	ld a, [wInSpecialMode]
 	and a
 	ret z
 	ld a, [wSpecialMode]
 	cp SPECIAL_MODE_MAP_MOVE
 	ret z
-	ld a, [wd5c6]
+	ld a, [wCatchModeTransitionFlag]
 	and a
 	jr nz, .asm_1c31f
 	ld a, [wCapturingMon]
 	and a
 	jr nz, .asm_1c31f
-	jp Func_1c3ca
+	jp ToggleBillboardIllumination_BlueField
 
 .asm_1c31f
-	callba Func_1c3ac
-	callba Func_10362
+	callba FillBillboardMapArea_BlueField
+	callba QueueBillboardAnimatedGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_10301
+	callba nz, LoadBillboardAnimatedPalettes
 	ld a, [wCapturingMon]
 	and a
 	ret z
@@ -278,18 +278,18 @@ Func_1c305: ; 0x1c305
 	call FarCopyData
 	ret
 
-Func_1c3ac: ; 0x1c3ac
+FillBillboardMapArea_BlueField: ; 0x1c3ac
 	ld a, $80
 	hlCoord 7, 4, vBGMap
-	call Func_1c3c3
+	call FillSixConsecutiveTiles_BlueField
 	hlCoord 7, 5, vBGMap
-	call Func_1c3c3
+	call FillSixConsecutiveTiles_BlueField
 	hlCoord 7, 6, vBGMap
-	call Func_1c3c3
+	call FillSixConsecutiveTiles_BlueField
 	hlCoord 7, 7, vBGMap
 	; fall through
 
-Func_1c3c3: ; 0x1c3c3
+FillSixConsecutiveTiles_BlueField: ; 0x1c3c3
 	ld [hli], a
 	ld [hli], a
 	ld [hli], a
@@ -298,7 +298,7 @@ Func_1c3c3: ; 0x1c3c3
 	ld [hli], a
 	ret
 
-Func_1c3ca: ; 0x1c3ca
+ToggleBillboardIllumination_BlueField: ; 0x1c3ca
 	ld hl, wBillboardTilesIlluminationStates
 	ld b, $18
 .asm_1c3cf
@@ -307,10 +307,10 @@ Func_1c3ca: ; 0x1c3ca
 	ld [hli], a
 	dec b
 	jr nz, .asm_1c3cf
-	callba Func_10184
+	callba UpdateBillboardTileGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_102bc
+	callba nz, LoadBillboardStaticPalette
 	ret
 
 LoadEvolutionTrinketGraphics_BlueField: ; 0x1c3ee
@@ -362,13 +362,13 @@ LoadBillboardStatusBarGraphics_BlueField: ; 0x1c43c
 	jr nz, .asm_1c450
 	ld a, [wNumMonHits]
 	and a
-	call nz, Func_1c46d
+	call nz, CallMonHitGraphicsRepeated_BlueField
 	ret
 
 .asm_1c450
 	cp SPECIAL_MODE_EVOLUTION
 	jr nz, .asm_1c458
-	call Func_1c47d
+	call LoadEvolutionProgressIcons_BlueField
 	ret
 
 .asm_1c458
@@ -381,15 +381,15 @@ LoadBillboardStatusBarGraphics_BlueField: ; 0x1c43c
 	call FarCopyData
 	ret
 
-Func_1c46d: ; 0x1c46d
+CallMonHitGraphicsRepeated_BlueField: ; 0x1c46d
 	push af
-	callba Func_10611
+	callba LoadCatchTextGraphics
 	pop af
 	dec a
-	jr nz, Func_1c46d
+	jr nz, CallMonHitGraphicsRepeated_BlueField
 	ret
 
-Func_1c47d: ; 0x1c47d
+LoadEvolutionProgressIcons_BlueField: ; 0x1c47d
 	ld de, $0000
 	ld a, [wNumEvolutionTrinkets]
 	and a
@@ -397,13 +397,13 @@ Func_1c47d: ; 0x1c47d
 	ld b, a
 .asm_1c486
 	ld a, [wCurrentEvolutionType]
-	call Func_1c491
+	call LoadSingleEvolutionIcon_BlueField
 	inc de
 	dec b
 	jr nz, .asm_1c486
 	ret
 
-Func_1c491: ; 0x1c491
+LoadSingleEvolutionIcon_BlueField: ; 0x1c491
 	push bc
 	push de
 	dec a

--- a/engine/pinball_game/load_stage_data/load_diglett_bonus.asm
+++ b/engine/pinball_game/load_stage_data/load_diglett_bonus.asm
@@ -4,14 +4,14 @@ _LoadStageDataDiglettBonus: ; 0x19a76
 	ld a, [wLoadingSavedGame]
 	and a
 	ret z
-	call Func_19bbd
-	call Func_19a96
+	call QueueGateGraphicsToLoad_DiglettBonus
+	call RestoreDiglettStatesOnLoad
 	ld a, [wDugrioState]
 	and a
-	call nz, Func_1ac2c
+	call nz, LoadDugtrioCollisionData
 	ret
 
-Func_19a96: ; 0x19a96
+RestoreDiglettStatesOnLoad: ; 0x19a96
 	ld hl, wDiglettStates
 	ld bc, NUM_DIGLETTS << 8
 .asm_19a9c
@@ -21,10 +21,10 @@ Func_19a96: ; 0x19a96
 	push bc
 	push hl
 	push af
-	call Func_19da8
+	call UpdateDiglettAnimationState
 	pop af
 	cp $6
-	call c, Func_19dcd
+	call c, WriteDiglettCollisionMapTiles
 	pop hl
 	pop bc
 .asm_19aae

--- a/engine/pinball_game/load_stage_data/load_gengar_bonus.asm
+++ b/engine/pinball_game/load_stage_data/load_gengar_bonus.asm
@@ -1,11 +1,11 @@
 _LoadStageDataGengarBonus: ; 0x1818b
 	callba LoadBallGraphics
 	call LoadFlippersPalette
-	call Func_18d72
+	call QueueSecondaryGateGraphics_GengarBonus
 	ld a, [wLoadingSavedGame]
 	callba LoadTimerGraphics
 	and a
 	ret z
-	call Func_183db
-	call Func_18d91
+	call QueueGateGraphicsToLoad_GengarBonus
+	call UpdateGateCollisionMapTiles_GengarBonus
 	ret

--- a/engine/pinball_game/load_stage_data/load_meowth_bonus.asm
+++ b/engine/pinball_game/load_stage_data/load_meowth_bonus.asm
@@ -1,7 +1,7 @@
 _LoadStageDataMeowthBonus: ; 0x24128
 	callba LoadBallGraphics
 	call LoadFlippersPalette
-	callba Func_24fa3
-	call Func_24516
+	callba UpdateMeowthMultiplierAnimation
+	call QueueGateGraphicsToLoad_MeowthBonus
 	callba LoadTimerGraphics
 	ret

--- a/engine/pinball_game/load_stage_data/load_mewtwo_bonus.asm
+++ b/engine/pinball_game/load_stage_data/load_mewtwo_bonus.asm
@@ -5,5 +5,5 @@ _LoadStageDataMewtwoBonus: ; 0x19310
 	ld a, [wLoadingSavedGame]
 	and a
 	ret z
-	call Func_194ac
+	call QueueGateGraphicsToLoad_MewtwoBonus
 	ret

--- a/engine/pinball_game/load_stage_data/load_red_field.asm
+++ b/engine/pinball_game/load_stage_data/load_red_field.asm
@@ -1,5 +1,5 @@
 _LoadStageDataRedFieldTop: ; 0x14000
-	call Func_14091
+	call SaveAndResetAnimationState_RedField
 	call LoadFieldStructureGraphics_RedField
 	call LoadPinballUpgradeTriggersGraphics_RedField
 	call LoadStaryuGraphics_Top
@@ -11,12 +11,12 @@ _LoadStageDataRedFieldTop: ; 0x14000
 	ret
 
 _LoadStageDataRedFieldBottom: ; 0x1401c
-	call Func_14091
+	call SaveAndResetAnimationState_RedField
 	call LoadBillboardGraphics_RedField
 	call ClearAllRedIndicators
 	call LoadCAVELightsGraphics_RedField
 	call LoadBillboardStatusBarGraphics_RedField
-	call Func_1414b
+	call HandleCatchAndEvolutionGraphics_RedField
 	call LoadEvolutionTrinketGraphics_RedField
 	call LoadAgainTextGraphics
 	call DrawBallSaverIcon
@@ -35,12 +35,12 @@ LoadTimerGraphics: ; 0x1404a
 	ldh a, [hGameBoyColorFlag]
 	and a
 	ret nz
-	ld a, [wd580]
+	ld a, [wTimerGraphicsNeedsLoading]
 	and a
 	ret z
 	ld a, $f
 	ld [wd581], a
-	call Func_1762f
+	call GetTimerSpriteIndex
 	ld hl, wTimerDigits
 	ld a, $ff
 	ld [hli], a
@@ -65,24 +65,24 @@ LoadTimerGraphics: ; 0x1404a
 	call LoadTimerDigitTiles
 	ret
 
-Func_14091: ; 0x14091
+SaveAndResetAnimationState_RedField: ; 0x14091
 	ld a, $ff
 	ld [wWhichAnimatedVoltorb], a
 	ld [wWhichBumperGfx], a
 	ld a, [wBallXPos + 1]
-	ld [wd4c5], a
+	ld [wBallPreviousXPosDMG], a
 	ld a, [wBallYPos + 1]
-	ld [wd4c6], a
+	ld [wBallPreviousYPosDMG], a
 	ld a, [wBallRotation]
-	ld [wd4c7], a
-	ld a, [wd503]
+	ld [wBallPreviousRotationDMG], a
+	ld a, [wStaryuAnimationTimer]
 	and a
 	ret z
 	xor a
-	ld [wd503], a
-	ld a, [wd502]
+	ld [wStaryuAnimationTimer], a
+	ld a, [wStaryuState]
 	res 1, a
-	ld [wd502], a
+	ld [wStaryuState], a
 	and $1
 	ld c, a
 	ld a, [wStageCollisionState]
@@ -155,27 +155,27 @@ ClearAllRedIndicators: ; 0x14135
 	jr nz, .Loop5Times
 	ret
 
-Func_1414b: ; 0x1414b
+HandleCatchAndEvolutionGraphics_RedField: ; 0x1414b
 	ld a, [wInSpecialMode]
 	and a
 	ret z
 	ld a, [wSpecialMode]
 	cp SPECIAL_MODE_MAP_MOVE
 	ret z
-	ld a, [wd5c6]
+	ld a, [wCatchModeTransitionFlag]
 	and a
 	jr nz, .asm_14165
 	ld a, [wCapturingMon]
 	and a
 	jr nz, .asm_14165
-	jp Func_14210
+	jp ToggleBillboardIllumination_RedField
 
 .asm_14165
-	callba Func_141f2
-	callba Func_10362
+	callba FillBillboardMapArea_RedField
+	callba QueueBillboardAnimatedGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_10301
+	callba nz, LoadBillboardAnimatedPalettes
 	ld a, [wCapturingMon]
 	and a
 	ret z
@@ -227,18 +227,18 @@ Func_1414b: ; 0x1414b
 	call FarCopyData
 	ret
 
-Func_141f2: ; 0x141f2
+FillBillboardMapArea_RedField: ; 0x141f2
 	ld a, $80
 	hlCoord 7, 4, vBGMap
-	call Func_14209
+	call FillSixConsecutiveTiles_RedField
 	hlCoord 7, 5, vBGMap
-	call Func_14209
+	call FillSixConsecutiveTiles_RedField
 	hlCoord 7, 6, vBGMap
-	call Func_14209
+	call FillSixConsecutiveTiles_RedField
 	hlCoord 7, 7, vBGMap
 	; fall through
 
-Func_14209: ; 0x14209
+FillSixConsecutiveTiles_RedField: ; 0x14209
 	ld [hli], a
 	ld [hli], a
 	ld [hli], a
@@ -247,7 +247,7 @@ Func_14209: ; 0x14209
 	ld [hli], a
 	ret
 
-Func_14210: ; 0x14210
+ToggleBillboardIllumination_RedField: ; 0x14210
 	ld hl, wBillboardTilesIlluminationStates
 	ld b, $18
 .asm_14215
@@ -256,10 +256,10 @@ Func_14210: ; 0x14210
 	ld [hli], a
 	dec b
 	jr nz, .asm_14215
-	callba Func_10184
+	callba UpdateBillboardTileGraphics
 	ldh a, [hGameBoyColorFlag]
 	and a
-	callba nz, Func_102bc
+	callba nz, LoadBillboardStaticPalette
 	ret
 
 LoadEvolutionTrinketGraphics_RedField: ; 0x14234
@@ -311,13 +311,13 @@ LoadBillboardStatusBarGraphics_RedField: ; 0x14282
 	jr nz, .asm_14296
 	ld a, [wNumMonHits]
 	and a
-	call nz, Func_142b3
+	call nz, CallMonHitGraphicsRepeated_RedField
 	ret
 
 .asm_14296
 	cp SPECIAL_MODE_EVOLUTION
 	jr nz, .asm_1429e
-	call Func_142c3
+	call LoadEvolutionProgressIcons_RedField
 	ret
 
 .asm_1429e
@@ -330,15 +330,15 @@ LoadBillboardStatusBarGraphics_RedField: ; 0x14282
 	call FarCopyData
 	ret
 
-Func_142b3: ; 0x142b3
+CallMonHitGraphicsRepeated_RedField: ; 0x142b3
 	push af
-	callba Func_10611
+	callba LoadCatchTextGraphics
 	pop af
 	dec a
-	jr nz, Func_142b3
+	jr nz, CallMonHitGraphicsRepeated_RedField
 	ret
 
-Func_142c3: ; 0x142c3
+LoadEvolutionProgressIcons_RedField: ; 0x142c3
 	ld de, $0000
 	ld a, [wNumEvolutionTrinkets]
 	and a
@@ -346,13 +346,13 @@ Func_142c3: ; 0x142c3
 	ld b, a
 .asm_142cc
 	ld a, [wCurrentEvolutionType]
-	call Func_142d7
+	call LoadSingleEvolutionIcon_RedField
 	inc de
 	dec b
 	jr nz, .asm_142cc
 	ret
 
-Func_142d7: ; 0x142d7
+LoadSingleEvolutionIcon_RedField: ; 0x142d7
 	push bc
 	push de
 	dec a

--- a/engine/pinball_game/load_stage_data/load_seel_bonus.asm
+++ b/engine/pinball_game/load_stage_data/load_seel_bonus.asm
@@ -1,7 +1,7 @@
 _LoadStageDataSeelBonus: ; 0x25b97
 	callba LoadBallGraphics
 	call LoadFlippersPalette
-	callba Func_262f4
-	call Func_25d0e
+	callba UpdateSeelStageScoreDisplay
+	call QueueGateGraphicsToLoad_SeelBonus
 	callba LoadTimerGraphics
 	ret

--- a/engine/pinball_game/load_stage_data/load_unused_stage.asm
+++ b/engine/pinball_game/load_stage_data/load_unused_stage.asm
@@ -8,7 +8,7 @@ DoNothing_18060: ; 0x18060
 DoNothing_18061: ; 0x18061
 	ret
 
-Func_18062: ; 0x18062
+CheckLaunchAlleyCollision_UnusedStage: ; 0x18062
 ; used by unused stage
 	callba CheckRedStageLaunchAlleyCollision
 	ret
@@ -16,6 +16,6 @@ Func_18062: ; 0x18062
 DoNothing_1806d: ; 0x1806d
 	ret
 
-Func_1806e: ; 0x1806e
+ResolveLaunchCollision_UnusedStage: ; 0x1806e
 	callba ResolveRedStagePinballLaunchCollision
 	ret

--- a/engine/pinball_game/map_move.asm
+++ b/engine/pinball_game/map_move.asm
@@ -31,12 +31,12 @@ StartMapMoveMode: ; 0x301ec
 	ld a, [wCurrentStage]
 	rst JumpTable  ; calls JumpToFuncInTable
 CallTable_3021f: ; 0x3021f
-	dw Func_311b4 ; STAGE_RED_FIELD_TOP
-	dw Func_311b4 ; STAGE_RED_FIELD_BOTTOM
+	dw InitRedMapModeIndicators ; STAGE_RED_FIELD_TOP
+	dw InitRedMapModeIndicators ; STAGE_RED_FIELD_BOTTOM
 	dw DoNothing_31324
 	dw DoNothing_31324
-	dw Func_31326 ; STAGE_BLUE_FIELD_TOP
-	dw Func_31326 ; STAGE_BLUE_FIELD_BOTTOM
+	dw InitBlueMapModeIndicators ; STAGE_BLUE_FIELD_TOP
+	dw InitBlueMapModeIndicators ; STAGE_BLUE_FIELD_BOTTOM
 
 ConcludeMapMoveMode: ; 0x3022b
 	xor a
@@ -49,12 +49,12 @@ ConcludeMapMoveMode: ; 0x3022b
 	ld a, [wCurrentStage]
 	rst JumpTable  ; calls JumpToFuncInTable
 CallTable_30247: ; 0x30247
-	dw Func_31234 ; STAGE_RED_FIELD_TOP
-	dw Func_31234 ; STAGE_RED_FIELD_BOTTOM
+	dw FinalizeRedMapModeIndicators ; STAGE_RED_FIELD_TOP
+	dw FinalizeRedMapModeIndicators ; STAGE_RED_FIELD_BOTTOM
 	dw DoNothing_31325
 	dw DoNothing_31325
-	dw Func_313c3 ; STAGE_BLUE_FIELD_TOP
-	dw Func_313c3 ; STAGE_BLUE_FIELD_TOP
+	dw FinalizeBlueMapModeIndicators ; STAGE_BLUE_FIELD_TOP
+	dw FinalizeBlueMapModeIndicators ; STAGE_BLUE_FIELD_TOP
 
 INCLUDE "engine/pinball_game/billboard_tiledata.asm"
 
@@ -81,7 +81,7 @@ LoadScrollingMapNameText: ; 0x3118f
 	call LoadScrollingText
 	ret
 
-Func_311b4: ; 0x311b4
+InitRedMapModeIndicators: ; 0x311b4
 	ld a, [wMapMoveDirection]
 	and a
 	jr nz, .asm_311ce
@@ -128,11 +128,11 @@ Func_311b4: ; 0x311b4
 	callba ClearAllRedIndicators
 	ret
 
-Func_31234: ; 0x31234
+FinalizeRedMapModeIndicators: ; 0x31234
 	callba ResetIndicatorStates
 	callba OpenSlotCave
 	callba SetLeftAndRightAlleyArrowIndicatorStates_RedField
-	callba Func_107e9
+	callba SetRedStageStructureBackup
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
@@ -252,7 +252,7 @@ DoNothing_31324: ; 0x31324
 DoNothing_31325: ; 0x31325
 	ret
 
-Func_31326: ; 0x31326
+InitBlueMapModeIndicators: ; 0x31326
 	ld a, [wMapMoveDirection]
 	and a
 	jr nz, .asm_3134c
@@ -302,10 +302,10 @@ Func_31326: ; 0x31326
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
-	callba Func_1c2cb
+	callba LoadArrowIndicators_BlueField
 	ret
 
-Func_313c3: ; 0x313c3
+FinalizeBlueMapModeIndicators: ; 0x313c3
 	callba ResetIndicatorStates
 	callba OpenSlotCave
 	callba SetLeftAndRightAlleyArrowIndicatorStates_BlueField
@@ -314,7 +314,7 @@ Func_313c3: ; 0x313c3
 	ld a, [wCurrentStage]
 	bit 0, a
 	ret z
-	callba Func_1c2cb
+	callba LoadArrowIndicators_BlueField
 	callba LoadSlotCaveCoverGraphics_BlueField
 	callba LoadMapBillboardTileData
 	ret
@@ -450,27 +450,27 @@ HandleRedMapModeCollision: ; 0x314ae
 	ld a, [wSpecialModeState]
 	call CallInFollowingTable
 PointerTable_314df: ; 0xd13df
-	padded_dab Func_314ef
-	padded_dab Func_314f1
-	padded_dab Func_314f3
-	padded_dab Func_31505
+	padded_dab MapMoveStateZero_Red
+	padded_dab MapMoveStateOne_Red
+	padded_dab MapMoveStateTwo_Red
+	padded_dab MapMoveStateThree_Red
 
-Func_314ef: ; 0x314ef
+MapMoveStateZero_Red: ; 0x314ef
 	scf
 	ret
 
-Func_314f1: ; 0x314f1
+MapMoveStateOne_Red: ; 0x314f1
 	scf
 	ret
 
-Func_314f3: ; 0x314f3
+MapMoveStateTwo_Red: ; 0x314f3
 	callba ConcludeMapMoveMode
 	ld de, MUSIC_BLUE_FIELD ; Either MUSIC_BLUE_FIELD or MUSIC_RED_FIELD. They have the same id in their respective audio Banks.
 	call PlaySong
 	scf
 	ret
 
-Func_31505: ; 0x31505
+MapMoveStateThree_Red: ; 0x31505
 	ld a, [wBottomTextEnabled]
 	and a
 	ret nz
@@ -580,15 +580,15 @@ HandleBlueMapModeCollision: ; 0x3161b
 	ld a, [wSpecialModeCollisionID]
 	jr z, .asm_3163d
 	cp SPECIAL_COLLISION_LEFT_TRIGGER
-	jp z, Func_31708
+	jp z, OpenBlueMapMoveSlotFromLeft
 	cp SPECIAL_COLLISION_SLOWPOKE
-	jp z, Func_31708
+	jp z, OpenBlueMapMoveSlotFromLeft
 	cp SPECIAL_COLLISION_RIGHT_TRIGGER
-	jp z, Func_3172a
+	jp z, OpenBlueMapMoveSlotFromRight
 	cp SPECIAL_COLLISION_CLOYSTER
-	jp z, Func_3172a
+	jp z, OpenBlueMapMoveSlotFromRight
 	cp SPECIAL_COLLISION_SLOT_HOLE
-	jp z, Func_3174c
+	jp z, ResolveSuccessfulBlueMapMove
 .asm_3163d
 	cp SPECIAL_COLLISION_NOTHING
 	jr z, .asm_31643
@@ -600,27 +600,27 @@ HandleBlueMapModeCollision: ; 0x3161b
 	ld a, [wSpecialModeState]
 	call CallInFollowingTable
 PointerTable_3164c: ; 0x3164c
-	padded_dab Func_3165c
-	padded_dab Func_3165e
-	padded_dab Func_31660
-	padded_dab Func_31672
+	padded_dab MapMoveStateZero_Blue
+	padded_dab MapMoveStateOne_Blue
+	padded_dab MapMoveStateTwo_Blue
+	padded_dab MapMoveStateThree_Blue
 
-Func_3165c: ; 0x3165c
+MapMoveStateZero_Blue: ; 0x3165c
 	scf
 	ret
 
-Func_3165e: ; 0x3165e
+MapMoveStateOne_Blue: ; 0x3165e
 	scf
 	ret
 
-Func_31660: ; 0x31660
+MapMoveStateTwo_Blue: ; 0x31660
 	callba ConcludeMapMoveMode
 	ld de, MUSIC_BLUE_FIELD ; Either MUSIC_BLUE_FIELD or MUSIC_RED_FIELD. They have the same id in their respective audio Banks.
 	call PlaySong
 	scf
 	ret
 
-Func_31672: ; 0x31672
+MapMoveStateThree_Blue: ; 0x31672
 	ld a, [wBottomTextEnabled] ;if text is off
 	and a
 	ret nz
@@ -657,7 +657,7 @@ UpdateMapMove_BlueField: ; 0x3168c
 	ld a, [wCurrentStage]
 	bit 0, a
 	jr z, .asm_316ee
-	callba Func_1c2cb
+	callba LoadArrowIndicators_BlueField
 	callba LoadSlotCaveCoverGraphics_BlueField
 	callba LoadMapBillboardTileData
 .asm_316ee
@@ -669,7 +669,7 @@ UpdateMapMove_BlueField: ; 0x3168c
 	call LoadScrollingText
 	ret
 
-Func_31708: ; 0x31708
+OpenBlueMapMoveSlotFromLeft: ; 0x31708
 	ld a, [wMapMoveDirection]
 	and a
 	jr nz, .asm_31728
@@ -688,7 +688,7 @@ Func_31708: ; 0x31708
 	scf
 	ret
 
-Func_3172a: ; 0x3172a
+OpenBlueMapMoveSlotFromRight: ; 0x3172a
 	ld a, [wMapMoveDirection]
 	and a
 	jr z, .asm_3174a
@@ -707,7 +707,7 @@ Func_3172a: ; 0x3172a
 	scf
 	ret
 
-Func_3174c: ; 0x3174c
+ResolveSuccessfulBlueMapMove: ; 0x3174c
 	ld de, MUSIC_NOTHING
 	call PlaySong
 	rst AdvanceFrame

--- a/engine/pinball_game/menu.asm
+++ b/engine/pinball_game/menu.asm
@@ -1,9 +1,9 @@
 HandleInGameMenu: ; 0x86d7
 ; Routine responsible for the "SAVE"/"CANCEL" menu.
-	ld a, [wd917]
+	ld a, [wDisableRumble]
 	push af
 	ld a, $1
-	ld [wd917], a
+	ld [wDisableRumble], a
 	call FillBottomMessageBufferWithBlackTile
 	xor a
 	ld [wDrawBottomMessageBox], a
@@ -19,10 +19,10 @@ HandleInGameMenu: ; 0x86d7
 	jr nz, .clearLoop
 	ld de, wBottomMessageText + $24
 	ld hl, SaveText
-	call Func_8797
+	call DrawMenuText
 	ld de, wBottomMessageText + $64
 	ld hl, CancelText
-	call Func_8797
+	call DrawMenuText
 	ld a, Bank(InGameMenuSymbolsGfx)
 	ld hl, InGameMenuSymbolsGfx + $50
 	ld de, vTilesSH + $60
@@ -81,21 +81,21 @@ HandleInGameMenu: ; 0x86d7
 .asm_8786
 	call FillBottomMessageBufferWithBlackTile
 	pop af
-	ld [wd917], a
+	ld [wDisableRumble], a
 	ld a, $1
 	ld [wDrawBottomMessageBox], a
 	ld a, [wInGameMenuIndex]
 	and a
 	ret
 
-Func_8797: ; 0x8797
+DrawMenuText: ; 0x8797
 	ld a, [hli]
 	and a
 	ret z
 	add $bf
 	ld [de], a
 	inc de
-	jr Func_8797
+	jr DrawMenuText
 
 SaveText: ; 0x87a0
 	db "SAVE@"

--- a/engine/pinball_game/object_collision/blue_stage_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/blue_stage_resolve_collision.asm
@@ -478,7 +478,7 @@ UpdateBlueStageSpinner: ; 0x1ca85
 	cp MAX_PIKACHU_SAVER_CHARGE
 	jr nz, .asm_1cb12
 	ld a, $64
-	ld [wd51e], a
+	ld [wSpinnerChargeSoundCooldown], a
 .asm_1cb12
 	ld a, [wCurrentStage]
 	bit 0, a
@@ -487,7 +487,7 @@ UpdateBlueStageSpinner: ; 0x1ca85
 	ret
 
 PlaySpinnerChargingSoundEffect_BlueField: ; 0x1cb1c
-	ld a, [wd51e]
+	ld a, [wSpinnerChargeSoundCooldown]
 	and a
 	ret nz
 	ld a, [wPikachuSaverCharge]
@@ -625,7 +625,7 @@ ResolveBlueStageBoardTriggerCollision: ; 0x1cfaa
 	ld [wStageCollisionState], a
 	callba LoadStageCollisionAttributes
 	ld a, $1
-	ld [wd580], a
+	ld [wTimerGraphicsNeedsLoading], a
 	callba LoadTimerGraphics
 .asm_1cfe5
 	ld a, [wWhichBoardTriggerId]
@@ -734,7 +734,7 @@ ResolveBlueStagePikachuCollision: ; 0x1d0a1
 	jr z, .asm_1d110
 	xor a
 	ld [wWhichPikachu], a
-	ld a, [wd51c]
+	ld a, [wPikachuSaverAnimationState]
 	and a
 	jr nz, .asm_1d110
 	ld a, [wPikachuSaverSlotRewardActive]
@@ -759,7 +759,7 @@ ResolveBlueStagePikachuCollision: ; 0x1d0a1
 	ld [wPikachuSaverCharge], a
 .asm_1d0dc
 	ld a, $1
-	ld [wd51c], a
+	ld [wPikachuSaverAnimationState], a
 	xor a
 	ld [wBallXVelocity], a
 	ld [wBallXVelocity + 1], a
@@ -776,22 +776,22 @@ ResolveBlueStagePikachuCollision: ; 0x1d0a1
 	ld de, wPikachuSaverAnimation
 	call InitAnimation
 	ld a, $2
-	ld [wd51c], a
+	ld [wPikachuSaverAnimationState], a
 	lb de, $00, $3b
 	call PlaySoundEffect
 .asm_1d110
-	ld a, [wd51c]
+	ld a, [wPikachuSaverAnimationState]
 	and a
 	call z, SetPikachuSaverSide_BlueField
 	call UpdatePikachuSaverAnimation_BlueField
 	ld a, [wPikachuSaverCharge]
 	cp MAX_PIKACHU_SAVER_CHARGE
 	ret nz
-	ld a, [wd51e]
+	ld a, [wSpinnerChargeSoundCooldown]
 	and a
 	ret z
 	dec a
-	ld [wd51e], a
+	ld [wSpinnerChargeSoundCooldown], a
 	cp $5a
 	ret nz
 	lb de, $0f, $22
@@ -799,7 +799,7 @@ ResolveBlueStagePikachuCollision: ; 0x1d0a1
 	ret
 
 UpdatePikachuSaverAnimation_BlueField: ; 0x1d133
-	ld a, [wd51c]
+	ld a, [wPikachuSaverAnimationState]
 	cp $1
 	jr nz, .asm_1d1ae
 	ld hl, PikachuSaverAnimationData_BlueField
@@ -811,7 +811,7 @@ UpdatePikachuSaverAnimation_BlueField: ; 0x1d133
 	jr nz, .asm_1d18c
 	xor a
 	ld [wAudioEngineEnabled], a
-	call Func_310a
+	call ClearBottomMessageBufferRows
 	rst AdvanceFrame
 	ld a, $1
 	callba PlayPikachuSoundClip
@@ -843,7 +843,7 @@ UpdatePikachuSaverAnimation_BlueField: ; 0x1d133
 	ld bc, FiveThousandPoints
 	callba AddBigBCD6FromQueueWithBallMultiplier
 	xor a
-	ld [wd51c], a
+	ld [wPikachuSaverAnimationState], a
 	ret
 
 .asm_1d1ae
@@ -857,7 +857,7 @@ UpdatePikachuSaverAnimation_BlueField: ; 0x1d133
 	cp $1
 	ret nz
 	xor a
-	ld [wd51c], a
+	ld [wPikachuSaverAnimationState], a
 	ret
 
 .asm_1d1c7
@@ -1621,7 +1621,7 @@ UpdatePoliwag: ; 0x1dc95
 	ld a, [wPoliwagState]
 	cp $2
 	ret nz
-	call Func_1130
+	call CheckGraphicsQueueEmpty
 	ret nz
 	ldh a, [hGameBoyColorFlag]
 	and a
@@ -2029,7 +2029,7 @@ ResolveBallUpgradeTriggersCollision_BlueField: ; 0x1e356
 	ld [wStageCollisionState], a
 	callba LoadStageCollisionAttributes
 	ld a, $1
-	ld [wd580], a
+	ld [wTimerGraphicsNeedsLoading], a
 	callba LoadTimerGraphics
 .asm_1e386
 	ld a, [wStageCollisionState]
@@ -2114,7 +2114,7 @@ ResolveBallUpgradeTriggersCollision_BlueField: ; 0x1e356
 	call EnableBottomText
 	ld hl, wScrollingText2
 	ld de, DigitsText1to8
-	call Func_32cc
+	call LoadScrollingScoreText
 	pop de
 	pop bc
 	ld hl, wScrollingText1

--- a/engine/pinball_game/object_collision/diglett_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/diglett_bonus_resolve_collision.asm
@@ -1,6 +1,6 @@
 ResolveDiglettBonusGameObjectCollisions: ; 0x19b88
-	call Func_19c52
-	call Func_1aad4
+	call ResolveDiglettHitCollision
+	call ResolveDugtrioHitCollision
 	call TryCloseGate_DiglettBonus
 	ret
 
@@ -22,10 +22,10 @@ TryCloseGate_DiglettBonus: ; 0x19b92
 	ld [wStageCollisionMap + $172], a
 	ld a, $7
 	ld [wStageCollisionMap + $192], a
-	call Func_19bbd
+	call QueueGateGraphicsToLoad_DiglettBonus
 	ret
 
-Func_19bbd: ; 0x19bbd
+QueueGateGraphicsToLoad_DiglettBonus: ; 0x19bbd
 	ld a, [wStageCollisionState]
 	sla a
 	ld c, a
@@ -132,7 +132,7 @@ Data_19c39: ; 0x19c39
 	db $14, $15
 	db $00  ; terminator
 
-Func_19c52: ; 0x19c52
+ResolveDiglettHitCollision: ; 0x19c52
 	ld a, [wd73b]
 	and a
 	jr z, .asm_19cc8
@@ -160,8 +160,8 @@ Func_19c52: ; 0x19c52
 	jr nc, .asm_19cc8
 	ld a, $8
 	ld [hl], a
-	call Func_19da8
-	call Func_19df0
+	call UpdateDiglettAnimationState
+	call ClearDiglettCollisionMapTiles
 	ld hl, wDiglettStates
 	ld bc, NUM_DIGLETTS << 8
 	xor a
@@ -184,11 +184,11 @@ Func_19c52: ; 0x19c52
 	call InitAnimation
 	ld a, $1
 	ld [wDugrioState], a
-	call Func_1ac2c
+	call LoadDugtrioCollisionData
 	ld de, MUSIC_WHACK_DUGTRIO
 	call PlaySong
 .asm_19cc8
-	call Func_19cdd
+	call InitializeDiglettsInSequence
 	ld a, [wd765]
 	and a
 	ret nz
@@ -196,10 +196,10 @@ Func_19c52: ; 0x19c52
 	ld [wd765], a
 	ld a, [wDugrioState]
 	and a
-	call nz, Func_1ac2c
+	call nz, LoadDugtrioCollisionData
 	ret
 
-Func_19cdd: ; 0x19cdd
+InitializeDiglettsInSequence: ; 0x19cdd
 	ld a, [wDiglettsInitializedFlag]
 	and a
 	jr nz, .alreadyInitializedDigletts
@@ -238,15 +238,15 @@ Func_19cdd: ; 0x19cdd
 	and $3
 	add $2
 	ld [hl], a
-	call Func_19da8
-	call Func_19dcd
+	call UpdateDiglettAnimationState
+	call WriteDiglettCollisionMapTiles
 	jr .asm_19d29
 
 .asm_19d21
 	and $3
 	add $2
 	ld [hl], a
-	call Func_19da8
+	call UpdateDiglettAnimationState
 .asm_19d29
 	pop hl
 	pop bc
@@ -294,8 +294,8 @@ Func_19cdd: ; 0x19cdd
 	and $3
 	add $2
 	ld [hl], a
-	call Func_19da8
-	call Func_19dcd
+	call UpdateDiglettAnimationState
+	call WriteDiglettCollisionMapTiles
 	jr .asm_19d8f
 
 .asm_19d77
@@ -306,14 +306,14 @@ Func_19cdd: ; 0x19cdd
 	xor a
 	ld [hl], a
 	ld a, $1
-	call Func_19da8
+	call UpdateDiglettAnimationState
 	jr .asm_19d8f
 
 .incrementDiglettState
 	and $3
 	add $2
 	ld [hl], a
-	call Func_19da8
+	call UpdateDiglettAnimationState
 .asm_19d8f
 	pop hl
 	pop bc
@@ -330,7 +330,7 @@ Func_19cdd: ; 0x19cdd
 	ld [wCurrentDiglett], a
 	ret
 
-Func_19da8: ; 0x19da8
+UpdateDiglettAnimationState: ; 0x19da8
 ; input: a = diglett state
 ;        c = diglett index
 	cp $6
@@ -359,7 +359,7 @@ Func_19da8: ; 0x19da8
 	pop bc
 	ret
 
-Func_19dcd: ; 0x19dcd
+WriteDiglettCollisionMapTiles: ; 0x19dcd
 	sla c
 	ld a, c
 	sla c
@@ -390,7 +390,7 @@ Func_19dcd: ; 0x19dcd
 	ld [de], a
 	ret
 
-Func_19df0: ; 0x19df0
+ClearDiglettCollisionMapTiles: ; 0x19df0
 	sla c
 	ld a, c
 	sla c
@@ -591,7 +591,7 @@ DiglettUpdateOrder: ; 0x19ef3
 
 INCLUDE "data/queued_tiledata/diglett_bonus/digletts.asm"
 
-Func_1aad4: ; 0x1aad4
+ResolveDugtrioHitCollision: ; 0x1aad4
 	ld a, [wd75f]
 	and a
 	jr z, .asm_1ab2c
@@ -630,10 +630,10 @@ Func_1aad4: ; 0x1aad4
 	ld a, $80
 	ld [wFlipperCollision], a
 .asm_1ab2c
-	call Func_1ab30
+	call UpdateDugtrioAnimation
 	ret
 
-Func_1ab30: ; 0x1ab30
+UpdateDugtrioAnimation: ; 0x1ab30
 	ld a, [wDugrioState]
 	sla a
 	ld c, a
@@ -760,7 +760,7 @@ Func_1ab30: ; 0x1ab30
 	ld hl, Data_1ac56
 	jr asm_1ac2f
 
-Func_1ac2c: ; 0x1ac2c
+LoadDugtrioCollisionData: ; 0x1ac2c
 	ld hl, Data_1ac4a
 asm_1ac2f:
 	ld de, wStageCollisionMap + $68

--- a/engine/pinball_game/object_collision/gengar_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/gengar_bonus_resolve_collision.asm
@@ -1,8 +1,8 @@
 ResolveGengarBonusGameObjectCollisions: ; 0x18377
-	call Func_18464
-	call Func_1860b
-	call Func_187b1
-	call Func_18d34
+	call ResolveGastlyHitCollision
+	call ResolveHaunterHitCollision
+	call ResolveGengarHitCollision
+	call ResolveGravestoneCollision
 	call TryCloseGate_GengarBonus
 	callba PlayLowTimeSfx
 	ld a, [wTimeRanOut]
@@ -32,11 +32,11 @@ TryCloseGate_GengarBonus: ; 0x183b7
 	ld [wStageCollisionState], a
 	ld [wGengarBonusClosedGate], a
 	callba LoadStageCollisionAttributes
-	call Func_183db
-	call Func_18d91
+	call QueueGateGraphicsToLoad_GengarBonus
+	call UpdateGateCollisionMapTiles_GengarBonus
 	ret
 
-Func_183db: ; 0x183db
+QueueGateGraphicsToLoad_GengarBonus: ; 0x183db
 	ld a, [wStageCollisionState]
 	sla a
 	ld c, a
@@ -167,7 +167,7 @@ TileData_1844e: ; 0x1844e
 
 	db $00 ; terminator
 
-Func_18464: ; 0x18464
+ResolveGastlyHitCollision: ; 0x18464
 	ld a, [wGastly1Enabled]
 	and a
 	ret z
@@ -226,24 +226,24 @@ Func_18464: ; 0x18464
 	ld bc, $0830
 	ld de, wGastly1InHitAnimation
 	ld hl, wd675
-	call Func_1850c
+	call UpdateGastlyVerticalOffset
 	ld bc, $5078
 	ld de, wGastly2InHitAnimation
 	ld hl, wd677
-	call Func_1850c
+	call UpdateGastlyVerticalOffset
 	ld bc, $3050
 	ld de, wGastly3InHitAnimation
 	ld hl, wd679
-	call Func_1850c
+	call UpdateGastlyVerticalOffset
 	ld de, wGastly1InHitAnimation
-	call Func_18562
+	call UpdateGastlyAnimationAndState
 	ld de, wGastly2InHitAnimation
-	call Func_18562
+	call UpdateGastlyAnimationAndState
 	ld de, wGastly3InHitAnimation
-	call Func_18562
+	call UpdateGastlyAnimationAndState
 	ret
 
-Func_1850c: ; 0x1850c
+UpdateGastlyVerticalOffset: ; 0x1850c
 	ld a, [de]
 	and a
 	ret nz
@@ -300,7 +300,7 @@ GastlyData_18542: ; 0x18542
 	db $37, $38, $39, $3A, $3B, $3A, $39, $38
 	db $37, $36, $35, $34, $33, $32, $31, $30
 
-Func_18562: ; 0x18562
+UpdateGastlyAnimationAndState: ; 0x18562
 	ld a, [de]
 	sla a
 	ld c, a
@@ -415,7 +415,7 @@ AnimationData_185e6: ; 0x185e6
 	db $80, $04
 	db $00 ; terminator
 
-Func_1860b: ; 0x1860b
+ResolveHaunterHitCollision: ; 0x1860b
 	ld a, [wd67e]
 	and a
 	ret z
@@ -474,18 +474,18 @@ Func_1860b: ; 0x1860b
 	ld bc, $5078
 	ld de, wd682
 	ld hl, wd691
-	call Func_186a1
+	call UpdateHaunterVerticalOffset
 	ld bc, $1038
 	ld de, wd68b
 	ld hl, wd693
-	call Func_186a1
+	call UpdateHaunterVerticalOffset
 	ld de, wd682
-	call Func_186f7
+	call UpdateHaunterAnimationAndState
 	ld de, wd68b
-	call Func_186f7
+	call UpdateHaunterAnimationAndState
 	ret
 
-Func_186a1: ; 0x186a1
+UpdateHaunterVerticalOffset: ; 0x186a1
 	ld a, [de]
 	and a
 	ret nz
@@ -542,7 +542,7 @@ HaunterData_186d7:
 	db $37, $38, $39, $3A, $3B, $3A, $39, $38
 	db $37, $36, $35, $34, $33, $32, $31, $30
 
-Func_186f7: ; 0x186f7
+UpdateHaunterAnimationAndState: ; 0x186f7
 	ld a, [de]
 	sla a
 	ld c, a
@@ -583,8 +583,8 @@ Func_186f7: ; 0x186f7
 	jr nz, .asm_18740
 	ld a, $1
 	ld [wd656], a
-	call Func_18d72
-	call Func_18d91
+	call QueueSecondaryGateGraphics_GengarBonus
+	call UpdateGateCollisionMapTiles_GengarBonus
 	ld de, MUSIC_NOTHING
 	call PlaySong
 	ret
@@ -665,7 +665,7 @@ AnimationData_1878a:
 	db $10, $05
 	db $00 ; terminator
 
-Func_187b1: ; 0x187b1
+ResolveGengarHitCollision: ; 0x187b1
 	ld a, [wd698]
 	and a
 	ret z
@@ -747,18 +747,18 @@ Func_187b1: ; 0x187b1
 	ld a, [wd69c]
 	cp $2
 	jr nc, .asm_18869
-	call Func_18876
+	call UpdateGengarVerticalPosition_LowerPhase
 	jr .asm_1886c
 
 .asm_18869
-	call Func_188e1
+	call UpdateGengarVerticalPosition_UpperPhase
 .asm_1886c
 	ld de, wd69c
-	call Func_189af
-	call Func_1894c
+	call UpdateGengarBonusGhostAnimation
+	call UpdateGengarTiltMechanic
 	ret
 
-Func_18876: ; 0x18876
+UpdateGengarVerticalPosition_LowerPhase: ; 0x18876
 	ld a, [wd6a3]
 	cp $1
 	jr z, .asm_1889b
@@ -811,7 +811,7 @@ Func_18876: ; 0x18876
 	ld [wd6a3], a
 	ret
 
-Func_188e1: ; 0x188e1
+UpdateGengarVerticalPosition_UpperPhase: ; 0x188e1
 	ld a, [wd6a3]
 	cp $1
 	jr z, .asm_18901
@@ -865,7 +865,7 @@ Func_188e1: ; 0x188e1
 	ld [wd6a3], a
 	ret
 
-Func_1894c: ; 0x1894c
+UpdateGengarTiltMechanic: ; 0x1894c
 	ld a, [wd6a6]
 	and a
 	jr nz, .asm_1898f
@@ -920,7 +920,7 @@ Func_1894c: ; 0x1894c
 	ld [wd6a6], a
 	ret
 
-Func_189af: ; 0x189af
+UpdateGengarBonusGhostAnimation: ; 0x189af
 	ld a, [de]
 	sla a
 	ld c, a
@@ -1417,7 +1417,7 @@ AnimationData_18d2f:
 	db $40, $00
 	db $00 ; terminator
 
-Func_18d34: ; 0x18d34
+ResolveGravestoneCollision: ; 0x18d34
 	ld a, [wWhichGravestone]
 	and a
 	jr z, .asm_18d71
@@ -1444,7 +1444,7 @@ Func_18d34: ; 0x18d34
 .asm_18d71
 	ret
 
-Func_18d72: ; 0x18d72
+QueueSecondaryGateGraphics_GengarBonus: ; 0x18d72
 	ld a, [wd656]
 	sla a
 	ld c, a
@@ -1465,7 +1465,7 @@ Func_18d72: ; 0x18d72
 	call QueueGraphicsToLoad
 	ret
 
-Func_18d91: ; 0x18d91
+UpdateGateCollisionMapTiles_GengarBonus: ; 0x18d91
 	ld a, [wd656]
 	and a
 	ld hl, Data_18dc9
@@ -1473,15 +1473,15 @@ Func_18d91: ; 0x18d91
 	ld hl, Data_18dd2
 .asm_18d9d
 	ld de, wStageCollisionMap + $c7
-	call Func_18db2
+	call CopyCollisionDataToMap
 	ld de, wStageCollisionMap + $ae
-	call Func_18db2
+	call CopyCollisionDataToMap
 	ld de, wStageCollisionMap + $123
-	call Func_18db2
+	call CopyCollisionDataToMap
 	ld de, wStageCollisionMap + $14d
 	; fall through
 
-Func_18db2: ; 0x18db2
+CopyCollisionDataToMap: ; 0x18db2
 	push hl
 	ld b, $3
 .asm_18db5
@@ -1545,7 +1545,7 @@ TileData_18df4: ; 0x18df4
 	dw TileData_18ec7
 
 TileData_18e09: ; 0x18e09
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw $9640
 	dw GengarBonusBaseGameBoyGfx + $E40
@@ -1553,7 +1553,7 @@ TileData_18e09: ; 0x18e09
 	db $00
 
 TileData_18e13: ; 0x18e13
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $67
 	dw GengarBonusBaseGameBoyGfx + $E70
@@ -1561,7 +1561,7 @@ TileData_18e13: ; 0x18e13
 	db $00
 
 TileData_18e1d: ; 0x18e1d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6A
 	dw GengarBonusBaseGameBoyGfx + $EA0
@@ -1569,7 +1569,7 @@ TileData_18e1d: ; 0x18e1d
 	db $00
 
 TileData_18e27: ; 0x18e27
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6D
 	dw GengarBonusBaseGameBoyGfx + $ED0
@@ -1577,7 +1577,7 @@ TileData_18e27: ; 0x18e27
 	db $00
 
 TileData_18e31: ; 0x18e31
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $70
 	dw GengarBonusBaseGameBoyGfx + $F00
@@ -1585,7 +1585,7 @@ TileData_18e31: ; 0x18e31
 	db $00
 
 TileData_18e3b: ; 0x18e3b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $73
 	dw GengarBonusBaseGameBoyGfx + $F30
@@ -1593,7 +1593,7 @@ TileData_18e3b: ; 0x18e3b
 	db $00
 
 TileData_18e45: ; 0x18e45
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $76
 	dw GengarBonusBaseGameBoyGfx + $F60
@@ -1601,7 +1601,7 @@ TileData_18e45: ; 0x18e45
 	db $00
 
 TileData_18e4f: ; 0x18e4f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $79
 	dw GengarBonusBaseGameBoyGfx + $F90
@@ -1609,7 +1609,7 @@ TileData_18e4f: ; 0x18e4f
 	db $00
 
 TileData_18e59: ; 0x18e59
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $7C
 	dw GengarBonusBaseGameBoyGfx + $FC0
@@ -1617,7 +1617,7 @@ TileData_18e59: ; 0x18e59
 	db $00
 
 TileData_18e63: ; 0x18e63
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7F
 	dw GengarBonusBaseGameBoyGfx + $FF0
@@ -1625,7 +1625,7 @@ TileData_18e63: ; 0x18e63
 	db $00
 
 TileData_18e6d: ; 0x18e6d
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $64
 	dw GengarBonusGroundGfx
@@ -1633,7 +1633,7 @@ TileData_18e6d: ; 0x18e6d
 	db $00
 
 TileData_18e77: ; 0x18e77
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $67
 	dw GengarBonusGroundGfx + $30
@@ -1641,7 +1641,7 @@ TileData_18e77: ; 0x18e77
 	db $00
 
 TileData_18e81: ; 0x18e81
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6A
 	dw GengarBonusGroundGfx + $60
@@ -1649,7 +1649,7 @@ TileData_18e81: ; 0x18e81
 	db $00
 
 TileData_18e8b: ; 0x18e8b
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $6D
 	dw GengarBonusGroundGfx + $90
@@ -1657,7 +1657,7 @@ TileData_18e8b: ; 0x18e8b
 	db $00
 
 TileData_18e95: ; 0x18e95
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $70
 	dw GengarBonusGroundGfx + $C0
@@ -1665,7 +1665,7 @@ TileData_18e95: ; 0x18e95
 	db $00
 
 TileData_18e9f: ; 0x18e9f
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $73
 	dw GengarBonusGroundGfx + $F0
@@ -1673,7 +1673,7 @@ TileData_18e9f: ; 0x18e9f
 	db $00
 
 TileData_18ea9: ; 0x18ea9
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $76
 	dw GengarBonusGroundGfx + $120
@@ -1681,7 +1681,7 @@ TileData_18ea9: ; 0x18ea9
 	db $00
 
 TileData_18eb3: ; 0x18eb3
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $79
 	dw GengarBonusGroundGfx + $150
@@ -1689,7 +1689,7 @@ TileData_18eb3: ; 0x18eb3
 	db $00
 
 TileData_18ebd: ; 0x18ebd
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $30, $03
 	dw vTilesBG tile $7C
 	dw GengarBonusGroundGfx + $180
@@ -1697,7 +1697,7 @@ TileData_18ebd: ; 0x18ebd
 	db $00
 
 TileData_18ec7: ; 0x18ec7
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $10, $01
 	dw vTilesBG tile $7F
 	dw GengarBonusGroundGfx + $1B0

--- a/engine/pinball_game/object_collision/meowth_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/meowth_bonus_resolve_collision.asm
@@ -1,4 +1,4 @@
-Func_24319: ; 0x2438f
+ResolveCoinCollision_Lower_MeowthBonus: ; 0x2438f
 	ld a, [wd6f4]
 	cp $0
 	jr z, .asm_24333
@@ -8,7 +8,7 @@ Func_24319: ; 0x2438f
 	ld a, [wMeowthJewel0YCoord]
 	add $4
 	ld c, a
-	call Func_24405
+	call CheckCoinCollisionInRange
 	ld a, $0
 	jr c, .asm_24373
 .asm_24333
@@ -21,7 +21,7 @@ Func_24319: ; 0x2438f
 	ld a, [wMeowthJewel1YCoord]
 	add $4
 	ld c, a
-	call Func_24405
+	call CheckCoinCollisionInRange
 	ld a, $1
 	jr c, .asm_24373
 .asm_2434d
@@ -34,7 +34,7 @@ Func_24319: ; 0x2438f
 	ld a, [wMeowthJewel2YCoord]
 	add $4
 	ld c, a
-	call Func_24405
+	call CheckCoinCollisionInRange
 	ld a, $2
 	jr c, .asm_24373
 	ld a, [wd6f4]
@@ -64,7 +64,7 @@ Func_24319: ; 0x2438f
 	ld [hl], $0
 	ret
 
-Func_2438f: ; 0x2438f
+ResolveCoinCollision_Upper_MeowthBonus: ; 0x2438f
 	ld a, [wd6f4]
 	cp $a
 	jr z, .asm_243a9
@@ -74,7 +74,7 @@ Func_2438f: ; 0x2438f
 	ld a, [wMeowthJewel3YCoord]
 	add $4
 	ld c, a
-	call Func_24405
+	call CheckCoinCollisionInRange
 	ld a, $a
 	jr c, .asm_243e9
 .asm_243a9
@@ -87,7 +87,7 @@ Func_2438f: ; 0x2438f
 	ld a, [wMeowthJewel4YCoord]
 	add $4
 	ld c, a
-	call Func_24405
+	call CheckCoinCollisionInRange
 	ld a, $b
 	jr c, .asm_243e9
 .asm_243c3
@@ -100,7 +100,7 @@ Func_2438f: ; 0x2438f
 	ld a, [wMeowthJewel5YCoord]
 	add $4
 	ld c, a
-	call Func_24405
+	call CheckCoinCollisionInRange
 	ld a, $c
 	jr c, .asm_243e9
 	ld a, [wd6f4]
@@ -130,7 +130,7 @@ Func_2438f: ; 0x2438f
 	ld [hl], $0
 	ret
 
-Func_24405: ; 0x24405
+CheckCoinCollisionInRange: ; 0x24405
 	ld hl, wMeowthJewel0XCoord
 	ld a, [wd6f4]
 	ld e, a
@@ -171,7 +171,7 @@ ResolveMeowthBonusGameObjectCollisions: ; 0x2442a
 	ld [wd79a], a
 .asm_2443f
 	ld de, wd79a
-	call Func_24f00
+	call DisplayMeowthMultiplierText
 	jr .asm_2444b
 
 .asm_24447
@@ -179,9 +179,9 @@ ResolveMeowthBonusGameObjectCollisions: ; 0x2442a
 	ld [wd79a], a
 .asm_2444b
 	call TryCloseGate_MeowthBonus
-	call Func_245ab
-	call Func_248ac
-	call Func_24d07
+	call HandleMeowthHitCollision
+	call UpdateMeowthBottomCoins
+	call UpdateMeowthTopCoins
 	ld a, [wMeowthStageScore]
 	cp $14
 	jr c, .asm_24498
@@ -255,10 +255,10 @@ TryCloseGate_MeowthBonus: ; 0x244f5
 	ld [wStageCollisionState], a
 	ld [wMeowthBonusClosedGate], a
 	callba LoadStageCollisionAttributes
-	call Func_24516
+	call QueueGateGraphicsToLoad_MeowthBonus
 	ret
 
-Func_24516: ; 0x24516
+QueueGateGraphicsToLoad_MeowthBonus: ; 0x24516
 	ld a, [wStageCollisionState]
 	sla a
 	ld c, a
@@ -389,7 +389,7 @@ TileData_24592: ; 0x24592
 
 	db $00 ; terminator
 
-Func_245ab: ; 0x245ab
+HandleMeowthHitCollision: ; 0x245ab
 	ld a, [wd6e7]
 	and a
 	jr z, .asm_24621
@@ -405,11 +405,11 @@ Func_245ab: ; 0x245ab
 	jr .asm_245cf
 
 .locatedAtBottom
-	call Func_247d9
+	call ProduceBottomCoin
 	jr .asm_245cf
 
 .locatedAtTop
-	call Func_24c28
+	call ProduceTopCoin
 .asm_245cf
 	xor a
 	ld [wd6e7], a
@@ -470,11 +470,11 @@ Func_245ab: ; 0x245ab
 .asm_24651
 	ld a, [wMeowthState]
 	cp $2
-	call c, Func_24709
-	call Func_2465d
+	call c, UpdateMeowthPosition
+	call UpdateMeowthAnimationFrame
 	ret
 
-Func_2465d: ; 0x2465d
+UpdateMeowthAnimationFrame: ; 0x2465d
 	ld a, [wMeowthState]
 	sla a
 	ld c, a
@@ -584,7 +584,7 @@ MeowthAnimationData5: ; 0x24704
 	db $17, MEOWTHSPRITE_TIMEOUT_1
 	db $00 ; terminator
 
-Func_24709: ; 0x24709
+UpdateMeowthPosition: ; 0x24709
 	ld a, [wMeowthXPosition]
 	ld hl, wMeowthXMovement
 	add [hl]
@@ -714,7 +714,7 @@ UpdateMeowthVerticalMovement: ; 0x2476d
 	ld [wMeowthYMovement], a
 	ret
 
-Func_247d9: ; 0x247d9
+ProduceBottomCoin: ; 0x247d9
 	ld a, [wd6f3]
 	and a
 	ret z
@@ -819,7 +819,7 @@ Func_247d9: ; 0x247d9
 .asm_248ab
 	ret
 
-Func_248ac: ; 0x248ac
+UpdateMeowthBottomCoins: ; 0x248ac
 	ld a, [wMeowthJewel0State]
 	cp $1
 	jr nz, .asm_248d3
@@ -828,7 +828,7 @@ Func_248ac: ; 0x248ac
 	jr z, .asm_248c4
 	ld a, $0
 	ld [wd6f4], a
-	call Func_24a30
+	call AnimateMovingCoin
 	jr .asm_248d3
 
 .asm_248c4
@@ -847,7 +847,7 @@ Func_248ac: ; 0x248ac
 	jr z, .asm_248eb
 	ld a, $1
 	ld [wd6f4], a
-	call Func_24a30
+	call AnimateMovingCoin
 	jr .asm_248fa
 
 .asm_248eb
@@ -866,7 +866,7 @@ Func_248ac: ; 0x248ac
 	jr z, .asm_24912
 	ld a, $2
 	ld [wd6f4], a
-	call Func_24a30
+	call AnimateMovingCoin
 	jr .asm_24921
 
 .asm_24912
@@ -907,7 +907,7 @@ Func_248ac: ; 0x248ac
 	ld a, [hl]
 	cp $2
 	jr nz, .asm_2495f
-	call Func_24e7f
+	call ApplyCoinHitSpriteEffect
 	jr .asm_24968
 
 .asm_2495f
@@ -928,7 +928,7 @@ Func_248ac: ; 0x248ac
 	ld a, [hl]
 	cp $2
 	jr nz, .asm_24985
-	call Func_24e7f
+	call ApplyCoinHitSpriteEffect
 	jr .asm_2498e
 
 .asm_24985
@@ -949,7 +949,7 @@ Func_248ac: ; 0x248ac
 	ld a, [hl]
 	cp $2
 	jr nz, .asm_249ab
-	call Func_24e7f
+	call ApplyCoinHitSpriteEffect
 	jr .asm_249b4
 
 .asm_249ab
@@ -1021,7 +1021,7 @@ Func_248ac: ; 0x248ac
 	ld [wMeowthState], a
 	ret
 
-Func_24a30: ; 0x24a30
+AnimateMovingCoin: ; 0x24a30
 	ld a, [wd6f4]
 	ld c, a
 	ld b, $0
@@ -1030,7 +1030,7 @@ Func_24a30: ; 0x24a30
 	ld a, [hl]
 	and a
 	jr z, .asm_24a42
-	call Func_24b41
+	call ContinueMovingCoinAnimation
 	ret
 
 .asm_24a42
@@ -1140,11 +1140,11 @@ Func_24a30: ; 0x24a30
 	ld a, c
 	cp $9
 	jr c, .asm_24aed
-	call Func_2438f
+	call ResolveCoinCollision_Upper_MeowthBonus
 	ret
 
 .asm_24aed
-	call Func_24319
+	call ResolveCoinCollision_Lower_MeowthBonus
 .asm_24af0
 	ret
 
@@ -1191,7 +1191,7 @@ Data_24af1:
 	db 0,  0
 	db 0,  0
 
-Func_24b41: ; 0x24b41
+ContinueMovingCoinAnimation: ; 0x24b41
 	ld a, [wd6f4]
 	ld b, $0
 	ld c, a
@@ -1199,7 +1199,7 @@ Func_24b41: ; 0x24b41
 	add hl, bc
 	ld a, [hl]
 	cp $14
-	jp nc, Func_24bf6
+	jp nc, SetCoinAnimationComplete
 	ld hl, wd6f5
 	add hl, bc
 	ld a, [hl]
@@ -1290,11 +1290,11 @@ Func_24b41: ; 0x24b41
 	ld a, c
 	cp $9
 	jr c, .asm_24be1
-	call Func_2438f
+	call ResolveCoinCollision_Upper_MeowthBonus
 	jr .asm_24be4
 
 .asm_24be1
-	call Func_24319
+	call ResolveCoinCollision_Lower_MeowthBonus
 .asm_24be4
 	ld a, [wd6f4]
 	ld b, $0
@@ -1309,7 +1309,7 @@ Func_24b41: ; 0x24b41
 	scf
 	ret
 
-Func_24bf6: ; 0x24bf6
+SetCoinAnimationComplete: ; 0x24bf6
 	ld a, [wd6f4]
 	ld b, $0
 	ld c, a
@@ -1340,7 +1340,7 @@ Data_24c0a:
 	db 0,  0
 	db 0,  0
 
-Func_24c28: ; 0x24c28
+ProduceTopCoin: ; 0x24c28
 	ld a, [wd6f3]
 	and a
 	ret z
@@ -1451,7 +1451,7 @@ Func_24c28: ; 0x24c28
 .asm_24d06
 	ret
 
-Func_24d07: ; 0x24d07
+UpdateMeowthTopCoins: ; 0x24d07
 	ld a, [wMeowthJewel3State]
 	cp $1
 	jr nz, .asm_24d2a
@@ -1460,7 +1460,7 @@ Func_24d07: ; 0x24d07
 	jr z, .asm_24d1f
 	ld a, $a
 	ld [wd6f4], a
-	call Func_24a30
+	call AnimateMovingCoin
 	jr .asm_24d2a
 
 .asm_24d1f
@@ -1477,7 +1477,7 @@ Func_24d07: ; 0x24d07
 	jr z, .asm_24d42
 	ld a, $b
 	ld [wd6f4], a
-	call Func_24a30
+	call AnimateMovingCoin
 	jr .asm_24d4d
 
 .asm_24d42
@@ -1494,7 +1494,7 @@ Func_24d07: ; 0x24d07
 	jr z, .asm_24d65
 	ld a, $c
 	ld [wd6f4], a
-	call Func_24a30
+	call AnimateMovingCoin
 	jr .asm_24d70
 
 .asm_24d65
@@ -1533,7 +1533,7 @@ Func_24d07: ; 0x24d07
 	ld a, [hl]
 	cp $2
 	jr nz, .asm_24dae
-	call Func_24e7f
+	call ApplyCoinHitSpriteEffect
 	jr .asm_24db7
 
 .asm_24dae
@@ -1554,7 +1554,7 @@ Func_24d07: ; 0x24d07
 	ld a, [hl]
 	cp $2
 	jr nz, .asm_24dd4
-	call Func_24e7f
+	call ApplyCoinHitSpriteEffect
 	jr .asm_24ddd
 
 .asm_24dd4
@@ -1575,7 +1575,7 @@ Func_24d07: ; 0x24d07
 	ld a, [hl]
 	cp $2
 	jr nz, .asm_24dfa
-	call Func_24e7f
+	call ApplyCoinHitSpriteEffect
 	jr .asm_24e03
 
 .asm_24dfa
@@ -1647,7 +1647,7 @@ Func_24d07: ; 0x24d07
 	ld [wMeowthState], a
 	ret
 
-Func_24e7f: ; 0x24e7f
+ApplyCoinHitSpriteEffect: ; 0x24e7f
 	ld a, b
 	ld [wd79c], a
 	ld a, c
@@ -1690,7 +1690,7 @@ Func_24e7f: ; 0x24e7f
 	jr z, .asm_24ed7
 	ld [wd79a], a
 	ld de, wd79a
-	call Func_24ee7
+	call ResetCoinAnimationState
 	jr .asm_24ede
 
 .asm_24ed7
@@ -1700,10 +1700,10 @@ Func_24e7f: ; 0x24e7f
 .asm_24ede
 	ld a, $1
 	ld [wd64e], a
-	call Func_24fa3
+	call UpdateMeowthMultiplierAnimation
 	ret
 
-Func_24ee7: ; 0x24ee7
+ResetCoinAnimationState: ; 0x24ee7
 	ld a, $ff
 	ld [wd795], a
 	ld a, [de]
@@ -1721,7 +1721,7 @@ Func_24ee7: ; 0x24ee7
 	call InitAnimation
 	ret
 
-Func_24f00: ; 0x24f00
+DisplayMeowthMultiplierText: ; 0x24f00
 	ld a, [de]
 	sla a
 	ld c, a
@@ -1830,7 +1830,7 @@ MeowthMultiplier6Animation: ; 0x24f8e
 	db $04, MEOWTHMULTIPLIERSPRITE_6_FRAME_0
 	db $00 ; terminator
 
-Func_24fa3: ; 0x24fa3
+UpdateMeowthMultiplierAnimation: ; 0x24fa3
 	ld a, [wMeowthStageScore]
 	ld c, a
 	ld b, $0

--- a/engine/pinball_game/object_collision/mewtwo_bonus_object_collision.asm
+++ b/engine/pinball_game/object_collision/mewtwo_bonus_object_collision.asm
@@ -1,9 +1,9 @@
 CheckMewtwoBonusStageGameObjectCollisions: ; 0x19330
-	call Func_19414
-	call Func_19337
+	call CheckMewtwoBodyCollision
+	call CheckAllOrbitingBallCollisions
 	ret
 
-Func_19337: ; 0x19337
+CheckAllOrbitingBallCollisions: ; 0x19337
 	ld hl, wOrbitingBall0XPos
 	ld bc, $0601
 .asm_1933d
@@ -22,7 +22,7 @@ Func_19337: ; 0x19337
 	dec hl
 	dec hl
 	bit 0, [hl]
-	call nz, Func_1936f
+	call nz, CheckOrbitingBallCollisionAndApplyPhysics
 	pop hl
 	pop bc
 	ld a, c
@@ -42,18 +42,18 @@ Func_19337: ; 0x19337
 	ld [wd6b5], a
 	ret
 
-Func_1936f: ; 0x1936f
+CheckOrbitingBallCollisionAndApplyPhysics: ; 0x1936f
 	cp $b
-	jp z, Func_19412
+	jp z, NoOrbitingBallCollision
 	ld a, [wBallXPos + 1]
 	sub b
 	cp $20
-	jp nc, Func_19412
+	jp nc, NoOrbitingBallCollision
 	ld b, a
 	ld a, [wBallYPos + 1]
 	sub c
 	cp $20
-	jp nc, Func_19412
+	jp nc, NoOrbitingBallCollision
 	ld c, a
 	ld e, a
 	ld d, $0
@@ -148,11 +148,11 @@ Func_1936f: ; 0x1936f
 	scf
 	ret
 
-Func_19412: ; 0x19312
+NoOrbitingBallCollision: ; 0x19312
 	and a
 	ret
 
-Func_19414: ; 0x19414
+CheckMewtwoBodyCollision: ; 0x19414
 	ld a, [wTriggeredGameObject]
 	inc a
 	jr nz, .asm_1944f

--- a/engine/pinball_game/object_collision/mewtwo_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/mewtwo_bonus_resolve_collision.asm
@@ -1,6 +1,6 @@
 ResolveMewtwoBonusGameObjectCollisions: ; 0x19451
-	call Func_19531
-	call Func_19701
+	call ResolveOrbitingBallHitCollision
+	call UpdateAllOrbitingBalls
 	call TryCloseGate_MewtwoBonus
 	callba PlayLowTimeSfx
 	ld a, [wTimeRanOut]
@@ -30,10 +30,10 @@ TryCloseGate_MewtwoBonus: ; 0x1948b
 	ld [wStageCollisionState], a
 	ld [wMewtwoBonusClosedGate], a
 	callba LoadStageCollisionAttributes
-	call Func_194ac
+	call QueueGateGraphicsToLoad_MewtwoBonus
 	ret
 
-Func_194ac: ; 0x194ac
+QueueGateGraphicsToLoad_MewtwoBonus: ; 0x194ac
 	ld a, [wStageCollisionState]
 	sla a
 	ld c, a
@@ -164,7 +164,7 @@ Data_1951c: ; 0x1951c
 
 	db $00 ; terminator
 
-Func_19531: ; 0x19531
+ResolveOrbitingBallHitCollision: ; 0x19531
 	ld a, [wd6aa]
 	and a
 	jr z, .asm_195a2
@@ -194,7 +194,7 @@ Func_19531: ; 0x19531
 	jr z, .asm_19582
 	ld a, $2
 	ld de, wMewtwoAnimationIndex
-	call Func_19679
+	call InitializeMewtwoAnimationState
 	lb de, $00, $39
 	call PlaySoundEffect
 	jr .asm_195a2
@@ -202,7 +202,7 @@ Func_19531: ; 0x19531
 .asm_19582
 	ld a, $3
 	ld de, wMewtwoAnimationIndex
-	call Func_19679
+	call InitializeMewtwoAnimationState
 	ld a, $1
 	ld [wFlippersDisabled], a
 	call LoadFlippersPalette
@@ -210,12 +210,12 @@ Func_19531: ; 0x19531
 	ld de, MUSIC_NOTHING
 	call PlaySong
 .asm_195a2
-	call Func_195ac
+	call InitializeMewtwoOrbitingBalls
 	ld de, wd6af
-	call Func_195f5
+	call UpdateMewtwoAnimationFrame
 	ret
 
-Func_195ac: ; 0x195ac
+InitializeMewtwoOrbitingBalls: ; 0x195ac
 	ld a, [wd6af]
 	and a
 	ret nz
@@ -234,7 +234,7 @@ Func_195ac: ; 0x195ac
 	ret nz
 	ld a, $1
 	ld de, wMewtwoAnimationIndex
-	call Func_19679
+	call InitializeMewtwoAnimationState
 	ret
 
 .asm_195ce
@@ -243,7 +243,7 @@ Func_195ac: ; 0x195ac
 	jr nz, .asm_195b9
 	ret
 
-Func_195d3: ; 0x195d3
+CheckMewtwoOrbitingBallAtPosition: ; 0x195d3
 	ld hl, wOrbitingBall0PosIndex
 	ld de, $0008
 	ld b, $6
@@ -261,7 +261,7 @@ Func_195d3: ; 0x195d3
 	ld e, l
 	dec de
 	ld a, $1
-	call Func_19876
+	call InitializeOrbitingBallAnimationState
 	ret
 
 .asm_195f0
@@ -270,7 +270,7 @@ Func_195d3: ; 0x195d3
 	jr nz, .asm_195db
 	ret
 
-Func_195f5: ; 0x195f5
+UpdateMewtwoAnimationFrame: ; 0x195f5
 	ld a, [de]
 	sla a
 	ld c, a
@@ -290,42 +290,42 @@ Func_195f5: ; 0x195f5
 	ld a, [de]
 	rst JumpTable  ; calls JumpToFuncInTable
 CallTable_1960d: ; 0x1960d
-	dw Func_19615
-	dw Func_1961e
-	dw Func_1962f
-	dw Func_19638
+	dw HandleMewtwoAnimationState0
+	dw HandleMewtwoAnimationState1
+	dw HandleMewtwoAnimationState2
+	dw HandleMewtwoAnimationState3
 
-Func_19615: ; 0x19615
+HandleMewtwoAnimationState0: ; 0x19615
 	dec de
 	ld a, [de]
 	cp $4
 	ret nz
 	xor a
-	jp Func_19679
+	jp InitializeMewtwoAnimationState
 
-Func_1961e: ; 0x1961e
+HandleMewtwoAnimationState1: ; 0x1961e
 	dec de
 	ld a, [de]
 	cp $c
 	jr nz, .asm_19628
-	call Func_195d3
+	call CheckMewtwoOrbitingBallAtPosition
 	ret
 
 .asm_19628
 	cp $d
 	ret nz
 	xor a
-	jp Func_19679
+	jp InitializeMewtwoAnimationState
 
-Func_1962f: ; 0x1962f
+HandleMewtwoAnimationState2: ; 0x1962f
 	dec de
 	ld a, [de]
 	cp $1
 	ret nz
 	xor a
-	jp Func_19679
+	jp InitializeMewtwoAnimationState
 
-Func_19638: ; 0x19638
+HandleMewtwoAnimationState3: ; 0x19638
 	dec de
 	ld a, [de]
 	cp $1
@@ -359,7 +359,7 @@ Func_19638: ; 0x19638
 	call PlaySoundEffect
 	ret
 
-Func_19679: ; 0x19679
+InitializeMewtwoAnimationState: ; 0x19679
 	push af
 	sla a
 	ld c, a
@@ -447,7 +447,7 @@ MewtwoDefeatedAnimation: ; 0x196c0
 	db $01, MEWTWOSPRITE_INVISIBLE
 	db $00 ; terminator
 
-Func_19701: ; 0x19701
+UpdateAllOrbitingBalls: ; 0x19701
 	ld a, [wd6b4]
 	and a
 	jr z, .asm_19742
@@ -472,7 +472,7 @@ Func_19701: ; 0x19701
 	jr nz, .asm_19742
 	dec de
 	ld a, $2
-	call Func_19876
+	call InitializeOrbitingBallAnimationState
 	ld bc, OneHundredThousandPoints
 	callba AddBigBCD6FromQueue
 	lb de, $00, $38
@@ -629,39 +629,39 @@ UpdateOrbitingBallAnimation: ; 0x19833
 	ld a, [de]
 	rst JumpTable  ; calls JumpToFuncInTable
 CallTable_19852: ; 0x19852
-	dw Func_1985a
-	dw Func_19863
-	dw Func_1986c
-	dw Func_1986d
+	dw HandleOrbitingBallAnimationState0
+	dw HandleOrbitingBallAnimationState1
+	dw HandleOrbitingBallAnimationState2
+	dw HandleOrbitingBallAnimationState3
 
-Func_1985a: ; 0x1985a
+HandleOrbitingBallAnimationState0: ; 0x1985a
 	dec de
 	ld a, [de]
 	cp $6
 	ret nz
 	xor a
-	jp Func_19876
+	jp InitializeOrbitingBallAnimationState
 
-Func_19863: ; 0x19863
+HandleOrbitingBallAnimationState1: ; 0x19863
 	dec de
 	ld a, [de]
 	cp $7
 	ret nz
 	xor a
-	jp Func_19876
+	jp InitializeOrbitingBallAnimationState
 
-Func_1986c: ; 0x1986c
+HandleOrbitingBallAnimationState2: ; 0x1986c
 	ret
 
-Func_1986d: ; 0x1986d
+HandleOrbitingBallAnimationState3: ; 0x1986d
 	dec de
 	ld a, [de]
 	cp $1
 	ret nz
 	xor a
-	jp Func_19876
+	jp InitializeOrbitingBallAnimationState
 
-Func_19876: ; 0x19876
+InitializeOrbitingBallAnimationState: ; 0x19876
 	push af
 	sla a
 	ld c, a
@@ -705,7 +705,7 @@ ResetOrbitingBalls: ; 0x1988e
 	dec de
 	dec de
 	ld a, $3
-	call Func_19876
+	call InitializeOrbitingBallAnimationState
 	jr .asm_198c0
 
 .asm_198b7

--- a/engine/pinball_game/object_collision/object_collision.asm
+++ b/engine/pinball_game/object_collision/object_collision.asm
@@ -13,7 +13,7 @@ GameObjectCollisions_CallTable: ; 0x2735
 	padded_dab CheckRedStageTopGameObjectCollisions       ; STAGE_RED_FIELD_TOP
 	padded_dab CheckRedStageBottomGameObjectCollisions    ; STAGE_RED_FIELD_BOTTOM
 	padded_dab DoNothing_18061
-	padded_dab Func_18062
+	padded_dab CheckLaunchAlleyCollision_UnusedStage
 	padded_dab CheckBlueStageTopGameObjectCollisions      ; STAGE_BLUE_FIELD_TOP
 	padded_dab CheckBlueStageBottomGameObjectCollisions   ; STAGE_BLUE_FIELD_BOTTOM
 	padded_dab CheckGengarBonusStageGameObjectCollisions  ; STAGE_GENGAR_BONUS
@@ -176,7 +176,7 @@ CallTable_2822: ; 0x2822
 	padded_dab ResolveRedFieldTopGameObjectCollisions     ; STAGE_RED_FIELD_TOP
 	padded_dab ResolveRedFieldBottomGameObjectCollisions  ; STAGE_RED_FIELD_BOTTOM
 	padded_dab DoNothing_1806d
-	padded_dab Func_1806e
+	padded_dab ResolveLaunchCollision_UnusedStage
 	padded_dab ResolveBlueFieldTopGameObjectCollisions    ; STAGE_BLUE_FIELD_TOP
 	padded_dab ResolveBlueFieldBottomGameObjectCollisions ; STAGE_BLUE_FIELD_BOTTOM
 	padded_dab ResolveGengarBonusGameObjectCollisions     ; STAGE_GENGAR_BONUS

--- a/engine/pinball_game/object_collision/red_stage_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/red_stage_resolve_collision.asm
@@ -178,7 +178,7 @@ AgainTextOnTileData:
 	dw AgainTextOnTileData2
 
 AgainTextOffTileData1:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $38
 	dw AgainTextOffGfx
@@ -186,7 +186,7 @@ AgainTextOffTileData1:
 	db $00
 
 AgainTextOffTileData2:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3a
 	dw AgainTextOffGfx + $20
@@ -194,7 +194,7 @@ AgainTextOffTileData2:
 	db $00
 
 AgainTextOnTileData1:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $38
 	dw StageRedFieldBottomBaseGameBoyGfx + $380
@@ -202,7 +202,7 @@ AgainTextOnTileData1:
 	db $00
 
 AgainTextOnTileData2:
-	dw Func_11d2
+	dw LoadBankedTileData
 	db $20, $02
 	dw vTilesSH tile $3a
 	dw StageRedFieldBottomBaseGameBoyGfx + $3a0
@@ -482,7 +482,7 @@ UpdateDiglettAnimations: ; 0x14990
 	jr .asm_149b6
 
 .asm_149a2
-	call Func_1130
+	call CheckGraphicsQueueEmpty
 	ret nz
 	ld a, $14
 	ld [wLeftMapMoveDiglettAnimationCounter], a
@@ -502,7 +502,7 @@ UpdateDiglettAnimations: ; 0x14990
 	ret
 
 .asm_149c6
-	call Func_1130
+	call CheckGraphicsQueueEmpty
 	ret nz
 	ld a, $14
 	ld [wRightMapMoveDiglettAnimationCounter], a
@@ -693,7 +693,7 @@ UpdateRedStageSpinner: ; 0x14e10
 	cp MAX_PIKACHU_SAVER_CHARGE
 	jr nz, .asm_14e9d
 	ld a, $64
-	ld [wd51e], a
+	ld [wSpinnerChargeSoundCooldown], a
 .asm_14e9d
 	ld a, [wCurrentStage]
 	bit 0, a
@@ -702,7 +702,7 @@ UpdateRedStageSpinner: ; 0x14e10
 	ret
 
 PlaySpinnerChargingSoundEffect_RedField: ; 0x14ea7
-	ld a, [wd51e]
+	ld a, [wSpinnerChargeSoundCooldown]
 	and a
 	ret nz
 	ld a, [wPikachuSaverCharge]
@@ -1006,7 +1006,7 @@ ResolveBallUpgradeTriggersCollision_RedField: ; 0x1535d
 	call EnableBottomText
 	ld hl, wScrollingText2
 	ld de, DigitsText1to8
-	call Func_32cc
+	call LoadScrollingScoreText
 	pop de
 	pop bc
 	ld hl, wScrollingText1
@@ -1469,7 +1469,7 @@ UpdateFieldStructures_RedField: ; 0x159c9
 	callba LoadStageCollisionAttributes
 	call LoadFieldStructureGraphics_RedField
 	ld a, $1
-	ld [wd580], a
+	ld [wTimerGraphicsNeedsLoading], a
 	call LoadTimerGraphics
 	ret
 
@@ -2317,7 +2317,7 @@ ResolveRedStagePikachuCollision: ; 0x1660c
 	jr z, .asm_1667b
 	xor a
 	ld [wWhichPikachu], a
-	ld a, [wd51c]
+	ld a, [wPikachuSaverAnimationState]
 	and a
 	jr nz, .asm_1667b
 	ld a, [wPikachuSaverSlotRewardActive]
@@ -2342,7 +2342,7 @@ ResolveRedStagePikachuCollision: ; 0x1660c
 	ld [wPikachuSaverCharge], a
 .asm_16647
 	ld a, $1
-	ld [wd51c], a
+	ld [wPikachuSaverAnimationState], a
 	xor a
 	ld [wBallXVelocity], a
 	ld [wBallXVelocity + 1], a
@@ -2359,22 +2359,22 @@ ResolveRedStagePikachuCollision: ; 0x1660c
 	ld de, wPikachuSaverAnimation
 	call InitAnimation
 	ld a, $2
-	ld [wd51c], a
+	ld [wPikachuSaverAnimationState], a
 	lb de, $00, $3b
 	call PlaySoundEffect
 .asm_1667b
-	ld a, [wd51c]
+	ld a, [wPikachuSaverAnimationState]
 	and a
 	call z, SetPikachuSaverSide_RedField
 	call UpdatePikachuSaverAnimation_RedField
 	ld a, [wPikachuSaverCharge]
 	cp MAX_PIKACHU_SAVER_CHARGE
 	ret nz
-	ld a, [wd51e]
+	ld a, [wSpinnerChargeSoundCooldown]
 	and a
 	ret z
 	dec a
-	ld [wd51e], a
+	ld [wSpinnerChargeSoundCooldown], a
 	cp $5a
 	ret nz
 	lb de, $0f, $22
@@ -2382,7 +2382,7 @@ ResolveRedStagePikachuCollision: ; 0x1660c
 	ret
 
 UpdatePikachuSaverAnimation_RedField: ; 0x1669e
-	ld a, [wd51c]
+	ld a, [wPikachuSaverAnimationState]
 	cp $1
 	jr nz, .asm_16719
 	ld hl, PikachuSaverAnimationData_RedField
@@ -2394,7 +2394,7 @@ UpdatePikachuSaverAnimation_RedField: ; 0x1669e
 	jr nz, .asm_166f7
 	xor a
 	ld [wAudioEngineEnabled], a
-	call Func_310a
+	call ClearBottomMessageBufferRows
 	rst AdvanceFrame
 	ld a, $1
 	callba PlayPikachuSoundClip
@@ -2426,7 +2426,7 @@ UpdatePikachuSaverAnimation_RedField: ; 0x1669e
 	ld bc, FiveThousandPoints
 	callba AddBigBCD6FromQueueWithBallMultiplier
 	xor a
-	ld [wd51c], a
+	ld [wPikachuSaverAnimationState], a
 	ret
 
 .asm_16719
@@ -2440,7 +2440,7 @@ UpdatePikachuSaverAnimation_RedField: ; 0x1669e
 	cp $1
 	ret nz
 	xor a
-	ld [wd51c], a
+	ld [wPikachuSaverAnimationState], a
 	ret
 
 .asm_16732
@@ -2501,35 +2501,35 @@ ResolveStaryuCollision_Top: ; 0x16781
 	jr z, .asm_167bd
 	xor a
 	ld [wStaryuCollision], a
-	ld a, [wd503]
+	ld a, [wStaryuAnimationTimer]
 	and a
 	jr nz, .asm_167c2
 	ld bc, FiveThousandPoints
 	callba AddBigBCD6FromQueueWithBallMultiplier
-	ld a, [wd502]
+	ld a, [wStaryuState]
 	xor $1
 	set 1, a
-	ld [wd502], a
+	ld [wStaryuState], a
 	ld a, $14
-	ld [wd503], a
+	ld [wStaryuAnimationTimer], a
 	call LoadStaryuGraphics_Top
 	ld a, SPECIAL_COLLISION_STARYU
 	callba CheckSpecialModeColision
 	ret
 
 .asm_167bd
-	ld a, [wd503]
+	ld a, [wStaryuAnimationTimer]
 	and a
 	ret z
 .asm_167c2
 	dec a
-	ld [wd503], a
+	ld [wStaryuAnimationTimer], a
 	ret nz
-	ld a, [wd502]
+	ld a, [wStaryuState]
 	res 1, a
-	ld [wd502], a
+	ld [wStaryuState], a
 	call LoadStaryuGraphics_Top
-	ld a, [wd502]
+	ld a, [wStaryuState]
 	and $1
 	ld c, a
 	ld a, [wStageCollisionState]
@@ -2551,30 +2551,30 @@ ResolveStaryuCollision_Bottom: ; 0x167ff
 	jr z, .noCollision
 	xor a
 	ld [wStaryuCollision], a
-	ld a, [wd503]
+	ld a, [wStaryuAnimationTimer]
 	and a
 	jr nz, .asm_1683e
 	ld bc, FiveThousandPoints
 	callba AddBigBCD6FromQueueWithBallMultiplier
-	ld a, [wd502]
+	ld a, [wStaryuState]
 	xor $1
-	ld [wd502], a
+	ld [wStaryuState], a
 	ld a, $14
-	ld [wd503], a
+	ld [wStaryuAnimationTimer], a
 	call LoadStaryuGraphics_Bottom
 	ld a, SPECIAL_COLLISION_STARYU
 	callba CheckSpecialModeColision
 	ret
 
 .noCollision
-	ld a, [wd503]
+	ld a, [wStaryuAnimationTimer]
 	and a
 	ret z
 .asm_1683e
 	dec a
-	ld [wd503], a
+	ld [wStaryuAnimationTimer], a
 	ret nz
-	ld a, [wd502]
+	ld a, [wStaryuState]
 	and $1
 	ld c, a
 	ld a, [wStageCollisionState]
@@ -2586,7 +2586,7 @@ ResolveStaryuCollision_Bottom: ; 0x167ff
 	ret
 
 LoadStaryuGraphics_Top: ; 0x16859
-	ld a, [wd502]
+	ld a, [wStaryuState]
 	sla a
 	ld c, a
 	ld b, $0
@@ -2607,7 +2607,7 @@ LoadStaryuGraphics_Top: ; 0x16859
 	ret
 
 LoadStaryuGraphics_Bottom: ; 0x16878
-	ld a, [wd502]
+	ld a, [wStaryuState]
 	and $1
 	sla a
 	ld c, a

--- a/engine/pinball_game/object_collision/seel_bonus_resolve_collision.asm
+++ b/engine/pinball_game/object_collision/seel_bonus_resolve_collision.asm
@@ -1,5 +1,5 @@
 ResolveSeelBonusGameObjectCollisions: ; 0x25c5a
-	call Func_25da3
+	call ResolveSeelHitCollision
 	call TryCloseGate_SeelBonus
 	ld a, [wSeelStageScore]
 	cp 20
@@ -68,10 +68,10 @@ TryCloseGate_SeelBonus: ; 0x25ced
 	ld [wStageCollisionState], a
 	ld [wSeelBonusClosedGate], a
 	callba LoadStageCollisionAttributes
-	call Func_25d0e
+	call QueueGateGraphicsToLoad_SeelBonus
 	ret
 
-Func_25d0e: ; 0x25d0e
+QueueGateGraphicsToLoad_SeelBonus: ; 0x25d0e
 	ld a, [wStageCollisionState]
 	sla a
 	ld c, a
@@ -202,7 +202,7 @@ TileData_25d8a: ; 0x25d8a
 
 	db $00 ; terminator
 
-Func_25da3: ; 0x25da3
+ResolveSeelHitCollision: ; 0x25da3
 	ld a, [wd767]
 	and a
 	jp z, .asm_25e38
@@ -251,7 +251,7 @@ Func_25da3: ; 0x25da3
 	jr z, .asm_25e04
 	ld [wd79a], a
 	ld de, wd79a
-	call Func_261f9
+	call DisplaySeelMultiplierAnimation
 	jr .asm_25e07
 
 .asm_25e04
@@ -263,7 +263,7 @@ Func_25da3: ; 0x25da3
 	ld [wRumbleDuration], a
 	lb de, $00, $30
 	call PlaySoundEffect
-	call Func_25e85
+	call CalculateSeelStreakBonus
 	ld hl, wSeelStageStreak
 	inc [hl]
 	ld a, [wSeelStageScore]
@@ -279,7 +279,7 @@ Func_25da3: ; 0x25da3
 	ld [hl], a
 	ld a, $1
 	ld [wd64e], a
-	call Func_262f4
+	call UpdateSeelStageScoreDisplay
 .asm_25e38
 	ld de, wd76c
 	call UpdateSeelAnimation
@@ -293,7 +293,7 @@ Func_25da3: ; 0x25da3
 	jr z, .asm_25e5d
 	ld [wd79a], a
 	ld de, wd79a
-	call Func_26212
+	call UpdateSeelMultiplierAnimationFrame
 	jr .asm_25e60
 
 .asm_25e5d
@@ -313,7 +313,7 @@ Func_25da3: ; 0x25da3
 	call UpdateSeelPosition
 	ret
 
-Func_25e85: ; 0x25e85
+CalculateSeelStreakBonus: ; 0x25e85
 	ld a, [wSeelStageStreak]
 	inc a
 	ld d, $1
@@ -456,20 +456,20 @@ UpdateSeelAnimation: ; 0x25f47
 	ld a, [de]
 	rst JumpTable  ; calls JumpToFuncInTable
 CallTable_25f5f: ; 0x25f5f
-	dw Func_25f77
-	dw Func_25fbe
-	dw Func_25ff3
-	dw Func_2602a
-	dw Func_2604c
-	dw Func_2607f
-	dw Func_260b6
-	dw Func_260d8
-	dw Func_260e2
-	dw Func_260ec
-	dw Func_26109
-	dw Func_26120
+	dw HandleSeelAnimationState1Collision
+	dw HandleSeelAnimationState4Collision
+	dw HandleSeelAnimationState7Emerge
+	dw HandleSeelAnimationState9Hit
+	dw HandleSeelAnimationState4BottomCoin
+	dw HandleSeelAnimationState7EmergeBottom
+	dw HandleSeelAnimationState9HitBottom
+	dw HandleSeelAnimationState5Check
+	dw HandleSeelAnimationState5Alternate
+	dw HandleSeelAnimationState1Direction
+	dw HandleSeelAnimationState7ToState5
+	dw HandleSeelAnimationState7ToState5Alt
 
-Func_25f77: ; 0x25f77
+HandleSeelAnimationState1Collision: ; 0x25f77
 	dec de
 	ld a, [de]
 	cp $2
@@ -488,7 +488,7 @@ Func_25f77: ; 0x25f77
 	jr z, .asm_25f8f
 	pop de
 	xor a
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
 .asm_25f8f
 	ld hl, wSeelStageStreak
@@ -523,9 +523,9 @@ Func_25f77: ; 0x25f77
 	call PlaySoundEffect
 	pop af
 	pop de
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
-Func_25fbe: ; 0x25fbe
+HandleSeelAnimationState4Collision: ; 0x25fbe
 	dec de
 	ld a, [de]
 	cp $4
@@ -543,7 +543,7 @@ Func_25fbe: ; 0x25fbe
 	jr z, .asm_25fd5
 	pop de
 	ld a, $1
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
 .asm_25fd5
 	ld a, [wd791]
@@ -555,7 +555,7 @@ Func_25fbe: ; 0x25fbe
 	ld a, $4
 	ld [de], a
 	ld a, $1
-	jp Func_26137
+	jp InitializeSeelAnimationState
 	ret ; unused instruction
 
 .asm_25fe9
@@ -563,15 +563,15 @@ Func_25fbe: ; 0x25fbe
 	inc [hl]
 	pop de
 	ld a, $2
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
-Func_25ff3: ; 0x25ff3
+HandleSeelAnimationState7Emerge: ; 0x25ff3
 	dec de
 	ld a, [de]
 	cp $7
 	ret nz
 	xor a
-	call Func_26137
+	call InitializeSeelAnimationState
 	inc de
 	inc de
 	inc de
@@ -602,13 +602,13 @@ Func_25ff3: ; 0x25ff3
 	call PlaySoundEffect
 	ret
 
-Func_2602a: ; 0x2602a
+HandleSeelAnimationState9Hit: ; 0x2602a
 	dec de
 	ld a, [de]
 	cp $9
 	ret nz
 	ld a, $1
-	call Func_26137
+	call InitializeSeelAnimationState
 	inc de
 	inc de
 	inc de
@@ -628,7 +628,7 @@ Func_2602a: ; 0x2602a
 	dec [hl]
 	ret
 
-Func_2604c: ; 0x2604c
+HandleSeelAnimationState4BottomCoin: ; 0x2604c
 	dec de
 	ld a, [de]
 	cp $4
@@ -646,7 +646,7 @@ Func_2604c: ; 0x2604c
 	jr z, .asm_26063
 	pop de
 	ld a, $4
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
 .asm_26063
 	ld a, [wd791]
@@ -657,7 +657,7 @@ Func_2604c: ; 0x2604c
 	pop de
 	ld a, $4
 	ld [de], a
-	jp Func_26137
+	jp InitializeSeelAnimationState
 	ret ; unused instruction
 
 .asm_26075
@@ -665,15 +665,15 @@ Func_2604c: ; 0x2604c
 	inc [hl]
 	pop de
 	ld a, $5
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
-Func_2607f: ; 0x2607f
+HandleSeelAnimationState7EmergeBottom: ; 0x2607f
 	dec de
 	ld a, [de]
 	cp $7
 	ret nz
 	xor a
-	call Func_26137
+	call InitializeSeelAnimationState
 	inc de
 	inc de
 	inc de
@@ -704,13 +704,13 @@ Func_2607f: ; 0x2607f
 	call PlaySoundEffect
 	ret
 
-Func_260b6: ; 0x260b6
+HandleSeelAnimationState9HitBottom: ; 0x260b6
 	dec de
 	ld a, [de]
 	cp $9
 	ret nz
 	ld a, $4
-	call Func_26137
+	call InitializeSeelAnimationState
 	inc de
 	inc de
 	inc de
@@ -730,23 +730,23 @@ Func_260b6: ; 0x260b6
 	dec [hl]
 	ret
 
-Func_260d8: ; 0x260d8
+HandleSeelAnimationState5Check: ; 0x260d8
 	dec de
 	ld a, [de]
 	cp $5
 	ret nz
 	ld a, $4
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
-Func_260e2: ; 0x260e2
+HandleSeelAnimationState5Alternate: ; 0x260e2
 	dec de
 	ld a, [de]
 	cp $5
 	ret nz
 	ld a, $1
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
-Func_260ec: ; 0x260ec
+HandleSeelAnimationState1Direction: ; 0x260ec
 	dec de
 	ld a, [de]
 	cp $1
@@ -764,20 +764,20 @@ Func_260ec: ; 0x260ec
 	jr z, .asm_26103
 	pop de
 	ld a, $b
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
 .asm_26103
 	pop de
 	ld a, $a
-	jp Func_26137
+	jp InitializeSeelAnimationState
 
-Func_26109: ; 0x26109
+HandleSeelAnimationState7ToState5: ; 0x26109
 	dec de
 	ld a, [de]
 	cp $7
 	ret nz
 	ld a, $1
-	call Func_26137
+	call InitializeSeelAnimationState
 	inc de
 	inc de
 	inc de
@@ -789,13 +789,13 @@ Func_26109: ; 0x26109
 	dec [hl]
 	ret
 
-Func_26120: ; 0x26120
+HandleSeelAnimationState7ToState5Alt: ; 0x26120
 	dec de
 	ld a, [de]
 	cp $7
 	ret nz
 	ld a, $4
-	call Func_26137
+	call InitializeSeelAnimationState
 	inc de
 	inc de
 	inc de
@@ -807,7 +807,7 @@ Func_26120: ; 0x26120
 	dec [hl]
 	ret
 
-Func_26137: ; 0x26137
+InitializeSeelAnimationState: ; 0x26137
 	push af
 	sla a
 	ld c, a
@@ -944,7 +944,7 @@ SeelSubmergeAfterHitLeftAnimation:
 	db $04, SEELSPRITE_TURN_RIGHT_TO_LEFT_3
 	db $00 ; terminator
 
-Func_261f9: ; 0x261f9
+DisplaySeelMultiplierAnimation: ; 0x261f9
 	ld a, $ff
 	ld [wd795], a
 	ld a, [de]
@@ -962,7 +962,7 @@ Func_261f9: ; 0x261f9
 	call InitAnimation
 	ret
 
-Func_26212: ; 0x26212
+UpdateSeelMultiplierAnimationFrame: ; 0x26212
 	ld a, [de]
 	sla a
 	ld c, a
@@ -1106,7 +1106,7 @@ SeelMultiplierAnimation256:
 	db $04, SEELMULTIPLIERSPRITE_256_FRAME_0
 	db $00 ; terminator
 
-Func_262f4: ; 0x262f4
+UpdateSeelStageScoreDisplay: ; 0x262f4
 	ld a, [wSeelStageScore]
 	ld c, a
 	ld b, $0

--- a/engine/pinball_game/score.asm
+++ b/engine/pinball_game/score.asm
@@ -1,4 +1,4 @@
-Func_8524: ; 0x8524
+DrawScoreDigits: ; 0x8524
 	ld hl, wScore + $5
 	lb bc, $0c, $01
 .loop
@@ -47,7 +47,7 @@ Func_8524: ; 0x8524
 	res 7, e
 	ret
 
-Func_8569:
+ClearAddScoreQueue:
 	xor a
 	ld hl, wAddScoreQueue
 	ld b, $31
@@ -107,18 +107,18 @@ ENDR
 	ld [wAddScoreQueueOffset], a
 	ret
 
-Func_85c7: ; 0x85c7
+ProcessScoreQueue: ; 0x85c7
 	ldh a, [hFrameCounter]
 	and $3
 	ret nz
-	ld a, [wd478]
+	ld a, [wScoreQueueReadOffset]
 	ld l, a
 	ld h, wAddScoreQueue / $100
 	ld de, wScore
 	ld a, [wAddScoreQueueOffset]
 	cp l
 	jr nz, .asm_85de
-	ld [wd479], a
+	ld [wScoreQueueSyncOffset], a
 .asm_85de
 	push hl
 	ld a, [hli]
@@ -133,8 +133,8 @@ Func_85c7: ; 0x85c7
 	or [hl]
 	pop hl
 	jr nz, .value_is_nonzero
-	ld a, [wd479]
-	ld [wd478], a
+	ld a, [wScoreQueueSyncOffset]
+	ld [wScoreQueueReadOffset], a
 	ret
 
 .value_is_nonzero
@@ -187,9 +187,9 @@ Func_85c7: ; 0x85c7
 	ld l, $0
 .asm_862d
 	ld a, l
-	ld [wd478], a
+	ld [wScoreQueueReadOffset], a
 	ld a, $1
-	ld [wd49f], a
+	ld [wScoreChanged], a
 	ret
 
 SetMaxScore: ; 0x8637
@@ -205,11 +205,11 @@ SetMaxScore: ; 0x8637
 	pop hl
 	ret
 
-Func_8645: ; 0x8645
+DrawScoreToBottomBar: ; 0x8645
 	xor a
-	ld [wd49f], a
+	ld [wScoreChanged], a
 	ld de, wBottomMessageBuffer + $47
-	call Func_8524
+	call DrawScoreDigits
 	ret
 
 HideScoreIfBallLow: ; 0x8650

--- a/engine/pinball_game/slot.asm
+++ b/engine/pinball_game/slot.asm
@@ -125,7 +125,7 @@ DoSlotRewardRoulette: ; 0xed8e
 	ldh a, [hGameBoyColorFlag]
 	and a
 	ld a, [wSlotRouletteBillboardPicture]
-	call nz, Func_f2a0
+	call nz, LoadBillboardBGPalette
 	ld b, $80
 .displayAnimatedRewardLoop
 	push bc
@@ -251,7 +251,7 @@ SlotRewardPikachuSaver: ; 0xef83
 	ld [wPikachuSaverCharge], a
 	xor a
 	ld [wAudioEngineEnabled], a
-	call Func_310a
+	call ClearBottomMessageBufferRows
 	rst AdvanceFrame
 	ld a, $0
 	callba PlayPikachuSoundClip
@@ -392,7 +392,7 @@ SlotRewardUpgradeBall: ; 0xf040
 	call EnableBottomText
 	ld hl, wScrollingText2
 	ld de, DigitsText1to8
-	call Func_32cc
+	call LoadScrollingScoreText
 	pop de
 	pop bc
 	ld hl, wScrollingText1
@@ -464,10 +464,10 @@ SlotBonusMultiplier: ; 0xf0c1
 	callba nz, AddExtraBall
 	callba GetBCDForNextBonusMultiplier_RedField
 	ld a, [wBonusMultiplierTensDigit]
-	callba Func_f154 ; no need for BankSwitch here...
+	callba LoadBonusMultiplierRailingGraphics ; no need for BankSwitch here...
 	ld a, [wBonusMultiplierOnesDigit]
 	add $14
-	callba Func_f154 ; no need for BankSwitch here...
+	callba LoadBonusMultiplierRailingGraphics ; no need for BankSwitch here...
 	ret
 
 .DivideBy25: ; 0xf14a
@@ -479,7 +479,7 @@ SlotBonusMultiplier: ; 0xf0c1
 	inc c
 	jr .div_25
 
-Func_f154: ; 0xf154
+LoadBonusMultiplierRailingGraphics: ; 0xf154
 	ld a, [wCurrentStage]
 	call CallInFollowingTable
 CallTable_f15a: ; 0xf15a
@@ -497,7 +497,7 @@ SlotRewardGoToBonusStage: ; 0xf172
 
 INCLUDE "engine/pinball_game/billboard.asm"
 
-Func_f2a0: ; 0xf2a0
+LoadBillboardBGPalette: ; 0xf2a0
 	push hl
 	ld c, a
 	ld b, $0
@@ -515,7 +515,7 @@ Func_f2a0: ; 0xf2a0
 	ld l, c
 	ld de, $0030
 	ld bc, $0010
-	call Func_7dc
+	call CopyCGBPalettesWithHBlankSync
 	pop hl
 	ret
 

--- a/engine/pinball_game/stage_init/init_gengar_bonus.asm
+++ b/engine/pinball_game/stage_init/init_gengar_bonus.asm
@@ -3,7 +3,7 @@ InitGengarBonusStage: ; 0x18099
 	and a
 	jr z, .asm_180ac
 	xor a
-	ld [wd674], a
+	ld [wGengarPhaseTimer], a
 	ld a, $8
 	ld [wd690], a
 	ld [wd6a1], a

--- a/engine/pinball_game/stage_init/init_stages.asm
+++ b/engine/pinball_game/stage_init/init_stages.asm
@@ -27,8 +27,8 @@ InitializeCurrentStage: ; 0x8311
 CallTable_8348: ; 0x8348
 	padded_dab InitRedField          ; STAGE_RED_FIELD_TOP
 	padded_dab InitRedField          ; STAGE_RED_FIELD_BOTTOM
-	padded_dab Func_18000
-	padded_dab Func_18000
+	padded_dab InitializeUnusedStage
+	padded_dab InitializeUnusedStage
 	padded_dab InitBlueField         ; STAGE_BLUE_FIELD_TOP
 	padded_dab InitBlueField         ; STAGE_BLUE_FIELD_BOTTOM
 	padded_dab InitGengarBonusStage  ; STAGE_GENGAR_BONUS

--- a/engine/pinball_game/stage_init/init_unused_stage.asm
+++ b/engine/pinball_game/stage_init/init_unused_stage.asm
@@ -1,4 +1,4 @@
-Func_18000: ; 0x18000
+InitializeUnusedStage: ; 0x18000
 ; unused -- Stage init function for unused stage.
 	ld hl, wc000
 	ld bc, $0a00

--- a/engine/pinball_game/timer.asm
+++ b/engine/pinball_game/timer.asm
@@ -14,7 +14,7 @@ StartTimer: ; 0x867d
 	ld a, $1
 	ld [wTimerActive], a
 	ld a, $1
-	ld [wd580], a
+	ld [wTimerGraphicsNeedsLoading], a
 	callba LoadTimerGraphics
 	ret
 

--- a/engine/pinball_game/vertical_screen_transition.asm
+++ b/engine/pinball_game/vertical_screen_transition.asm
@@ -19,7 +19,7 @@ FieldVerticalTransition: ; 0xe674
 	call ToggleAudioEngineUpdateMethod
 	call DisableLCD
 	call ClearSpriteBuffer
-	call Func_1129
+	call SnapshotGraphicsQueuePosition
 	call LoadStageCollisionAttributes
 	call LoadStageData
 	call ToggleAudioEngineUpdateMethod

--- a/engine/pokedex.asm
+++ b/engine/pokedex.asm
@@ -1721,7 +1721,7 @@ DrawSummaryWindowMonImage: ; 0x28add
 	call ReadByteFromBank
 	ld bc, $10b0
 	ld hl, rBGPI
-	call Func_8e1
+	call LoadTileDataWithBankSwitch
 	ret
 
 LoadUncaughtPokemonBackgroundGfx: ; 0x28b76
@@ -1879,17 +1879,17 @@ PlayMonPokedexCatchAnimation: ; 0x28bf5
 	push de
 	ld bc, $10b0
 	ld hl, rBGPI
-	call Func_8e1
+	call LoadTileDataWithBankSwitch
 	pop de
 	pop af
 	push af
 	ld bc, $08d8
 	ld hl, rOBPI
-	call Func_8e1
+	call LoadTileDataWithBankSwitch
 	pop af
 	ld bc, $08e8
 	ld hl, rOBPI
-	call Func_8e1
+	call LoadTileDataWithBankSwitch
 	ret
 
 CheckIfMonHasAnimation: ; 0x28cc2
@@ -2086,7 +2086,7 @@ LoadPokemonDescriptionVWFCharacterTiles: ; 0x28d97
 	ldh [hVariableWidthFontFF92], a
 	cp $ff
 	jr nz, .asm_28dbb
-	call Func_208c
+	call LoadDexVWFCharacterSpecial
 	jr .asm_28dc8
 
 .asm_28dbb

--- a/engine/select_gameboy_target_menu.asm
+++ b/engine/select_gameboy_target_menu.asm
@@ -13,7 +13,7 @@ SelectGameboyTargetMenuFunctions: ; 0x8004
 
 InitSelectGameboyTargetMenu: ; 0x800a
 	xor a
-	ldh [hFFC4], a
+	ldh [hDMGPaletteUpdateNeeded], a
 	ldh a, [hJoypadState]
 	cp D_UP
 	jr nz, .skipDebugMenu
@@ -170,7 +170,7 @@ SelectCGBOrDMG: ; 0x8104
 	and (D_DOWN | D_UP)
 	jr z, .directionNotPressed
 	ldh a, [hGameBoyColorFlag]
-	ldh [hFFC4], a
+	ldh [hDMGPaletteUpdateNeeded], a
 	xor $1
 	ldh [hGameBoyColorFlag], a
 	jr .moveCursor

--- a/engine/titlescreen.asm
+++ b/engine/titlescreen.asm
@@ -4,8 +4,8 @@ HandleTitlescreen: ; 0xc000
 TitlescreenFunctions: ; 0xc004
 	dw FadeInTitlescreen
 	dw TitlescreenLoop ; titlescreen loop
-	dw Func_c10e ; previously saved game menu
-	dw Func_c1cb ; game start, pokedex, option
+	dw HandleContinuePromptScreen ; previously saved game menu
+	dw GoToSelectedMenuScreen ; game start, pokedex, option
 	dw GoToHighScoresFromTitlescreen ; go to high scores
 
 FadeInTitlescreen: ; 0xc00e
@@ -57,7 +57,7 @@ TitlescreenFadeInGfx_GameBoyColor: ; 0xc06b
 	db $FF, $FF ; terminators
 
 TitlescreenLoop: ; 0xc089
-	call Func_c0ee
+	call HandleTitlescreenCursorInput
 	call HandleTitlescreenAnimations
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_A_BUTTON, a  ; was A button pressed?
@@ -109,10 +109,10 @@ TitlescreenLoop: ; 0xc089
 	ld [wScreenState], a
 	ret
 
-Func_c0ee: ; 0xc0ee
+HandleTitlescreenCursorInput: ; 0xc0ee
 	ld hl, wTitleScreenCursorSelection
 	ld c, $2
-	call Func_c1fc
+	call HandleMenuCursorUpDown
 	ret
 
 HandleTitlescreenAnimations: ; 0xc0f7
@@ -123,14 +123,14 @@ HandleTitlescreenAnimations: ; 0xc0f7
 	ld a, SPRITE_TITLESCREEN_BLANK  ; seemingly-unused sprite data for titlescreen. It's just blank tiles.
 	call LoadSpriteData
 .asm_c104
-	call Func_c21d  ; does nothing...
+	call DoNothing_Titlescreen  ; does nothing...
 	call HandleTitlescreenPikachuBlinkingAnimation
 	call HandleTitlescreenPokeballAnimation
 	ret
 
-Func_c10e: ; 0xc10e
-	call Func_c1a2
-	call Func_c1b1
+HandleContinuePromptScreen: ; 0xc10e
+	call HandleContinuePromptCursorInput
+	call UpdateContinuePromptAnimations
 	ld a, [wTitlescreenContinuePromptAnimationFrame]
 	cp $6
 	ret nz
@@ -191,7 +191,7 @@ Func_c10e: ; 0xc10e
 .asm_c18f
 	call CleanSpriteBuffer
 	rst AdvanceFrame
-	call Func_c1b1
+	call UpdateContinuePromptAnimations
 	ld a, [wTitlescreenContinuePromptAnimationFrame]
 	cp $e
 	jr nz, .asm_c18f
@@ -199,16 +199,16 @@ Func_c10e: ; 0xc10e
 	dec [hl]
 	ret
 
-Func_c1a2: ; 0xc1a2
+HandleContinuePromptCursorInput: ; 0xc1a2
 	ld a, [wTitlescreenContinuePromptAnimationFrame]
 	cp $6
 	ret nz
 	ld hl, wTitleScreenGameStartCursorSelection
 	ld c, $1
-	call Func_c1fc
+	call HandleMenuCursorUpDown
 	ret
 
-Func_c1b1: ; 0xc1b1
+UpdateContinuePromptAnimations: ; 0xc1b1
 	call HandleTitleScreenContinuePromptAnimation
 	ldh a, [hGameBoyColorFlag]
 	and a
@@ -217,12 +217,12 @@ Func_c1b1: ; 0xc1b1
 	ld a, SPRITE_TITLESCREEN_BLANK
 	call LoadSpriteData
 .asm_c1c1
-	call Func_c21d
+	call DoNothing_Titlescreen
 	call HandleTitlescreenPikachuBlinkingAnimation
 	call HandleTitlescreenPokeballAnimation
 	ret
 
-Func_c1cb: ; 0c1cb
+GoToSelectedMenuScreen: ; 0c1cb
 	call FadeOut
 	call DisableLCD
 	ld a, [wTitleScreenCursorSelection]
@@ -252,7 +252,7 @@ GoToHighScoresFromTitlescreen: ; 0xc1e7
 	ld [wHighScoreIsEnteringName], a
 	ret
 
-Func_c1fc: ; 0xc1fc
+HandleMenuCursorUpDown: ; 0xc1fc
 	ldh a, [hPressedButtons]
 	ld b, a
 	ld a, [hl]
@@ -277,7 +277,7 @@ Func_c1fc: ; 0xc1fc
 	call PlaySoundEffect
 	ret
 
-Func_c21d: ; 0xc21d
+DoNothing_Titlescreen: ; 0xc21d
 ; World's greatest function.
 	ret
 

--- a/home.asm
+++ b/home.asm
@@ -101,12 +101,12 @@ Start: ; 0x150
 	call WriteDMACodeToHRAM
 	call ClearSpriteBuffer
 	xor a
-	ld [wd7fb], a
-	ld [wd7fc], a
-	ld [wd7fd], a
+	ld [wGraphicsQueueWriteIndex], a
+	ld [wGraphicsQueueReadIndex], a
+	ld [wGraphicsQueueOverflow], a
 	ldh [hStatIntrRoutine], a
-	ldh [hFFB1], a
-	ld [wd8e1], a
+	ldh [hSerialInterruptMode], a
+	ld [wSerialCommunicationEnabled], a
 	ld [wd7fe], a
 	ldh [hSGBInit], a
 	ld hl, hLCDC
@@ -128,7 +128,7 @@ Start: ; 0x150
 	ld [wToggleAudioEngineUpdateMethod], a
 	ld a, Bank(PlaySong_BankF)
 	call SetSongBank
-	call Func_23b
+	call DetectGameBoyColor
 	ldh a, [hGameBoyColorFlag]
 	and a
 	jr nz, .asm_222
@@ -141,7 +141,7 @@ Start: ; 0x150
 	and a
 	jr z, .asm_222
 	ld a, $1
-	ld [wd917], a
+	ld [wDisableRumble], a
 .asm_222
 	ld a, $1
 	ldh [rIE], a  ; Only enable LCD Status interrupt
@@ -154,7 +154,7 @@ Start: ; 0x150
 	ld a, BANK(Main)
 	ld hl, Main
 	call BankSwitchSimple
-Func_23b: ; 0x23b
+DetectGameBoyColor: ; 0x23b
 	ldh a, [hGameBoyColorFlag]
 	cp $11
 	jr nz, .asm_248
@@ -200,12 +200,12 @@ SoftReset:
 	call WriteDMACodeToHRAM
 	call ClearSpriteBuffer
 	xor a
-	ld [wd7fb], a
-	ld [wd7fc], a
-	ld [wd7fd], a
+	ld [wGraphicsQueueWriteIndex], a
+	ld [wGraphicsQueueReadIndex], a
+	ld [wGraphicsQueueOverflow], a
 	ldh [hStatIntrRoutine], a
-	ldh [hFFB1], a
-	ld [wd8e1], a
+	ldh [hSerialInterruptMode], a
+	ld [wSerialCommunicationEnabled], a
 	ld [wd7fe], a
 	ld hl, hLCDC
 	xor a
@@ -230,7 +230,7 @@ SoftReset:
 	and a
 	jr z, .asm_02d5
 	ld a, $1
-	ld [wd917], a
+	ld [wDisableRumble], a
 .asm_02d5
 	ld a, $1
 	ldh [rIE], a
@@ -255,7 +255,7 @@ VBlank: ; 0x2f2
 	call hPushSprite ; sprite DMA transfer
 	ldh a, [hLCDC]
 	ldh [rLCDC], a
-	call Func_113a
+	call ProcessQueuedGraphics
 	ei
 	ldh a, [rLY]
 	cp $90
@@ -326,9 +326,9 @@ VBlank: ; 0x2f2
 .asm_365
 	ld hl, hVBlankCount
 	inc [hl]
-	ld a, [wd8e1]
+	ld a, [wSerialCommunicationEnabled]
 	and a
-	call nz, Func_167b
+	call nz, PollSerialCommunication
 	ld a, [wUpdateAudioEngineUsingTimerInterrupt]
 	and a
 	jr nz, .skipAudioEngineUpdate
@@ -354,7 +354,7 @@ VBlank: ; 0x2f2
 	ldh [rTAC], a ; Timer interrupt will fire ~60 times per second
 .skipTimerToggle
 	ld hl, MBC5SRamBank
-	ld a, [wd917]
+	ld a, [wDisableRumble]
 	and a
 	jr nz, .asm_3b5
 	ld a, [wRumblePattern]
@@ -472,7 +472,7 @@ Serial: ; 0x445
 	push hl
 	ld hl, Data_45d
 	push hl
-	ldh a, [hFFB1]
+	ldh a, [hSerialInterruptMode]
 	sla a
 	ld c, a
 	ld b, $0
@@ -608,7 +608,7 @@ DisableLCD: ; 0x576
 	ret
 
 EnableLCD: ; 0x588
-	ldh a, [hFFC4]
+	ldh a, [hDMGPaletteUpdateNeeded]
 	and a
 	call nz, .UpdatePals
 	ldh a, [hLCDC]
@@ -1229,7 +1229,7 @@ QueueGraphicsToLoadWithFunc: ; 0x10c5
 	jr nc, .wait_ly
 .skip_wait_ly
 	pop af
-	ld hl, wd7fb
+	ld hl, wGraphicsQueueWriteIndex
 	ld l, [hl]
 	ld h, wcb00 / $100
 	inc bc
@@ -1251,7 +1251,7 @@ QueueGraphicsToLoadWithFunc: ; 0x10c5
 	ld [MBC5RomBank], a
 	dec bc
 	ld a, [bc]
-	ld hl, wd7fa
+	ld hl, wGraphicsQueueSize
 	add [hl]
 	cp $30
 	jr c, .size_okay
@@ -1263,14 +1263,14 @@ QueueGraphicsToLoadWithFunc: ; 0x10c5
 	pop af
 	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
-	ld hl, wd7fb
+	ld hl, wGraphicsQueueWriteIndex
 	ld l, [hl]
 	ld h, wca00 / $100
 	inc l
 	ld [hl], $0
 	dec l
 	ld [hl], e
-	ld hl, wd7fb
+	ld hl, wGraphicsQueueWriteIndex
 	inc [hl]
 	ldh a, [rLCDC]
 	bit 7, a
@@ -1279,27 +1279,27 @@ QueueGraphicsToLoadWithFunc: ; 0x10c5
 	push af
 	res 0, a
 	ldh [rIE], a
-	call Func_113a
+	call ProcessQueuedGraphics
 	pop af
 	ldh [rIE], a
 	ret
 
-Func_1129: ; 0x1129
-	ld a, [wd7fb]
-	ld [wd7fc], a
+SnapshotGraphicsQueuePosition: ; 0x1129
+	ld a, [wGraphicsQueueWriteIndex]
+	ld [wGraphicsQueueReadIndex], a
 	ret
 
-Func_1130: ; 0x1130
+CheckGraphicsQueueEmpty: ; 0x1130
 	push hl
-	ld a, [wd7fb]
-	ld hl, wd7fc
+	ld a, [wGraphicsQueueWriteIndex]
+	ld hl, wGraphicsQueueReadIndex
 	cp [hl]
 	pop hl
 	ret
 
-Func_113a: ; 0x113a
-	ld hl, wd7fc
-	ld a, [wd7fb]
+ProcessQueuedGraphics: ; 0x113a
+	ld hl, wGraphicsQueueReadIndex
+	ld a, [wGraphicsQueueWriteIndex]
 	cp [hl]
 	ret z
 	ld l, [hl]
@@ -1335,12 +1335,12 @@ Func_113a: ; 0x113a
 
 .done
 	ld a, l
-	ld [wd7fc], a
-	ld hl, wd7fb
+	ld [wGraphicsQueueReadIndex], a
+	ld hl, wGraphicsQueueWriteIndex
 	cp [hl]
 	ret nz
 	xor a
-	ld [wd7fa], a
+	ld [wGraphicsQueueSize], a
 	ret
 
 JumpToHL: ; 0x117a
@@ -1378,7 +1378,7 @@ LoadTileListsBank1: ; 0x118d
 	ldh [rVBK], a
 	ret
 
-Func_1198:
+LoadSequentialTileLists:
 	ld h, d
 	ld l, e
 .asm_119a
@@ -1441,16 +1441,16 @@ FillTileListsBank1: ; 0x11c7
 	ldh [rVBK], a
 	ret
 
-Func_11d2:
+LoadBankedTileData:
 	ld h, d
 	ld l, e
 	ldh a, [hLoadedROMBank]
-	ldh [hFF94], a
+	ldh [hBankedCopySourceBank], a
 .asm_11d8
 	ld a, [hli]
 	and a
 	ret z
-	ldh [hFF95], a
+	ldh [hBankedCopyCount], a
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -1465,7 +1465,7 @@ Func_11d2:
 	push hl
 	ld h, b
 	ld l, c
-	ldh a, [hFF95]
+	ldh a, [hBankedCopyCount]
 	ld b, a
 .asm_11f1
 	ld a, [hli]
@@ -1519,18 +1519,18 @@ Func_11d2:
 	dec b
 	jr nz, .asm_11f1
 	pop hl
-	ldh a, [hFF94]
+	ldh a, [hBankedCopySourceBank]
 	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	jr .asm_11d8
 
-Func_122e:
+LoadVRAMTilemapData:
 	ld a, $1
 	ldh [rVBK], a
 	ld h, d
 	ld l, e
 	ldh a, [hLoadedROMBank]
-	ldh [hFF94], a
+	ldh [hBankedCopySourceBank], a
 .asm_1238
 	ld a, [hli]
 	and a
@@ -1540,7 +1540,7 @@ Func_122e:
 	ret
 
 .asm_1240
-	ldh [hFF95], a
+	ldh [hBankedCopyCount], a
 	ld a, [hli]
 	ld e, a
 	ld a, [hli]
@@ -1555,7 +1555,7 @@ Func_122e:
 	push hl
 	ld h, b
 	ld l, c
-	ldh a, [hFF95]
+	ldh a, [hBankedCopyCount]
 	ld b, a
 .asm_1256
 	ld a, [hli]
@@ -1564,7 +1564,7 @@ Func_122e:
 	dec b
 	jr nz, .asm_1256
 	pop hl
-	ldh a, [hFF94]
+	ldh a, [hBankedCopySourceBank]
 	ldh [hLoadedROMBank], a
 	ld [MBC5RomBank], a
 	jr .asm_1238
@@ -1583,7 +1583,7 @@ LoadPalettes:
 	ld a, [hli]
 	and a
 	ret z
-	ldh [hFF94], a
+	ldh [hBankedCopySourceBank], a
 	ld a, [hli]
 	bit 6, a
 	ld de, rBGPI
@@ -1606,7 +1606,7 @@ LoadPalettes:
 	push hl
 	ld h, b
 	ld l, c
-	ldh a, [hFF94]
+	ldh a, [hBankedCopySourceBank]
 	ld b, a
 .loadColor
 	ld a, [hli]
@@ -1624,39 +1624,39 @@ LoadPalettes:
 INCLUDE "home/sgb.asm"
 INCLUDE "home/serial.asm"
 
-Func_1a21: ; 0x1a21
-	call Func_1a59
-	call Func_1a89
+InitiateHighScoreTransfer: ; 0x1a21
+	call InitializeSerialCommunication
+	call ProcessSerialHandshakeResponse
 	jr c, .asm_1a3f
 .asm_1a29
-	call Func_1aa9
-	call Func_1b3d
+	call TransferTileDataToBuffer
+	call StartHighScoreSerialTransfer
 	jr c, .asm_1a3f
 	ld a, [wd86c]
 	and a
 	jr z, .asm_1a29
-	call Func_1b60
+	call RunHighScoreDataExchange
 	jr c, .asm_1a3f
-	call Func_1b88
+	call ValidateSerialDataExchange
 .asm_1a3f
-	call Func_1ba7
+	call DisableSerialCommunication
 	ret
 
-Func_1a43: ; 0x1a43
+InitiateHighScoreTransferWithFlag: ; 0x1a43
 	xor a
 	ld [wd86e], a
-	call Func_1a59
-	call Func_1a89
+	call InitializeSerialCommunication
+	call ProcessSerialHandshakeResponse
 	jr c, .asm_1a54
 	ld a, $1
 	ld [wd86e], a
 .asm_1a54
-	call Func_1ba7
+	call DisableSerialCommunication
 	ret
 
 	ret ; unused instruction?
 
-Func_1a59: ; 0x1a59
+InitializeSerialCommunication: ; 0x1a59
 	ld [wd86a], a
 	ld a, h
 	ld [wd869], a
@@ -1670,35 +1670,35 @@ Func_1a59: ; 0x1a59
 	ld [wd86b], a
 	ld [wd86c], a
 	ld [wd86d], a
-	call Func_16a2
+	call ResetSerialCommunication
 	ld hl, rIE
 	set 3, [hl]
 	xor a
-	ldh [hFFB1], a
+	ldh [hSerialInterruptMode], a
 	ld a, $1
-	ld [wd8e1], a
+	ld [wSerialCommunicationEnabled], a
 	ret
 
-Func_1a89: ; 0x1a89
-	call Func_16e2
+ProcessSerialHandshakeResponse: ; 0x1a89
+	call ProcessSerialResponse
 	cp $f0
 	jr z, .asm_1a9f
 	cp $ff
-	jp z, Func_1bb2
+	jp z, HandleSerialCommunicationError
 	ld a, [wd8c8]
 	cp $81
-	jp nz, Func_1bb2
+	jp nz, HandleSerialCommunicationError
 	and a
 	ret
 
 .asm_1a9f
 	ldh a, [hNewlyPressedButtons]
 	bit 1, a
-	jp nz, Func_1bd3
+	jp nz, HandleSerialCommunicationCancellation
 	rst AdvanceFrame
-	jr Func_1a89
+	jr ProcessSerialHandshakeResponse
 
-Func_1aa9: ; 0x1aa9
+TransferTileDataToBuffer: ; 0x1aa9
 	ld a, [wd866]
 	ld l, a
 	ld a, [wd867]
@@ -1709,7 +1709,7 @@ Func_1aa9: ; 0x1aa9
 	ld c, $14
 .asm_1ab8
 	ld a, [hli]
-	call Func_1ae2
+	call DecodeNibbleEncodedTile
 	dec c
 	jr nz, .asm_1ab8
 	ld a, l
@@ -1734,7 +1734,7 @@ Func_1aa9: ; 0x1aa9
 .asm_1ae1
 	ret
 
-Func_1ae2: ; 0x1ae2
+DecodeNibbleEncodedTile: ; 0x1ae2
 	push bc
 	push hl
 	xor $80
@@ -1770,14 +1770,14 @@ ENDR
 	pop bc
 	ret
 
-Func_1b3d: ; 0x1b3d
+StartHighScoreSerialTransfer: ; 0x1b3d
 	ld a, [wd86c]
 	ld [wd8dd], a
 	ld hl, wc000
 	ld a, $1
-	call Func_1779
+	call InitiateSerialDataTransfer
 	cp $ff
-	jp z, Func_1bb2
+	jp z, HandleSerialCommunicationError
 	cp $f0
 	jr z, .asm_1b56
 	and a
@@ -1786,18 +1786,18 @@ Func_1b3d: ; 0x1b3d
 .asm_1b56
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
-	jp nz, Func_1bd3
+	jp nz, HandleSerialCommunicationCancellation
 	rst AdvanceFrame
-	jr Func_1b3d
+	jr StartHighScoreSerialTransfer
 
-Func_1b60: ; 0x1b60
+RunHighScoreDataExchange: ; 0x1b60
 	ld a, $1
 	ld [wd8a8], a
 	ld a, $13
 	ld [wd8a9], a
-	call Func_1740
+	call ProcessSerialDataExchange
 	cp $ff
-	jp z, Func_1bb2
+	jp z, HandleSerialCommunicationError
 	cp $f0
 	jr z, .asm_1b7e
 	ld bc, $001e
@@ -1808,39 +1808,39 @@ Func_1b60: ; 0x1b60
 .asm_1b7e
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
-	jp nz, Func_1bd3
+	jp nz, HandleSerialCommunicationCancellation
 	rst AdvanceFrame
-	jr Func_1b60
+	jr RunHighScoreDataExchange
 
-Func_1b88: ; 0x1b88
+ValidateSerialDataExchange: ; 0x1b88
 	ld a, [wd8c7]
 	ld b, a
 	cp $ff
-	jr z, Func_1bb2
+	jr z, HandleSerialCommunicationError
 	and $f0
-	jr nz, Func_1bb2
+	jr nz, HandleSerialCommunicationError
 	bit 1, b
 	jr nz, .asm_1b9d
-	call Func_16a2
+	call ResetSerialCommunication
 	and a
 	ret
 
 .asm_1b9d
 	ldh a, [hNewlyPressedButtons]
 	bit BIT_B_BUTTON, a
-	jp nz, Func_1bd3
+	jp nz, HandleSerialCommunicationCancellation
 	rst AdvanceFrame
-	jr Func_1b88
+	jr ValidateSerialDataExchange
 
-Func_1ba7: ; 0x1ba7
+DisableSerialCommunication: ; 0x1ba7
 	ld hl, rIE
 	res 3, [hl]
 	xor a
-	ld [wd8e1], a
+	ld [wSerialCommunicationEnabled], a
 	and a
 	ret
 
-Func_1bb2: ; 0x1bb2
+HandleSerialCommunicationError: ; 0x1bb2
 	ld hl, Data_1bcf
 	ld a, [wd8c7]
 	cp $ff
@@ -1855,7 +1855,7 @@ Func_1bb2: ; 0x1bb2
 .asm_1bc6
 	ld a, [hl]
 	ld [wd86d], a
-	call Func_16a2
+	call ResetSerialCommunication
 	scf
 	ret
 
@@ -1863,12 +1863,12 @@ Data_1bcf:
 	;  $ff, >$7f, >$3f, else
 	db $02,  $01,  $04,  $03
 
-Func_1bd3: ; 0x1bd3
+HandleSerialCommunicationCancellation: ; 0x1bd3
 	lb de, $00, $01
 	call PlaySoundEffect
 	ld a, $5
 	ld [wd86d], a
-	call Func_16a2
+	call ResetSerialCommunication
 	scf
 	ret
 
@@ -2015,7 +2015,7 @@ Unused_Func_1f81:
 	ld hl, $4f06
 	jr asm_1fca
 
-Func_1f9a:
+LoadSpriteData2WithOffset:
 	push bc
 	push de
 	push hl
@@ -2031,7 +2031,7 @@ Func_1f9a:
 	ld hl, SpriteDataPointers2
 	jr asm_1fca
 
-Func_1fb3:
+LoadSpriteDataWithOffset:
 	push bc
 	push de
 	push hl
@@ -2161,7 +2161,7 @@ LoadDexVWFCharacter: ; 0x206d
 	scf
 	ret
 
-Func_208c: ; 0x208c
+LoadDexVWFCharacterSpecial: ; 0x208c
 	ldh a, [hLoadedROMBank]
 	push af
 	ld a, Bank(Func_8ee0)

--- a/home/bcd.asm
+++ b/home/bcd.asm
@@ -1,6 +1,6 @@
 ; This file contains functions to handle adding and retrieving BCD (binary coded decimal) values.
 
-Func_3500:
+AddBCDEToScoreWithMultiplier:
 	ld hl, wScoreToAdd
 	ld a, e
 	ld [hli], a
@@ -74,7 +74,7 @@ RetrieveJackpot: ; 0x3556
 	ld b, a
 	ret
 
-Func_3567:
+BCDAddBCToHL:
 ; BCD add bc to hl
 	ld a, l
 	add c
@@ -86,7 +86,7 @@ Func_3567:
 	ld h, a
 	ret
 
-Func_3570:
+BCDAddDEToHL:
 ; BCD add de to hl
 	ld a, l
 	add e
@@ -98,7 +98,7 @@ Func_3570:
 	ld h, a
 	ret
 
-Func_3579: ; 0x3579
+ClearJackpot: ; 0x3579
 ; Delete 4-byte BCD value at wCurrentJackpot
 	ld hl, wCurrentJackpot
 	xor a

--- a/home/copy.asm
+++ b/home/copy.asm
@@ -1,4 +1,4 @@
-Func_61b: ; 0x61b
+WaitForLCDHBlank: ; 0x61b
 	ldh a, [rLY]  ; LY register (LCDC Y-Coordinate)
 	cp $40
 	jr c, .asm_625
@@ -279,7 +279,7 @@ LoadVRAMData: ; 0x73f
 	push af
 	call WaitForLCD
 .loop
-	call Func_61b
+	call WaitForLCDHBlank
 .waitForHBlank
 	ldh a, [rSTAT]
 	and $3
@@ -331,7 +331,7 @@ FarCopyPalettes: ; 0x790
 	ld hl, rLCDC
 	bit 7, [hl]
 	pop hl
-	jp nz, Func_7dc
+	jp nz, CopyCGBPalettesWithHBlankSync
 	bit 7, h
 	jr nz, .asm_7ad
 	ldh [hROMBankBuffer], a
@@ -381,7 +381,7 @@ FarCopyPalettes: ; 0x790
 	ld [MBC5RomBank], a
 	ret
 
-Func_7dc: ; 0x7dc
+CopyCGBPalettesWithHBlankSync: ; 0x7dc
 	bit 7, h
 	jr nz, .asm_7ef
 	ldh [hROMBankBuffer], a
@@ -414,7 +414,7 @@ Func_7dc: ; 0x7dc
 	pop hl
 	call WaitForLCD
 .asm_80e
-	call Func_61b
+	call WaitForLCDHBlank
 .asm_811
 	ldh a, [rSTAT]
 	and $3
@@ -471,7 +471,7 @@ PutTileInVRAM: ; 0x848
 ;        hl = pointer to VRAM location where tile should be placed
 	push af
 	call WaitForLCD
-	call Func_61b
+	call WaitForLCDHBlank
 .asm_84f
 	ldh a, [rSTAT]
 	and $3
@@ -480,10 +480,10 @@ PutTileInVRAM: ; 0x848
 	ld [hl], a  ; Store tile number in VRAM background map
 	ret
 
-Func_858: ; 0x858
+WriteTileToVRAMBank1: ; 0x858
 	push af
 	call WaitForLCD
-	call Func_61b
+	call WaitForLCDHBlank
 .asm_85f
 	ldh a, [rSTAT]
 	and $3
@@ -547,27 +547,27 @@ LoadBillboardPaletteMap: ; 0x86f
 .asm_8ae
 	push bc
 	ld a, [de]
-	call Func_858
+	call WriteTileToVRAMBank1
 	inc hl
 	inc de
 	ld a, [de]
-	call Func_858
+	call WriteTileToVRAMBank1
 	inc hl
 	inc de
 	ld a, [de]
-	call Func_858
+	call WriteTileToVRAMBank1
 	inc hl
 	inc de
 	ld a, [de]
-	call Func_858
+	call WriteTileToVRAMBank1
 	inc hl
 	inc de
 	ld a, [de]
-	call Func_858
+	call WriteTileToVRAMBank1
 	inc hl
 	inc de
 	ld a, [de]
-	call Func_858
+	call WriteTileToVRAMBank1
 	inc de
 	ld bc, $001b
 	add hl, bc
@@ -579,7 +579,7 @@ LoadBillboardPaletteMap: ; 0x86f
 	ld [MBC5RomBank], a
 	ret
 
-Func_8e1: ; 0x8e1
+LoadTileDataWithBankSwitch: ; 0x8e1
 	ldh [hROMBankBuffer], a
 	ldh a, [hLoadedROMBank]
 	push af

--- a/home/ir.asm
+++ b/home/ir.asm
@@ -1,4 +1,4 @@
-Func_1be3: ; 0x1be3
+InitializeIRTimingData: ; 0x1be3
 	ld a, $c0
 	ldh [rRP], a
 	ld a, $ff
@@ -37,23 +37,23 @@ Func_1be3: ; 0x1be3
 	ld [hl], $5
 	ret
 
-Func_1c1b: ; 0x1c1b
+WaitForIRSignalHigh: ; 0x1c1b
 	inc d
 	ret z
 	ldh a, [$ff00+c]
 	bit 1, a
-	jr z, Func_1c1b
+	jr z, WaitForIRSignalHigh
 	ret
 
-Func_1c23: ; 0x1c23
+WaitForIRSignalLow: ; 0x1c23
 	inc d
 	ret z
 	ldh a, [$ff00+c]
 	bit 1, a
-	jr nz, Func_1c23
+	jr nz, WaitForIRSignalLow
 	ret
 
-Func_1c2b: ; 0x1c2b
+SendIRPulse: ; 0x1c2b
 	ld a, $c1
 	ldh [$ff00+c], a
 .asm_1c2e
@@ -61,7 +61,7 @@ Func_1c2b: ; 0x1c2b
 	jr nz, .asm_1c2e
 	ret
 
-Func_1c32: ; 0x1c32
+SendIRGap: ; 0x1c32
 	ld a, $c0
 	ldh [$ff00+c], a
 .asm_1c35
@@ -69,7 +69,7 @@ Func_1c32: ; 0x1c32
 	jr nz, .asm_1c35
 	ret
 
-Func_1c39:
+EstablishIRConnection:
 	xor a
 	ldh [hNumFramesSinceLastVBlank], a
 	ld a, $1
@@ -79,104 +79,104 @@ Func_1c39:
 	ld c, rRP % $100
 	ldh a, [$ff00+c]
 	and b
-	jr z, Func_1c50
+	jr z, HandleIRReceiveHandshake
 	ldh a, [hNumFramesSinceLastVBlank]
 	and a
-	jr nz, Func_1ca1
+	jr nz, HandleIRSendHandshake
 	jr .asm_1c41
 
-Func_1c50: ; 0x1c50
+HandleIRReceiveHandshake: ; 0x1c50
 	ld a, $1
 	ld [wd8e9], a
 	ld b, $1a
 	ld c, rRP % $100
 	ld d, $0
 	ld e, d
-	call Func_1c23
+	call WaitForIRSignalLow
 	ld a, d
 	and a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	ld d, e
-	call Func_1c1b
+	call WaitForIRSignalHigh
 	ld a, d
 	and a
-	jp z, Func_1dc2
-	call Func_1c23
+	jp z, SetIRErrorState
+	call WaitForIRSignalLow
 	ld a, d
 	and a
-	jp z, Func_1dc2
-	call Func_1c1b
+	jp z, SetIRErrorState
+	call WaitForIRSignalHigh
 	ld a, d
 	and a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	cp $8
-	jp c, Func_1dc2
+	jp c, SetIRErrorState
 	cp $2a
-	jp nc, Func_1dc2
+	jp nc, SetIRErrorState
 	ld a, $0
 	ld [wd8ea], a
 	ld d, b
-	call Func_1c32
+	call SendIRGap
 	ld d, b
-	call Func_1c2b
+	call SendIRPulse
 	ld d, b
-	call Func_1c32
+	call SendIRGap
 	ld d, b
-	call Func_1c2b
+	call SendIRPulse
 	ld d, b
-	call Func_1c32
+	call SendIRGap
 	ret
 
-Func_1ca1: ; 0x1ca1
+HandleIRSendHandshake: ; 0x1ca1
 	ld a, $2
 	ld [wd8e9], a
 	ld b, $1a
 	ld c, rRP % $100
 	ld d, b
 	ld e, $0
-	call Func_1c32
+	call SendIRGap
 	ld d, b
-	call Func_1c2b
+	call SendIRPulse
 	ld d, b
-	call Func_1c32
+	call SendIRGap
 	ld d, b
-	call Func_1c2b
+	call SendIRPulse
 	ld d, b
-	call Func_1c32
+	call SendIRGap
 	ld d, e
-	call Func_1c23
+	call WaitForIRSignalLow
 	ld a, d
 	and a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	ld d, e
-	call Func_1c1b
+	call WaitForIRSignalHigh
 	ld a, d
 	and a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	ld d, e
-	call Func_1c23
+	call WaitForIRSignalLow
 	ld a, d
 	and a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	ld d, e
-	call Func_1c1b
+	call WaitForIRSignalHigh
 	ld a, d
 	and a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	ld d, $1a
-	call Func_1c32
+	call SendIRGap
 	ld a, $0
 	ld [wd8ea], a
 	ret
 
-Func_1cef:
+DisableIRCommunication:
 	xor a
 	ldh [rRP], a
 	ld a, $ff
 	ld [wd8ea], a
 	ret
 
-Func_1cf8: ; 0x1cf8
+TransmitIRData: ; 0x1cf8
 	xor a
 	ld [wd8e4], a
 	ld [wd8e5], a
@@ -189,37 +189,37 @@ Func_1cf8: ; 0x1cf8
 	dec hl
 	ld b, $2
 	ld d, $1e
-	call Func_1c32
-	call Func_1d44
+	call SendIRGap
+	call TransmitIRDataBytes
 	pop bc
 	pop hl
-	call Func_1ed3
-	call Func_1d44
+	call IRTimingNop
+	call TransmitIRDataBytes
 	ld a, [wd8e4]
 	ld [wd8e6], a
 	ld a, [wd8e5]
 	ld [wd8e7], a
 	ld hl, wd8e6
 	ld b, $2
-	call Func_1d44
+	call TransmitIRDataBytes
 	ld hl, wd8ea
 	ld b, $1
-	call Func_1e3b
+	call ReceiveIRDataBytes
 	ld a, [wd8e6]
 	ld [wd8e4], a
 	ld a, [wd8e7]
 	ld [wd8e5], a
 	ret
 
-Func_1d44: ; 0x1d44
+TransmitIRDataBytes: ; 0x1d44
 	ld a, [wd8ea]
 	cp $0
 	ret nz
 	ld c, rRP % $100
 	ld d, $16
-	call Func_1c2b
+	call SendIRPulse
 	ld d, $16
-	call Func_1c32
+	call SendIRGap
 	ld a, b
 	cpl
 	ld b, a
@@ -240,7 +240,7 @@ Func_1d44: ; 0x1d44
 	jr .asm_1d78
 
 .asm_1d75
-	call Func_1ed3
+	call IRTimingNop
 .asm_1d78
 	ld a, e
 	rlca
@@ -248,74 +248,74 @@ Func_1d44: ; 0x1d44
 	jr nc, .asm_1d8d
 	ld a, [wd8eb]
 	ld d, a
-	call Func_1c2b
+	call SendIRPulse
 	ld a, [wd8ec]
 	ld d, a
-	call Func_1c32
+	call SendIRGap
 	jr .asm_1d9b
 
 .asm_1d8d
 	ld a, [wd8ed]
 	ld d, a
-	call Func_1c2b
+	call SendIRPulse
 	ld a, [wd8ee]
 	ld d, a
-	call Func_1c32
+	call SendIRGap
 .asm_1d9b
 	ld a, [wd8e3]
 	dec a
 	ld [wd8e3], a
 	jr z, .asm_1dac
-	call Func_1ed4
-	call Func_1ed4
+	call IRTimingDelay
+	call IRTimingDelay
 	jr .asm_1d78
 
 .asm_1dac
 	jr .asm_1d59
 
 .asm_1dae
-	call Func_1ed3
-	call Func_1ed3
-	call Func_1ed4
+	call IRTimingNop
+	call IRTimingNop
+	call IRTimingDelay
 	ld d, $16
-	call Func_1c2b
+	call SendIRPulse
 	ld d, $16
-	call Func_1c32
+	call SendIRGap
 	ret
 
-Func_1dc2: ; 0x1dc2
+SetIRErrorState: ; 0x1dc2
 	ld a, $2
 	ld [wd8ea], a
 	ret
 
-Func_1dc8:
+SetIRChecksumError:
 	ld a, [wd8ea]
 	or $1
 	ld [wd8ea], a
 	ret
 
-Func_1dd1: ; 0x1dd1
+SetIRProtocolError: ; 0x1dd1
 	ld a, [wd8ea]
 	or $4
 	ld [wd8ea], a
 	ret
 
-Func_1dda: ; 0x1dda
+ReceiveIRData: ; 0x1dda
 	xor a
 	ld [wd8e4], a
 	ld [wd8e5], a
 	push hl
 	ld hl, wd8e6
 	ld b, $2
-	call Func_1e3b
+	call ReceiveIRDataBytes
 	ld a, [wd8e7]
 	ld [wd8e8], a
 	ld b, a
 	pop hl
 	ld a, [wd8e6]
 	cp $5a
-	jp nz, Func_1dd1
-	call Func_1e3b
+	jp nz, SetIRProtocolError
+	call ReceiveIRDataBytes
 	ld a, [wd8e4]
 	ld d, a
 	ld a, [wd8e5]
@@ -323,7 +323,7 @@ Func_1dda: ; 0x1dda
 	push de
 	ld hl, wd8e6
 	ld b, $2
-	call Func_1e3b
+	call ReceiveIRDataBytes
 	pop de
 	ld hl, wd8e6
 	ld a, [hli]
@@ -340,7 +340,7 @@ Func_1dda: ; 0x1dda
 	push de
 	ld hl, wd8ea
 	ld b, $1
-	call Func_1d44
+	call TransmitIRDataBytes
 	pop de
 	ld a, d
 	ld [wd8e4], a
@@ -351,28 +351,28 @@ Func_1dda: ; 0x1dda
 	ret z
 	ret
 
-Func_1e3b: ; 0x1e3b
+ReceiveIRDataBytes: ; 0x1e3b
 	ld a, [wd8ea]
 	cp $0
 	ret nz
 	ld c, rRP % $100
 	ld d, $0
-	call Func_1c23
+	call WaitForIRSignalLow
 	ld a, d
 	or a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	ld d, $0
-	call Func_1c1b
+	call WaitForIRSignalHigh
 	ld a, d
 	or a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	ld d, $0
-	call Func_1c23
+	call WaitForIRSignalLow
 	ld a, d
 	or a
-	jp z, Func_1dc2
-	call Func_1ed4
-	call Func_1ed4
+	jp z, SetIRErrorState
+	call IRTimingDelay
+	call IRTimingDelay
 	push af
 	pop af
 	ld a, b
@@ -385,8 +385,8 @@ Func_1e3b: ; 0x1e3b
 	ld [wd8e3], a
 .asm_1e74
 	ld d, $0
-	call Func_1c1b
-	call Func_1c23
+	call WaitForIRSignalHigh
+	call WaitForIRSignalLow
 	ld a, [wd8ef]
 	cp d
 	jr nc, .asm_1e88
@@ -407,8 +407,8 @@ Func_1e3b: ; 0x1e3b
 	ld a, e
 	rlca
 	ld e, a
-	call Func_1ed4
-	call Func_1ed4
+	call IRTimingDelay
+	call IRTimingDelay
 	jr .asm_1e74
 
 .asm_1ea0
@@ -424,32 +424,32 @@ Func_1e3b: ; 0x1e3b
 	jr .asm_1eb7
 
 .asm_1eb4
-	call Func_1ed3
+	call IRTimingNop
 .asm_1eb7
 	jr .asm_1e6c
 
 .asm_1eb9
 	ld d, $0
-	call Func_1c1b
+	call WaitForIRSignalHigh
 	ld a, d
 	and a
-	jp z, Func_1dc2
+	jp z, SetIRErrorState
 	ld d, $11
-	call Func_1c32
+	call SendIRGap
 	ret
 
-Func_1ec9:
+TransmitIRPacket:
 	ld b, $00
-	jp Func_1cf8
+	jp TransmitIRData
 
-Func_1ece:
+ReceiveIRPacket:
 	ld b, $00
-	jp Func_1dda
+	jp ReceiveIRData
 
-Func_1ed3: ; 0x1ed3
+IRTimingNop: ; 0x1ed3
 	ret
 
-Func_1ed4: ; 0x1ed4
+IRTimingDelay: ; 0x1ed4
 	jr z, .asm_1ed6
 .asm_1ed6
 	jr nz, .asm_1ed8

--- a/home/palettes.asm
+++ b/home/palettes.asm
@@ -422,7 +422,7 @@ LoadCurrentPalettesIntoFadePalettes: ; 0xd9d
 	inc c
 	call WaitForLCD
 .asm_da4
-	call Func_61b
+	call WaitForLCDHBlank
 .asm_da7
 	ldh a, [rSTAT]
 	and $3

--- a/home/serial.asm
+++ b/home/serial.asm
@@ -1,15 +1,15 @@
-Func_14c4: ; 14c4 (0:14c4)
+HandleSerialCommunication: ; 14c4 (0:14c4)
 	ld a, [wd8dc]
 	and a
-	jp nz, Func_165f
+	jp nz, SerialReturn
 	ld a, [wd8ad]
 	cp $7
-	jp z, Func_1612
+	jp z, HandleSerialCompletionState
 	ld a, [wd8af]
 	and a
 	jr nz, .asm_14df
-	call Func_1502
-	jp Func_1663
+	call SendSerialHandshakeBytes
+	jp SerialDone
 
 .asm_14df
 	ld a, [wd8b0]
@@ -21,19 +21,19 @@ Func_14c4: ; 14c4 (0:14c4)
 	ld a, [wd8b2]
 	cp $2
 	jr z, .asm_14f7
-	call Func_15e1
+	call TransmitSerialChecksum
 	jr .asm_14ff
 
 .asm_14f7
-	call Func_15f8
+	call ReceiveSerialChecksum
 	jr .asm_14ff
 
 .asm_14fc
-	call Func_1527
+	call ExchangeSerialDataBytes
 .asm_14ff
-	jp Func_1663
+	jp SerialDone
 
-Func_1502: ; 1502 (0:1502)
+SendSerialHandshakeBytes: ; 1502 (0:1502)
 	ld hl, wd8b9
 	ld c, [hl]
 	inc [hl]
@@ -55,7 +55,7 @@ Func_1502: ; 1502 (0:1502)
 	ld [wd8af], a
 	ret
 
-Func_1527: ; 1527 (0:1527)
+ExchangeSerialDataBytes: ; 1527 (0:1527)
 	ld a, [wd8b9]
 	ld c, a
 	ld a, [wd8ba]
@@ -130,19 +130,19 @@ Func_1527: ; 1527 (0:1527)
 	ret
 
 .asm_15b1
-	call Func_15c8
+	call ResetSerialBufferPointers
 	ret
 
 .asm_15b5
 	ld a, [wd8c8 + 1]
 	ld [wd8c8], a
-Func_15bb:
+CompleteSerialTransfer:
 	ld a, $7
 	ld [wd8ad], a
 	ld a, $1
 	ld [wd8c5], a
-	call Func_16bf
-Func_15c8: ; 15c8 (0:15c8)
+	call ClearSerialExchangeState
+ResetSerialBufferPointers: ; 15c8 (0:15c8)
 	ld a, [wd8b5]
 	ld [wd8b3], a
 	ld a, [wd8b6]
@@ -153,7 +153,7 @@ Func_15c8: ; 15c8 (0:15c8)
 	ld [wd8bc], a
 	ret
 
-Func_15e1: ; 15e1 (0:15e1)
+TransmitSerialChecksum: ; 15e1 (0:15e1)
 	ld c, a
 	ld b, $0
 	ld hl, wd8c3
@@ -168,7 +168,7 @@ Func_15e1: ; 15e1 (0:15e1)
 	inc [hl]
 	ret
 
-Func_15f8: ; 15f8 (0:15f8)
+ReceiveSerialChecksum: ; 15f8 (0:15f8)
 	ldh a, [rSB]
 	ld [wd8c8], a
 	xor a
@@ -181,10 +181,10 @@ Func_15f8: ; 15f8 (0:15f8)
 	inc [hl]
 	ld a, [hl]
 	cp $2
-	jr z, Func_15bb
+	jr z, CompleteSerialTransfer
 	ret
 
-Func_1612: ; 1612 (0:1612)
+HandleSerialCompletionState: ; 1612 (0:1612)
 	ld a, [wd8cb]
 	ld [wd8ae], a
 	ld a, [wd8c7]
@@ -221,19 +221,19 @@ Func_1612: ; 1612 (0:1612)
 	ld [wd8c5], a
 	ld a, [wd8cc]
 	and a
-	jr nz, Func_165f
+	jr nz, SerialReturn
 	xor a
 	ld [wd8db], a
-Func_165f: ; 165f (0:165f)
+SerialReturn: ; 165f (0:165f)
 	ret
 
-Func_1660:
+ClearSerialControl:
 	xor a
 	ldh [rSC], a
-Func_1663: ; 1663 (0:1663)
+SerialDone: ; 1663 (0:1663)
 	ret
 
-Func_1664:
+SerialInterruptHandler:
 	push af
 	ldh a, [rSC]
 	bit 7, a
@@ -243,14 +243,14 @@ Func_1664:
 	push hl
 	ld a, $1
 	ld [wd8ca], a
-	call Func_14c4
+	call HandleSerialCommunication
 	pop hl
 	pop de
 	pop bc
 .asm_1679
 	pop af
 	reti
-Func_167b: ; 0x167b
+PollSerialCommunication: ; 0x167b
 	ld a, [wd8ad]
 	cp $1
 	ret nz
@@ -268,16 +268,16 @@ Func_167b: ; 0x167b
 	xor a
 	ld [hl], a
 	ld [wd8e2], a
-	call Func_18ac
+	call TriggerSerialPoll
 	ret
 
-Func_169d:
+ClearSerialRegisters:
 	xor a
 	ldh [rSC], a
 	ldh [rSB], a
 	; fallthrough
 
-Func_16a2: ; 0x16a2
+ResetSerialCommunication: ; 0x16a2
 	xor a
 	ldh [rSB], a
 	ldh [rSC], a
@@ -285,16 +285,16 @@ Func_16a2: ; 0x16a2
 	dec a
 	ld [wd8c7], a
 	ld [wd8c8], a
-	call Func_16b5
+	call ResetSerialTransactionState
 	ret
 
-Func_16b5: ; 0x16b5
+ResetSerialTransactionState: ; 0x16b5
 	xor a
 	ld [wd8c5], a
 	ld [wd8ca], a
 	ld [wd8db], a
 	; fall through
-Func_16bf: ; 0x16bf
+ClearSerialExchangeState: ; 0x16bf
 	xor a
 	ld [wd8af], a
 	ld [wd8b0], a
@@ -309,23 +309,23 @@ Func_16bf: ; 0x16bf
 	ld [wd8e2], a
 	ret
 
-Func_16e2: ; 0x16e2
+ProcessSerialResponse: ; 0x16e2
 	ld a, [wd8db]
 	and a
 	jr z, .asm_16ec
-	call Func_16fd
+	call CheckSerialTransactionComplete
 	ret nc
 .asm_16ec
 	ld a, [wd8ae]
 	cp $1
 	jr nz, .asm_16f7
-	call Func_16fd
+	call CheckSerialTransactionComplete
 	ret nc
 .asm_16f7
-	call Func_1925
-	jp Func_19e5
+	call InitiateSerialHandshake
+	jp FinalizeSerialState
 
-Func_16fd: ; 0x16fd
+CheckSerialTransactionComplete: ; 0x16fd
 	ld a, [wd8c5]
 	cp $2
 	jr nz, .asm_173c
@@ -370,7 +370,7 @@ Func_16fd: ; 0x16fd
 	ld a, $f0
 	ret
 
-Func_1740: ; 0x1740
+ProcessSerialDataExchange: ; 0x1740
 	ld a, [wd8ad]
 	cp $1
 	jr z, .asm_1752
@@ -390,22 +390,22 @@ Func_1740: ; 0x1740
 	ld a, [wd8db]
 	and a
 	jr z, .asm_1762
-	call Func_16fd
+	call CheckSerialTransactionComplete
 	ret nc
 .asm_1762
 	ld a, [wd8ae]
 	cp $2
 	jr nz, .asm_176d
-	call Func_16fd
+	call CheckSerialTransactionComplete
 	ret nc
 .asm_176d
 	ld a, [wd8c7]
 	cp $ff
 	ret z
-	call Func_1932
-	jp Func_19e5
+	call InitiateSerialDataPacket
+	jp FinalizeSerialState
 
-Func_1779: ; 0x1779
+InitiateSerialDataTransfer: ; 0x1779
 	ld c, a
 	ld a, [wd8ad]
 	and a
@@ -465,8 +465,8 @@ Func_1779: ; 0x1779
 .asm_17d6
 	ld bc, $0280
 .asm_17d9
-	call Func_1989
-	jp Func_19e5
+	call SetupSerialMultiPartTransfer
+	jp FinalizeSerialState
 
 .asm_17df
 	ld a, [wd8c5]
@@ -552,10 +552,10 @@ Func_1779: ; 0x1779
 	and a
 	ld a, [wd8c7]
 	jr z, .asm_1860
-	call Func_19d7
-	jp Func_19e5
+	call InitiateSerialRetransmit
+	jp FinalizeSerialState
 
-Func_1879:
+SendSerialAcknowledgment:
 	ld a, [wd8ad]
 	cp $1
 	jr z, .asm_188b
@@ -571,22 +571,22 @@ Func_1879:
 	ld a, [wd8db]
 	and a
 	jr z, .asm_1895
-	call Func_16fd
+	call CheckSerialTransactionComplete
 	ret nc
 .asm_1895
 	ld a, [wd8ae]
 	cp $4
 	jr nz, .asm_18a0
-	call Func_16fd
+	call CheckSerialTransactionComplete
 	ret nc
 .asm_18a0
 	ld a, [wd8c7]
 	cp $ff
 	ret z
-	call Func_19bd
-	jp Func_19e5
+	call InitiateSerialAck
+	jp FinalizeSerialState
 
-Func_18ac: ; 0x18ac
+TriggerSerialPoll: ; 0x18ac
 	ld a, [wd8ad]
 	cp $1
 	jr z, .asm_18be
@@ -602,16 +602,16 @@ Func_18ac: ; 0x18ac
 	ld a, [wd8db]
 	and a
 	jr z, .asm_18c8
-	call Func_16fd
+	call CheckSerialTransactionComplete
 	ret nc
 .asm_18c8
 	ld a, [wd8c7]
 	cp $ff
 	ret z
-	call Func_19ca
-	jp Func_19e5
+	call InitiateSerialPollTransaction
+	jp FinalizeSerialState
 
-Func_18d4: ; 0x18d4
+SetupSerialTransaction: ; 0x18d4
 	ld [wd8cb], a
 	ld a, d
 	ld [wd8cc], a
@@ -629,7 +629,7 @@ Func_18d4: ; 0x18d4
 	ld [wd8b6], a
 	xor a
 	ld [wd8c5], a
-	call Func_16bf
+	call ClearSerialExchangeState
 	ret
 
 SerialTranfserData_18ff: ; 0x18ff
@@ -682,19 +682,19 @@ SerialTransferData_191d: ; 0x191d
 	db $00
 	db $00
 
-Func_1925: ; 0x1925
+InitiateSerialHandshake: ; 0x1925
 	ld a, $1
 	ld d, $0
 	ld hl, SerialTransferData_1901
 	ld bc, $0008
-	jp Func_18d4
+	jp SetupSerialTransaction
 
-Func_1932: ; 0x19332
+InitiateSerialDataPacket: ; 0x19332
 	ld a, $2
 	ld d, $0
 	ld hl, wd8cd
 	ld bc, $000c
-	call Func_18d4
+	call SetupSerialTransaction
 	ld hl, SerialTransferData_1909
 	ld de, wd8cd
 	ld bc, $0004
@@ -702,16 +702,16 @@ Func_1932: ; 0x19332
 	ld de, $0006
 	ld a, [wd8a8]
 	ld [wd8d1], a
-	call Func_1982
+	call AddToSerialChecksum
 	ld a, [wd8a9]
 	ld [wd8d2], a
-	call Func_1982
+	call AddToSerialChecksum
 	ld a, [wd8aa]
 	ld [wd8d3], a
-	call Func_1982
+	call AddToSerialChecksum
 	ld a, [wd8a7]
 	ld [wd8d4], a
-	call Func_1982
+	call AddToSerialChecksum
 	ld a, e
 	ld [wd8d5], a
 	ld a, d
@@ -721,7 +721,7 @@ Func_1932: ; 0x19332
 	ld [wd8d8], a
 	ret
 
-Func_1982: ; 0x1982
+AddToSerialChecksum: ; 0x1982
 	add e
 	ld e, a
 	ld a, d
@@ -729,7 +729,7 @@ Func_1982: ; 0x1982
 	ld d, a
 	ret
 
-Func_1989: ; 0x1989
+SetupSerialMultiPartTransfer: ; 0x1989
 	ld a, l
 	ld [wd8bf], a
 	ld a, h
@@ -743,7 +743,7 @@ Func_1989: ; 0x1989
 	ld d, $1
 	ld hl, wd8cd
 	ld bc, $0004
-	call Func_18d4
+	call SetupSerialTransaction
 	ld a, [SerialTransferData_190d]
 	ld [wd8cd], a
 	ld a, [wd8ac]
@@ -755,31 +755,31 @@ Func_1989: ; 0x1989
 	ld [wd8d0], a
 	ret
 
-Func_19bd: ; 19bd (0:19bd)
+InitiateSerialAck: ; 19bd (0:19bd)
 	ld a, $4
 	ld d, $0
 	ld hl, SerialTransferData_1915
 	ld bc, $8
-	jp Func_18d4
+	jp SetupSerialTransaction
 
-Func_19ca: ; 0x19ca
+InitiateSerialPollTransaction: ; 0x19ca
 	ld a, $5
 	ld d, $0
 	ld hl, SerialTransferData_191d
 	ld bc, $0008
-	jp Func_18d4
+	jp SetupSerialTransaction
 
-Func_19d7: ; 0x19d7
+InitiateSerialRetransmit: ; 0x19d7
 	ld a, $6
 	ld d, $1
 	ld hl, SerialTransferData_190d
 	ld bc, $0008
-	jp Func_18d4
+	jp SetupSerialTransaction
 
 ; unused
 	ret
 
-Func_19e5: ; 0x19e5
+FinalizeSerialState: ; 0x19e5
 	ld a, [wd8ad]
 	cp $1
 	jr z, .asm_19f8

--- a/home/text.asm
+++ b/home/text.asm
@@ -28,7 +28,7 @@ FillBottomMessageBufferWithBlackTile: ; 0x30e8 wipes the message buffer and disa
 	ld [wStationaryText3], a
 	ret
 
-Func_310a: ; 0x310a
+ClearBottomMessageBufferRows: ; 0x310a
 	ld a, $81
 	ld hl, wBottomMessageBuffer + $40
 	ld b, $5
@@ -372,7 +372,7 @@ LoadScrollingText: ; 0x32aa
 	jr nz, .copyTextLoop
 	ret
 
-Func_32cc: ; 0x32cc
+LoadScrollingScoreText: ; 0x32cc
 	ld a, $1
 	ld [hli], a
 	ld a, [de]
@@ -404,11 +404,11 @@ Func_32cc: ; 0x32cc
 	ld a, [hl]
 	swap a
 	and $f
-	call Func_3309
+	call LoadBCDDigitAsScrollingText
 	dec b
 	ld a, [hld]
 	and $f
-	call Func_3309
+	call LoadBCDDigitAsScrollingText
 	dec b
 	jr nz, .asm_32ec
 	ld a, '0'
@@ -421,7 +421,7 @@ Func_32cc: ; 0x32cc
 	ld [de], a
 	ret
 
-Func_3309: ; 0x3309
+LoadBCDDigitAsScrollingText: ; 0x3309
 	jr nz, .asm_3312
 	ld a, b
 	dec a

--- a/hram.asm
+++ b/hram.asm
@@ -35,8 +35,8 @@ hVariableWidthFontFF92:: db ; 0xFF92
 hVariableWidthFontFF93:: db ; 0xFF93
 	ENDU
 
-hFF94:: db ; 0xFF94
-hFF95:: db ; 0xFF95
+hBankedCopySourceBank:: db ; 0xFF94
+hBankedCopyCount:: db ; 0xFF95
 ds 2
 
 hJoypadState:: db ; 0xFF98  ; current state of buttons. See joy_constants.asm for which bits
@@ -69,7 +69,7 @@ hNextFrameHBlankSCY:: db ; 0xFFAD
 hHBlankSCY:: db ; 0xFFAE
 hLCDCMask:: db ; 0xFFAF
 hStatIntrRoutine:: db ; 0xFFB0
-hFFB1:: db ; 0xFFB1
+hSerialInterruptMode:: db ; 0xFFB1
 
 hNumFramesSinceLastVBlank:: db ; 0xFFB2
 hFrameCounter:: db ; 0xFFB3
@@ -91,7 +91,7 @@ hFlipperStateChange:: dw ; 0xFFC0
 hPreviousFlipperState:: db ; 0xFFC2
 hFlipperState:: db ; 0xFFC3
 
-hFFC4:: db ; 0xFFC4
+hDMGPaletteUpdateNeeded:: db ; 0xFFC4
 
 SECTION "HRAM.2", HRAM
 

--- a/wram.asm
+++ b/wram.asm
@@ -125,10 +125,12 @@ wHighScoreId:: ; 0xd473
 wAddScoreQueueOffset:: ; 0xd477
 	ds $1
 
-wd478:: ; 0xd478
+wScoreQueueReadOffset:: ; 0xd478
+; Read offset into wAddScoreQueue. Advances as score entries are processed by ProcessScoreQueue.
 	ds $1
 
-wd479:: ; 0xd479
+wScoreQueueSyncOffset:: ; 0xd479
+; Tracks the last synchronized position in the score queue.
 	ds $1
 
 wCurrentJackpot:: ; 0xd47a
@@ -208,7 +210,8 @@ wNumBallLives:: ; 0xd49e
 ; The total number of "lives" the ball has. It is always 3. wCurBallLife is compared to it whenever the player loses a ball.
 	ds $1
 
-wd49f:: ; 0xd49f
+wScoreChanged:: ; 0xd49f
+; Set to 1 when the score has been updated and needs to be redrawn.
 	ds $2
 
 wBallSaverIconOn:: ; 0xd4a1
@@ -295,13 +298,17 @@ wBallSpin:: ; 0xd4c3
 wBallRotation:: ; 0xd4c4
 	ds $1
 
-wd4c5:: ; 0xd4c5
+wBallPreviousXPosDMG:: ; 0xd4c5
+; Previous ball X position for DMG trail rendering. On DMG, the ball sprite
+; is drawn at both current and previous positions to create a visual trail.
 	ds $1
 
-wd4c6:: ; 0xd4c6
+wBallPreviousYPosDMG:: ; 0xd4c6
+; Previous ball Y position for DMG trail rendering.
 	ds $1
 
-wd4c7:: ; 0xd4c7
+wBallPreviousRotationDMG:: ; 0xd4c7
+; Previous ball rotation for DMG trail rendering.
 	ds $1
 
 wBallSize:: ; 0xd4c8
@@ -471,10 +478,14 @@ wStaryuCollision:: ; 0xd500
 ; Second byte is set by HandleGameObjectCollision, but is unused
 	ds $2
 
-wd502:: ; 0xd502
+wStaryuState:: ; 0xd502
+; Toggles between 0 and 1 to track which Staryu frame is active.
+; Used as an index into graphics pointer tables for Staryu animation.
 	ds $1
 
-wd503:: ; 0xd503
+wStaryuAnimationTimer:: ; 0xd503
+; Countdown timer (initialized to $14/20 frames) for Staryu animation.
+; When it reaches 0, the Staryu state is reset.
 	ds $1
 
 wStaryuAnimation:: ; 0xd504
@@ -529,14 +540,18 @@ wWhichPikachuSaverSide:: ; 0xd518
 wPikachuSaverAnimation:: ; 0xd519
 	animation wPikachuSaverAnimation
 
-wd51c:: ; 0xd51c
+wPikachuSaverAnimationState:: ; 0xd51c
+; Tracks animation progression of Pikachu Saver activation.
+; 0 = inactive, 1 = first animation frame, 2 = second animation frame.
 	ds $1
 
 wPikachuSaverSlotRewardActive:: ; 0xd51d
 ; Set to 1 if the Pikachu Saver slot reward is active. 0 otherwise.
 	ds $1
 
-wd51e:: ; 0xd51e
+wSpinnerChargeSoundCooldown:: ; 0xd51e
+; Countdown timer preventing rapid spinner charging sound effects.
+; Set to $64 (100 frames) when charge reaches maximum.
 	ds $1
 
 wWhichBoardTrigger:: ; 0xd51f
@@ -593,10 +608,14 @@ wSpecialModeState:: ; 0xd54d
 ; Tracks the current state of special modes (catchem, evolution, map move)
 	ds $1
 
-wd54e:: ; 0xd54e set to 20 by catch mode when all tiles are flipped and on lower stage
+wCatchModeFlashFrameCounter:: ; 0xd54e
+; Frame countdown for billboard tile flash animation when all catch mode tiles are flipped.
+; Set to $14 (20 frames) per animation cycle.
 	ds $1
 
-wd54f:: ; 0xd54f set to 5 by catch mode when all tiles are flipped and on lower stage
+wCatchModeFlashPhaseCounter:: ; 0xd54f
+; Phase counter for billboard tile flash animation. Set to 5 cycles total.
+; Alternates tile illumination states each phase.
 	ds $1
 
 wSpecialMode:: ; 0xd550
@@ -631,10 +650,14 @@ wEvolutionTrinketCooldownFrames:: ; 0xd556
 ; cooldown is created so the player has to wait a few seconds until the objects becomes activated again.
 	ds $2
 
-wd558:: ; 0xd558
+wEvolutionIndicatorState2Backup:: ; 0xd558
+; Backs up wIndicatorStates + 2 before evolution trinket hunt.
+; Restored when trinket is found or evolution mode completes.
 	ds $1
 
-wd559:: ; 0xd559
+wEvolutionIndicatorState3Backup:: ; 0xd559
+; Backs up wIndicatorStates + 3 before evolution trinket hunt.
+; Restored when trinket is found or evolution mode completes.
 	ds $1
 
 wMapMoveDirection:: ; 0xd55a
@@ -710,7 +733,9 @@ wTimeRanOut:: ; 0xd57e set to 1 when the timer reaches 0
 wPauseTimer:: ; 0xd57f If set to nz, timer pauses
 	ds $1
 
-wd580:: ; 0xd580
+wTimerGraphicsNeedsLoading:: ; 0xd580
+; Set to 1 when timer graphics need to be loaded/drawn.
+; Checked before drawing timer display, cleared when pokemon is caught.
 	ds $1
 
 wd581:: ; 0xd581
@@ -772,7 +797,8 @@ wCatchModeMonUpdateTimer:: ; 0xd5c4 increments while the caught mon is active on
 wNumMewHits:: ; 0xd5c5
 	ds $1
 
-wd5c6:: ; 0xd5c6
+wCatchModeTransitionFlag:: ; 0xd5c6
+; Set to 1 when catch mode transitions to next state. Cleared on init and ball capture.
 	ds $1
 
 wWildMonCollision:: ; 0xd5c7
@@ -1183,7 +1209,9 @@ wGastly3XPos:: ; 0xd671
 wGastly3YPos:: ; 0xd673
 	ds $2
 
-wd674:: ; 0xd674
+wGengarPhaseTimer:: ; 0xd674
+; Countdown timer for Gengar bonus animation phase transitions.
+; Set to 4, decremented each frame during sprite drawing.
 	ds $1
 
 wd675:: ; 0xd675
@@ -1873,16 +1901,20 @@ wNoCollisionApplied:: ; 0xd7f8
 wInGameMenuIndex:: ; 0xd7f9
 	ds $1
 
-wd7fa:: ; 0xd7fa
+wGraphicsQueueSize:: ; 0xd7fa
+; Tracks the total size of pending graphics data in the queue.
+; Reset to 0 when queue is fully processed. Checked against $30 as a capacity limit.
 	ds $1
 
-wd7fb:: ; 0xd7fb
+wGraphicsQueueWriteIndex:: ; 0xd7fb
+; Write index for the queued graphics loading system. Incremented when new entries are added.
 	ds $1
 
-wd7fc:: ; 0xd7fc
+wGraphicsQueueReadIndex:: ; 0xd7fc
+; Read index for the queued graphics loading system. Updated as entries are consumed.
 	ds $1
 
-wd7fd:: ; 0xd7fd
+wGraphicsQueueOverflow:: ; 0xd7fd
 	ds $1
 
 wd7fe:: ; 0xd7fe
@@ -2193,7 +2225,8 @@ wd8de:: ; 0xd8de
 wd8e0:: ; 0xd8e0
 	ds $1
 
-wd8e1:: ; 0xd8e1
+wSerialCommunicationEnabled:: ; 0xd8e1
+; Set to 1 when serial/IR communication is active. Triggers serial processing during VBlank.
 	ds $1
 
 wd8e2:: ; 0xd8e2
@@ -2299,7 +2332,8 @@ wd915:: ; 0xd915
 wd916:: ; 0xd916
 	ds $1
 
-wd917:: ; 0xd917
+wDisableRumble:: ; 0xd917
+; Set to 1 when SGB is detected or on non-rumble hardware. Prevents rumble motor activation.
 	ds $1
 
 wd918:: ; 0xd918


### PR DESCRIPTION


## Core Systems (home.asm, score.asm, menu.asm, pinball_game.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_23b | DetectGameBoyColor | home.asm |
| Func_1129 | SnapshotGraphicsQueuePosition | home.asm |
| Func_1130 | CheckGraphicsQueueEmpty | home.asm |
| Func_113a | ProcessQueuedGraphics | home.asm |
| Func_122e | LoadVRAMTilemapData | home.asm |
| Func_1198 | LoadSequentialTileLists | home.asm |
| Func_11d2 | LoadBankedTileData | home.asm |
| Func_167b | PollSerialCommunication | home.asm |
| Func_310a | ClearBottomMessageBufferRows | home/text.asm |
| Func_32cc | LoadScrollingScoreText | home/text.asm |
| Func_3309 | LoadBCDDigitAsScrollingText | home/text.asm |
| Func_3500 | AddBCDEToScoreWithMultiplier | home/bcd.asm |
| Func_3567 | BCDAddBCToHL | home/bcd.asm |
| Func_3570 | BCDAddDEToHL | home/bcd.asm |
| Func_3579 | ClearJackpot | home/bcd.asm |
| Func_8524 | DrawScoreDigits | score.asm |
| Func_8569 | ClearAddScoreQueue | score.asm |
| Func_85c7 | ProcessScoreQueue | score.asm |
| Func_8645 | DrawScoreToBottomBar | score.asm |
| Func_8797 | DrawMenuText | menu.asm |
| Func_dba9 | DrawBallLifeIndicator | pinball_game.asm |

## VRAM Copy Utilities (home/copy.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_61b | WaitForLCDHBlank | home/copy.asm |
| Func_7dc | CopyCGBPalettesWithHBlankSync | home/copy.asm |
| Func_858 | WriteTileToVRAMBank1 | home/copy.asm |
| Func_8e1 | LoadTileDataWithBankSwitch | home/copy.asm |

## Sprite Loading (home.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_1f9a | LoadSpriteData2WithOffset | home.asm |
| Func_1fb3 | LoadSpriteDataWithOffset | home.asm |
| Func_208c | LoadDexVWFCharacterSpecial | home.asm |

## Flipper Physics (flippers.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_e2e4 | FixedPointDivide | flippers.asm |
| Func_e3de | CalculateFlipperXForce | flippers.asm |

## Timer Display (draw_timer.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_1762f | GetTimerSpriteIndex | draw_timer.asm |
| Func_17665 | QueueTimerDigitGraphics | draw_timer.asm |

## Serial Communication (home/serial.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_14c4 | HandleSerialCommunication | home/serial.asm |
| Func_1502 | SendSerialHandshakeBytes | home/serial.asm |
| Func_1527 | ExchangeSerialDataBytes | home/serial.asm |
| Func_15bb | CompleteSerialTransfer | home/serial.asm |
| Func_15c8 | ResetSerialBufferPointers | home/serial.asm |
| Func_15e1 | TransmitSerialChecksum | home/serial.asm |
| Func_15f8 | ReceiveSerialChecksum | home/serial.asm |
| Func_1612 | HandleSerialCompletionState | home/serial.asm |
| Func_165f | SerialReturn | home/serial.asm |
| Func_1660 | ClearSerialControl | home/serial.asm |
| Func_1663 | SerialDone | home/serial.asm |
| Func_1664 | SerialInterruptHandler | home/serial.asm |
| Func_169d | ClearSerialRegisters | home/serial.asm |
| Func_16a2 | ResetSerialCommunication | home/serial.asm |
| Func_16b5 | ResetSerialTransactionState | home/serial.asm |
| Func_16bf | ClearSerialExchangeState | home/serial.asm |
| Func_16e2 | ProcessSerialResponse | home/serial.asm |
| Func_16fd | CheckSerialTransactionComplete | home/serial.asm |
| Func_1740 | ProcessSerialDataExchange | home/serial.asm |
| Func_1779 | InitiateSerialDataTransfer | home/serial.asm |
| Func_1879 | SendSerialAcknowledgment | home/serial.asm |
| Func_18ac | TriggerSerialPoll | home/serial.asm |
| Func_18d4 | SetupSerialTransaction | home/serial.asm |
| Func_1925 | InitiateSerialHandshake | home/serial.asm |
| Func_1932 | InitiateSerialDataPacket | home/serial.asm |
| Func_1982 | AddToSerialChecksum | home/serial.asm |
| Func_1989 | SetupSerialMultiPartTransfer | home/serial.asm |
| Func_19bd | InitiateSerialAck | home/serial.asm |
| Func_19ca | InitiateSerialPollTransaction | home/serial.asm |
| Func_19d7 | InitiateSerialRetransmit | home/serial.asm |
| Func_19e5 | FinalizeSerialState | home/serial.asm |

## Serial High Score Transfer (home.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_1a21 | InitiateHighScoreTransfer | home.asm |
| Func_1a43 | InitiateHighScoreTransferWithFlag | home.asm |
| Func_1a59 | InitializeSerialCommunication | home.asm |
| Func_1a89 | ProcessSerialHandshakeResponse | home.asm |
| Func_1aa9 | TransferTileDataToBuffer | home.asm |
| Func_1ae2 | DecodeNibbleEncodedTile | home.asm |
| Func_1b3d | StartHighScoreSerialTransfer | home.asm |
| Func_1b60 | RunHighScoreDataExchange | home.asm |
| Func_1b88 | ValidateSerialDataExchange | home.asm |
| Func_1ba7 | DisableSerialCommunication | home.asm |
| Func_1bb2 | HandleSerialCommunicationError | home.asm |
| Func_1bd3 | HandleSerialCommunicationCancellation | home.asm |

## IR Communication (home/ir.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_1be3 | InitializeIRTimingData | home/ir.asm |
| Func_1c1b | WaitForIRSignalHigh | home/ir.asm |
| Func_1c23 | WaitForIRSignalLow | home/ir.asm |
| Func_1c2b | SendIRPulse | home/ir.asm |
| Func_1c32 | SendIRGap | home/ir.asm |
| Func_1c39 | EstablishIRConnection | home/ir.asm |
| Func_1c50 | HandleIRReceiveHandshake | home/ir.asm |
| Func_1ca1 | HandleIRSendHandshake | home/ir.asm |
| Func_1cef | DisableIRCommunication | home/ir.asm |
| Func_1cf8 | TransmitIRData | home/ir.asm |
| Func_1d44 | TransmitIRDataBytes | home/ir.asm |
| Func_1dc2 | SetIRErrorState | home/ir.asm |
| Func_1dc8 | SetIRChecksumError | home/ir.asm |
| Func_1dd1 | SetIRProtocolError | home/ir.asm |
| Func_1dda | ReceiveIRData | home/ir.asm |
| Func_1e3b | ReceiveIRDataBytes | home/ir.asm |
| Func_1ec9 | TransmitIRPacket | home/ir.asm |
| Func_1ece | ReceiveIRPacket | home/ir.asm |
| Func_1ed3 | IRTimingNop | home/ir.asm |
| Func_1ed4 | IRTimingDelay | home/ir.asm |

## End of Ball Bonus (end_of_ball_bonus.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_f57f | ClearBottomMessageAndUpdateVRAM | end_of_ball_bonus.asm |
| Func_f676 | DisplayBonusMultiplierLoop | end_of_ball_bonus.asm |
| Func_f70d | DisplayFinalBonusScore | end_of_ball_bonus.asm |
| Func_f78e | ConvertByteToDecimalDisplay | end_of_ball_bonus.asm |
| Func_f80d | CopyMessageBufferToVRAM | end_of_ball_bonus.asm |
| Func_f81b | FillBufferWithSpaceTile | end_of_ball_bonus.asm |
| Func_f824 | ClearMessageAndWaitForInput | end_of_ball_bonus.asm |
| Func_f83a | WaitForButtonPressOrTimeout | end_of_ball_bonus.asm |
| Func_f853 | AccumulateBonusPoints | end_of_ball_bonus.asm |
| Func_f8bd | ConvertBCD6ToDecimalString | end_of_ball_bonus.asm |
| Func_f8d5 | ConvertBCDNibbleToChar | end_of_ball_bonus.asm |

## Slot and Billboard (slot.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_f154 | LoadBonusMultiplierRailingGraphics | slot.asm |
| Func_f2a0 | LoadBillboardBGPalette | slot.asm |

## Catch Mode (catchem_mode.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_10184 | UpdateBillboardTileGraphics | catchem_mode.asm |
| Func_101d9 | QueueBillboardTileDMGGraphics | catchem_mode.asm |
| Func_10230 | QueueBillboardTileCGBPalette | catchem_mode.asm |
| Func_102bc | LoadBillboardStaticPalette | catchem_mode.asm |
| Func_10301 | LoadBillboardAnimatedPalettes | catchem_mode.asm |
| Func_10362 | QueueBillboardAnimatedGraphics | catchem_mode.asm |
| Func_1038e | QueueBillboardAnimatedTileEntry | catchem_mode.asm |
| Func_10611 | LoadCatchTextGraphics | catchem_mode.asm |
| Func_10648 | UpdateBillboardTileFlashAnimation | catchem_mode.asm |
| Func_10696 | DisplayLetsGetPokemonText | catchem_mode.asm |
| Func_106a6 | DisplayPokemonRanAwayText | catchem_mode.asm |
| Func_107e9 | SetRedStageStructureBackup | catchem_mode.asm |
| Func_10848 | AwardFirstPokemonCaughtBonus | catchem_mode.asm |
| Func_10871 | InitializeCatchModeRedField | catchem_mode.asm |
| Func_108f5 | ConcludeCatchModeRedField | catchem_mode.asm |
| Func_1098c | InitializeCatchModeBlueField | catchem_mode.asm |
| Func_109fc | ConcludeCatchModeBlueField | catchem_mode.asm |

## Catch Mode Red/Blue Field

| Old Name | New Name | File |
|----------|----------|------|
| Func_20041 | CheckAllTilesFlipped_RedField | catchem_mode_red_field.asm |
| Func_2005f | RunBillboardFlashAnimation_RedField | catchem_mode_red_field.asm |
| Func_2006b | TransitionToAnimatedMon_RedField | catchem_mode_red_field.asm |
| Func_20302 | CheckAllTilesFlipped_BlueField | catchem_mode_blue_field.asm |
| Func_20320 | RunBillboardFlashAnimation_BlueField | catchem_mode_blue_field.asm |
| Func_2032c | TransitionToAnimatedMon_BlueField | catchem_mode_blue_field.asm |

## Map Move Mode (map_move.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_311b4 | InitRedMapModeIndicators | map_move.asm |
| Func_31234 | FinalizeRedMapModeIndicators | map_move.asm |
| Func_31326 | InitBlueMapModeIndicators | map_move.asm |
| Func_313c3 | FinalizeBlueMapModeIndicators | map_move.asm |
| Func_314ef | MapMoveStateZero_Red | map_move.asm |
| Func_314f1 | MapMoveStateOne_Red | map_move.asm |
| Func_314f3 | MapMoveStateTwo_Red | map_move.asm |
| Func_31505 | MapMoveStateThree_Red | map_move.asm |
| Func_3165c | MapMoveStateZero_Blue | map_move.asm |
| Func_3165e | MapMoveStateOne_Blue | map_move.asm |
| Func_31660 | MapMoveStateTwo_Blue | map_move.asm |
| Func_31672 | MapMoveStateThree_Blue | map_move.asm |
| Func_31708 | OpenBlueMapMoveSlotFromLeft | map_move.asm |
| Func_3172a | OpenBlueMapMoveSlotFromRight | map_move.asm |
| Func_3174c | ResolveSuccessfulBlueMapMove | map_move.asm |

## Evolution Mode

| Old Name | New Name | File |
|----------|----------|------|
| Func_20651 | AwardEvolutionTrinket_RedField | evolution_mode_red_field.asm |

## Load Stage Data (Red Field)

| Old Name | New Name | File |
|----------|----------|------|
| Func_14091 | SaveAndResetAnimationState_RedField | load_red_field.asm |
| Func_1414b | HandleCatchAndEvolutionGraphics_RedField | load_red_field.asm |
| Func_141f2 | FillBillboardMapArea_RedField | load_red_field.asm |
| Func_14209 | FillSixConsecutiveTiles_RedField | load_red_field.asm |
| Func_14210 | ToggleBillboardIllumination_RedField | load_red_field.asm |
| Func_142b3 | CallMonHitGraphicsRepeated_RedField | load_red_field.asm |
| Func_142c3 | LoadEvolutionProgressIcons_RedField | load_red_field.asm |
| Func_142d7 | LoadSingleEvolutionIcon_RedField | load_red_field.asm |

## Load Stage Data (Blue Field)

| Old Name | New Name | File |
|----------|----------|------|
| Func_1c1db | ResetForceFieldState_BlueField | load_blue_field.asm |
| Func_1c203 | SaveBallStateForDMG_BlueField | load_blue_field.asm |
| Func_1c2cb | LoadArrowIndicators_BlueField | load_blue_field.asm |
| Func_1c305 | HandleCatchAndEvolutionGraphics_BlueField | load_blue_field.asm |
| Func_1c3ac | FillBillboardMapArea_BlueField | load_blue_field.asm |
| Func_1c3c3 | FillSixConsecutiveTiles_BlueField | load_blue_field.asm |
| Func_1c3ca | ToggleBillboardIllumination_BlueField | load_blue_field.asm |
| Func_1c46d | CallMonHitGraphicsRepeated_BlueField | load_blue_field.asm |
| Func_1c47d | LoadEvolutionProgressIcons_BlueField | load_blue_field.asm |
| Func_1c491 | LoadSingleEvolutionIcon_BlueField | load_blue_field.asm |

## Load Stage Data (Diglett Bonus)

| Old Name | New Name | File |
|----------|----------|------|
| Func_19a96 | RestoreDiglettStatesOnLoad | load_diglett_bonus.asm |

## Gengar Bonus Stage

| Old Name | New Name | File |
|----------|----------|------|
| Func_183db | QueueGateGraphicsToLoad_GengarBonus | gengar_bonus_resolve_collision.asm |
| Func_18464 | ResolveGastlyHitCollision | gengar_bonus_resolve_collision.asm |
| Func_1850c | UpdateGastlyVerticalOffset | gengar_bonus_resolve_collision.asm |
| Func_18562 | UpdateGastlyAnimationAndState | gengar_bonus_resolve_collision.asm |
| Func_1860b | ResolveHaunterHitCollision | gengar_bonus_resolve_collision.asm |
| Func_186a1 | UpdateHaunterVerticalOffset | gengar_bonus_resolve_collision.asm |
| Func_186f7 | UpdateHaunterAnimationAndState | gengar_bonus_resolve_collision.asm |
| Func_187b1 | ResolveGengarHitCollision | gengar_bonus_resolve_collision.asm |
| Func_18876 | UpdateGengarVerticalPosition_LowerPhase | gengar_bonus_resolve_collision.asm |
| Func_188e1 | UpdateGengarVerticalPosition_UpperPhase | gengar_bonus_resolve_collision.asm |
| Func_1894c | UpdateGengarTiltMechanic | gengar_bonus_resolve_collision.asm |
| Func_189af | UpdateGengarBonusGhostAnimation | gengar_bonus_resolve_collision.asm |
| Func_18d34 | ResolveGravestoneCollision | gengar_bonus_resolve_collision.asm |
| Func_18d72 | QueueSecondaryGateGraphics_GengarBonus | gengar_bonus_resolve_collision.asm |
| Func_18d91 | UpdateGateCollisionMapTiles_GengarBonus | gengar_bonus_resolve_collision.asm |
| Func_18db2 | CopyCollisionDataToMap | gengar_bonus_resolve_collision.asm |
| Func_19020 | DrawAllGastlySprites | draw_gengar_bonus_sprites.asm |
| Func_19033 | DrawGastlySprite | draw_gengar_bonus_sprites.asm |
| Func_19070 | LoadGastlyGraphics | draw_gengar_bonus_sprites.asm |
| Func_190b9 | DrawAllHaunterSprites | draw_gengar_bonus_sprites.asm |
| Func_190c6 | DrawHaunterSprite | draw_gengar_bonus_sprites.asm |
| Func_19104 | LoadHaunterGraphics | draw_gengar_bonus_sprites.asm |
| Func_19185 | DrawAllGengarSprites | draw_gengar_bonus_sprites.asm |
| Func_1918c | DrawGengarSprite | draw_gengar_bonus_sprites.asm |
| Func_191cb | LoadGengarGraphics | draw_gengar_bonus_sprites.asm |

## Diglett Bonus Stage

| Old Name | New Name | File |
|----------|----------|------|
| Func_19bbd | QueueGateGraphicsToLoad_DiglettBonus | diglett_bonus_resolve_collision.asm |
| Func_19c52 | ResolveDiglettHitCollision | diglett_bonus_resolve_collision.asm |
| Func_19cdd | InitializeDiglettsInSequence | diglett_bonus_resolve_collision.asm |
| Func_19da8 | UpdateDiglettAnimationState | diglett_bonus_resolve_collision.asm |
| Func_19dcd | WriteDiglettCollisionMapTiles | diglett_bonus_resolve_collision.asm |
| Func_19df0 | ClearDiglettCollisionMapTiles | diglett_bonus_resolve_collision.asm |
| Func_1aad4 | ResolveDugtrioHitCollision | diglett_bonus_resolve_collision.asm |
| Func_1ab30 | UpdateDugtrioAnimation | diglett_bonus_resolve_collision.asm |
| Func_1ac2c | LoadDugtrioCollisionData | diglett_bonus_resolve_collision.asm |

## Mewtwo Bonus Stage

| Old Name | New Name | File |
|----------|----------|------|
| Func_19337 | CheckAllOrbitingBallCollisions | mewtwo_bonus_object_collision.asm |
| Func_1936f | CheckOrbitingBallCollisionAndApplyPhysics | mewtwo_bonus_object_collision.asm |
| Func_19412 | NoOrbitingBallCollision | mewtwo_bonus_object_collision.asm |
| Func_19414 | CheckMewtwoBodyCollision | mewtwo_bonus_object_collision.asm |
| Func_194ac | QueueGateGraphicsToLoad_MewtwoBonus | mewtwo_bonus_resolve_collision.asm |
| Func_19531 | ResolveOrbitingBallHitCollision | mewtwo_bonus_resolve_collision.asm |
| Func_195ac | InitializeMewtwoOrbitingBalls | mewtwo_bonus_resolve_collision.asm |
| Func_195d3 | CheckMewtwoOrbitingBallAtPosition | mewtwo_bonus_resolve_collision.asm |
| Func_195f5 | UpdateMewtwoAnimationFrame | mewtwo_bonus_resolve_collision.asm |
| Func_19615 | HandleMewtwoAnimationState0 | mewtwo_bonus_resolve_collision.asm |
| Func_1961e | HandleMewtwoAnimationState1 | mewtwo_bonus_resolve_collision.asm |
| Func_1962f | HandleMewtwoAnimationState2 | mewtwo_bonus_resolve_collision.asm |
| Func_19638 | HandleMewtwoAnimationState3 | mewtwo_bonus_resolve_collision.asm |
| Func_19679 | InitializeMewtwoAnimationState | mewtwo_bonus_resolve_collision.asm |
| Func_19701 | UpdateAllOrbitingBalls | mewtwo_bonus_resolve_collision.asm |
| Func_1985a | HandleOrbitingBallAnimationState0 | mewtwo_bonus_resolve_collision.asm |
| Func_19863 | HandleOrbitingBallAnimationState1 | mewtwo_bonus_resolve_collision.asm |
| Func_1986c | HandleOrbitingBallAnimationState2 | mewtwo_bonus_resolve_collision.asm |
| Func_1986d | HandleOrbitingBallAnimationState3 | mewtwo_bonus_resolve_collision.asm |
| Func_19876 | InitializeOrbitingBallAnimationState | mewtwo_bonus_resolve_collision.asm |
| Func_19976 | DrawMewtwoSprite | draw_mewtwo_bonus_sprites.asm |

## Meowth Bonus Stage

| Old Name | New Name | File |
|----------|----------|------|
| Func_24319 | ResolveCoinCollision_Lower_MeowthBonus | meowth_bonus_resolve_collision.asm |
| Func_2438f | ResolveCoinCollision_Upper_MeowthBonus | meowth_bonus_resolve_collision.asm |
| Func_24405 | CheckCoinCollisionInRange | meowth_bonus_resolve_collision.asm |
| Func_24516 | QueueGateGraphicsToLoad_MeowthBonus | meowth_bonus_resolve_collision.asm |
| Func_245ab | HandleMeowthHitCollision | meowth_bonus_resolve_collision.asm |
| Func_2465d | UpdateMeowthAnimationFrame | meowth_bonus_resolve_collision.asm |
| Func_24709 | UpdateMeowthPosition | meowth_bonus_resolve_collision.asm |
| Func_247d9 | ProduceBottomCoin | meowth_bonus_resolve_collision.asm |
| Func_248ac | UpdateMeowthBottomCoins | meowth_bonus_resolve_collision.asm |
| Func_24a30 | AnimateMovingCoin | meowth_bonus_resolve_collision.asm |
| Func_24b41 | ContinueMovingCoinAnimation | meowth_bonus_resolve_collision.asm |
| Func_24bf6 | SetCoinAnimationComplete | meowth_bonus_resolve_collision.asm |
| Func_24c28 | ProduceTopCoin | meowth_bonus_resolve_collision.asm |
| Func_24d07 | UpdateMeowthTopCoins | meowth_bonus_resolve_collision.asm |
| Func_24e7f | ApplyCoinHitSpriteEffect | meowth_bonus_resolve_collision.asm |
| Func_24ee7 | ResetCoinAnimationState | meowth_bonus_resolve_collision.asm |
| Func_24f00 | DisplayMeowthMultiplierText | meowth_bonus_resolve_collision.asm |
| Func_24fa3 | UpdateMeowthMultiplierAnimation | meowth_bonus_resolve_collision.asm |
| Func_2586c | DrawMeowthSprite | draw_meowth_bonus_sprites.asm |
| Func_25895 | DrawMeowthBottomCoinSprites | draw_meowth_bonus_sprites.asm |
| Func_2595e | DrawMeowthTopCoinSprites | draw_meowth_bonus_sprites.asm |
| Func_259fe | DrawMeowthMultiplierSprite | draw_meowth_bonus_sprites.asm |
| Func_25a39 | DrawMeowthProgressSparkle | draw_meowth_bonus_sprites.asm |

## Seel Bonus Stage

| Old Name | New Name | File |
|----------|----------|------|
| Func_25d0e | QueueGateGraphicsToLoad_SeelBonus | seel_bonus_resolve_collision.asm |
| Func_25da3 | ResolveSeelHitCollision | seel_bonus_resolve_collision.asm |
| Func_25e85 | CalculateSeelStreakBonus | seel_bonus_resolve_collision.asm |
| Func_25f77 | HandleSeelAnimationState1Collision | seel_bonus_resolve_collision.asm |
| Func_25fbe | HandleSeelAnimationState4Collision | seel_bonus_resolve_collision.asm |
| Func_25ff3 | HandleSeelAnimationState7Emerge | seel_bonus_resolve_collision.asm |
| Func_2602a | HandleSeelAnimationState9Hit | seel_bonus_resolve_collision.asm |
| Func_2604c | HandleSeelAnimationState4BottomCoin | seel_bonus_resolve_collision.asm |
| Func_2607f | HandleSeelAnimationState7EmergeBottom | seel_bonus_resolve_collision.asm |
| Func_260b6 | HandleSeelAnimationState9HitBottom | seel_bonus_resolve_collision.asm |
| Func_260d8 | HandleSeelAnimationState5Check | seel_bonus_resolve_collision.asm |
| Func_260e2 | HandleSeelAnimationState5Alternate | seel_bonus_resolve_collision.asm |
| Func_260ec | HandleSeelAnimationState1Direction | seel_bonus_resolve_collision.asm |
| Func_26109 | HandleSeelAnimationState7ToState5 | seel_bonus_resolve_collision.asm |
| Func_26120 | HandleSeelAnimationState7ToState5Alt | seel_bonus_resolve_collision.asm |
| Func_26137 | InitializeSeelAnimationState | seel_bonus_resolve_collision.asm |
| Func_261f9 | DisplaySeelMultiplierAnimation | seel_bonus_resolve_collision.asm |
| Func_26212 | UpdateSeelMultiplierAnimationFrame | seel_bonus_resolve_collision.asm |
| Func_262f4 | UpdateSeelStageScoreDisplay | seel_bonus_resolve_collision.asm |
| Func_26ba9 | DrawAllSeelSprites | draw_seel_bonus_sprites.asm |
| Func_26bbc | DrawSeelSprite | draw_seel_bonus_sprites.asm |
| Func_26bf7 | DrawSeelMultiplierSprite | draw_seel_bonus_sprites.asm |
| Func_26c3c | DrawSeelProgressSparkle | draw_seel_bonus_sprites.asm |

## Titlescreen (titlescreen.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_c0ee | HandleTitlescreenCursorInput | titlescreen.asm |
| Func_c10e | HandleContinuePromptScreen | titlescreen.asm |
| Func_c1a2 | HandleContinuePromptCursorInput | titlescreen.asm |
| Func_c1b1 | UpdateContinuePromptAnimations | titlescreen.asm |
| Func_c1cb | GoToSelectedMenuScreen | titlescreen.asm |
| Func_c1fc | HandleMenuCursorUpDown | titlescreen.asm |
| Func_c21d | DoNothing_Titlescreen | titlescreen.asm |

## High Scores Screen (high_scores_screen.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_ca8f | InitializeHighScoreEntry | high_scores_screen.asm |
| Func_cb14 | LoadHighScoresScreen | high_scores_screen.asm |
| Func_ccac | UpdateHighScoreNameEntry | high_scores_screen.asm |
| Func_ccb6 | HandleHighScoresScreenInput | high_scores_screen.asm |
| Func_cd6c | HandleHighScorePrintingSending | high_scores_screen.asm |
| Func_cdce | TransmitReceiveHighScores | high_scores_screen.asm |
| Func_ceca | WaitForVBlankLine0 | high_scores_screen.asm |
| Func_cf58 | DisplayHighScoresErrorDialog | high_scores_screen.asm |
| Func_cf7d | HandleHighScoresPrintSendSelection | high_scores_screen.asm |
| Func_cfa6 | DrawHighScoresPrintSendDialog | high_scores_screen.asm |
| Func_cfcb | InsertReceivedHighScore | high_scores_screen.asm |
| Func_d035 | AdvanceHighScoreComparisonPointers | high_scores_screen.asm |
| Func_d042 | PrintHighScoresToIR | high_scores_screen.asm |
| Func_d0e3 | TransferHighScoreGraphicsToIR | high_scores_screen.asm |
| Func_d0f5 | TransferHighScoreHexCharsToIR | high_scores_screen.asm |
| Func_d107 | FormatHighScoresToHexDisplay | high_scores_screen.asm |
| Func_d159 | ConvertNibbleToHexTile | high_scores_screen.asm |
| Func_d18b | HandleHighScoreNameCharacterInput | high_scores_screen.asm |
| Func_d1d2 | HandleHighScoreNamePositionInput | high_scores_screen.asm |
| Func_d211 | UpdateHighScoreNameEntryAsterisks | high_scores_screen.asm |
| Func_d2cb | RenderHighScoreEntry | high_scores_screen.asm |
| Func_d317 | PlaceHighScoreTileWithPalette | high_scores_screen.asm |
| Func_d336 | DeterminePaletteOffsetForHex | high_scores_screen.asm |
| Func_d348 | PlaceHighScoreTileBufNoVRAM | high_scores_screen.asm |
| Func_d361 | RenderHighScoreEntryToVRAM | high_scores_screen.asm |
| Func_d3ad | PlaceHighScoreTileVRAM | high_scores_screen.asm |
| Func_d3d0 | DeterminePaletteOffsetForHexVRAM | high_scores_screen.asm |
| Func_d3e2 | PlaceHighScoreTileVRAMDirect | high_scores_screen.asm |
| Func_d46f | UpdateHighScoreNameTile | high_scores_screen.asm |
| Func_d4cf | HandleHighScoresStageTransition | high_scores_screen.asm |
| Func_d57b | PrepareHighScoresTransition | high_scores_screen.asm |
| Func_d5d0 | CompleteHighScoresStageTransition | high_scores_screen.asm |
| Func_d68a | CheckDexCompletionAndShowCrown | high_scores_screen.asm |
| Func_d6b6 | MarkDexCompletionInHighScoresBar | high_scores_screen.asm |

## Options Screen (options_screen.asm)

| Old Name | New Name | File |
|----------|----------|------|
| Func_c35a | InitializeOptionsScreen | options_screen.asm |
| Func_c400 | HandleOptionsScreenMainLoop | options_screen.asm |
| Func_c41a | HandleOptionsMenuNavigation | options_screen.asm |
| Func_c43a | UpdateOptionsScreenAnimations | options_screen.asm |
| Func_c447 | HandleOptionsMenuSelection | options_screen.asm |
| Func_c483 | ExitToTitleScreen | options_screen.asm |
| Func_c493 | HandleGameSettingsScreen | options_screen.asm |
| Func_c4b4 | HandleRumbleToggleInput | options_screen.asm |
| Func_c4e6 | UpdateGameSettingsScreenAnimations | options_screen.asm |
| Func_c4f4 | ResetAnimationFrames | options_screen.asm |
| Func_c506 | HandleKeyConfigScreen | options_screen.asm |
| Func_c534 | HandleKeyConfigNavigation | options_screen.asm |
| Func_c554 | UpdateKeyConfigArrowSprite | options_screen.asm |
| Func_c55a | HandleKeyConfigSelection | options_screen.asm |
| Func_c621 | RenderKeyInputCursorFrame | options_screen.asm |
| Func_c639 | SaveKeyInputResult | options_screen.asm |
| Func_c644 | ClearKeyConfigOption | options_screen.asm |
| Func_c691 | HandleSoundTestScreen | options_screen.asm |
| Func_c6bf | HandleSoundTestModeToggle | options_screen.asm |
| Func_c6d9 | UpdateSoundTestScreenAnimations | options_screen.asm |
| Func_c6e8 | HandleSoundTestSelection | options_screen.asm |
| Func_c869 | TriggerRumbleAtPikachuPeakFrame | options_screen.asm |
| Func_c8f1 | UpdateArrowCursorSprite | options_screen.asm |
| Func_c92e | UpdateFadedArrowSprite | options_screen.asm |
| Func_c948 | RenderAllKeyConfigDigits | options_screen.asm |
| Func_c95f | ConvertKeyButtonToTileDigit | options_screen.asm |
| Func_c9aa | WriteNonzeroTileToBuffer | options_screen.asm |
| Func_c9be | UpdateKeyInputDisplayBuffer | options_screen.asm |
| Func_c9ff | ConvertButtonBitToTileArray | options_screen.asm |
| Func_ca15 | ClearBufferTiles | options_screen.asm |
| Func_ca29 | ConvertTileArrayToButtonBits | options_screen.asm |

## Unused Stage

| Old Name | New Name | File |
|----------|----------|------|
| Func_18000 | InitializeUnusedStage | init_unused_stage.asm |
| Func_1804a | InitBallPosition_UnusedStage | ball_init_unused_stage.asm |
| Func_18062 | CheckLaunchAlleyCollision_UnusedStage | load_unused_stage.asm |
| Func_1806e | ResolveLaunchCollision_UnusedStage | load_unused_stage.asm |
| Func_18079 | DrawSprites_UnusedStageNoFlippers | draw_unused_stage_sprites.asm |
| Func_18084 | DrawSprites_UnusedStageWithFlippers | draw_unused_stage_sprites.asm |

## Sprite Drawing (Red Field)

| Old Name | New Name | File |
|----------|----------|------|
| Func_17e4f | LoadRedFieldExtraSprites_Unused | draw_red_field_sprites.asm |
| Func_17e5e | ProcessSpriteDataList_Unused | draw_red_field_sprites.asm |

## Ball Loss

| Old Name | New Name | File |
|----------|----------|------|
| Func_de4e | DoNothing_BallLoss_Unused | ball_loss_red_field.asm |

## WRAM Variables

| Old Name | New Name | File |
|----------|----------|------|
| wd478 | wScoreQueueReadOffset | wram.asm |
| wd479 | wScoreQueueSyncOffset | wram.asm |
| wd49f | wScoreChanged | wram.asm |
| wd4c5 | wBallPreviousXPosDMG | wram.asm |
| wd4c6 | wBallPreviousYPosDMG | wram.asm |
| wd4c7 | wBallPreviousRotationDMG | wram.asm |
| wd502 | wStaryuState | wram.asm |
| wd503 | wStaryuAnimationTimer | wram.asm |
| wd51c | wPikachuSaverAnimationState | wram.asm |
| wd51e | wSpinnerChargeSoundCooldown | wram.asm |
| wd54e | wCatchModeFlashFrameCounter | wram.asm |
| wd54f | wCatchModeFlashPhaseCounter | wram.asm |
| wd558 | wEvolutionIndicatorState2Backup | wram.asm |
| wd559 | wEvolutionIndicatorState3Backup | wram.asm |
| wd580 | wTimerGraphicsNeedsLoading | wram.asm |
| wd5c6 | wCatchModeTransitionFlag | wram.asm |
| wd674 | wGengarPhaseTimer | wram.asm |
| wd7fa | wGraphicsQueueSize | wram.asm |
| wd7fb | wGraphicsQueueWriteIndex | wram.asm |
| wd7fc | wGraphicsQueueReadIndex | wram.asm |
| wd7fd | wGraphicsQueueOverflow | wram.asm |
| wd8e1 | wSerialCommunicationEnabled | wram.asm |
| wd917 | wDisableRumble | wram.asm |

## HRAM Variables

| Old Name | New Name | File |
|----------|----------|------|
| hFF94 | hBankedCopySourceBank | hram.asm |
| hFF95 | hBankedCopyCount | hram.asm |
| hFFB1 | hSerialInterruptMode | hram.asm |
| hFFC4 | hDMGPaletteUpdateNeeded | hram.asm |

## Summary

- 347 functions renamed
- 23 WRAM variables renamed
- 4 HRAM variables renamed
- 374 total identifiers renamed
